### PR TITLE
Update docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:19.10
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -7,6 +7,8 @@ ENV ANDROID_SDK_FILENAME sdk-tools-linux-4333796.zip
 ENV ANDROID_SDK_URL https://dl.google.com/android/repository/${ANDROID_SDK_FILENAME}
 ENV ANDROID_API_LEVELS android-29
 ENV ANDROID_BUILD_TOOLS_VERSION 28.0.3
+ENV ANDROID_NDK_VERSION 21.0.6113669
+ENV CMAKE_VERSION 3.6.4111459
 ENV ANDROID_HOME /usr/local/android-sdk
 ENV PATH ${PATH}:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
 ENV JAVA_OPTS "-Dprofile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8 -Dfile.encoding=UTF-8"
@@ -26,7 +28,7 @@ RUN mkdir /usr/local/android-sdk && \
     rm ${ANDROID_SDK_FILENAME}
 
 # install sdk packages
-RUN echo y | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;28.0.3" "cmake;3.6.4111459" "ndk;21.0.6113669" "patcher;v4" "platforms;android-29"
+RUN echo y | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" "cmake;${CMAKE_VERSION}" "ndk;${ANDROID_NDK_VERSION}" "patcher;v4" "platforms;${ANDROID_API_LEVELS}"
 
 # copy project over to docker image
 COPY . /home/ubuntu/phoenix

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,7 @@ def gitCommitHash = 'git rev-parse --verify --short HEAD'.execute().text.trim()
 
 android {
   compileSdkVersion 29
+  ndkVersion '21.0.6113669'
   defaultConfig {
     applicationId "fr.acinq.phoenix.testnet"
     minSdkVersion 24


### PR DESCRIPTION
Due to the recent ubuntu releases the updates for ubuntu 18.10 have been dropped and when the docker build invoked `apt-get update` it failed with:
```
E: The repository 'http://archive.ubuntu.com/ubuntu cosmic Release' does not have a Release file.
```
The fix is to bump the ubuntu version to a more recent 19.10.

However this is not enough because some recent changes in the build (perhaps [this](https://github.com/ACINQ/phoenix/commit/c9e49693a4d8bc0ab1a5d19aef76bf16d42f06d3)?) made necessary to explicitly set the version of the ndk used, otherwise the gradle build failed with:
```
android.ndkVersion from module build.gradle is not set
ndk.dir in local.properties is not set
ANDROID_NDK_HOME environment variable is not set
sdkFolder is /usr/local/android-sdk
Because no explicit NDK was requested, the default version '20.0.5594570' for this Android Gradle Plugin will be used
Considering /usr/local/android-sdk/ndk-bundle in SDK ndk-bundle folder
Considering /usr/local/android-sdk/ndk/21.0.6113669 in SDK ndk folder
Rejected /usr/local/android-sdk/ndk-bundle in SDK ndk-bundle folder because that location has no source.properties
Rejected /usr/local/android-sdk/ndk/21.0.6113669 in SDK ndk folder because that NDK had version 21.0.6113669 which didn't match the requested version 20.0.5594570
```
The proposed fix is to set the ndk version in the gradle build.