### PR TITLE
Multistage deterministic build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /.idea
 app/release
 app/debug
+apk
+logs

--- a/BUILD.md
+++ b/BUILD.md
@@ -47,6 +47,6 @@ which revision you need to use in the deterministic build.
 ### How to build phoenix deterministically
 
 1. Clone the phoenix project from https://github.com/ACINQ/phoenix
-3. Run `docker build -t phoenix_build . --build-arg ECLAIR_TAG=<GIT_TAG_OF_ECLAIR_CORE>` to create the build environment
+3. Run `docker build -t phoenix_build .` to create the build environment
 4. Run `docker run --rm -v $(pwd):/home/ubuntu/phoenix/app/build/outputs -w /home/ubuntu/phoenix phoenix_build ./gradlew assemble`
 5. Built artifacts are in `.apk/release`

--- a/BUILD.md
+++ b/BUILD.md
@@ -48,5 +48,5 @@ which revision you need to use in the deterministic build.
 
 1. Clone the phoenix project from https://github.com/ACINQ/phoenix
 3. Run `docker build -t phoenix_build . --build-arg ECLAIR_TAG=<GIT_TAG_OF_ECLAIR_CORE>` to create the build environment
-4. Run `docker run --rm -v $(pwd):/home/ubuntu/phoenix/app/build -w /home/ubuntu/phoenix phoenix_build ./gradlew assemble`
-5. Built artifacts are in $(pwd)/outputs/apk/release
+4. Run `docker run --rm -v $(pwd):/home/ubuntu/phoenix/app/build/outputs -w /home/ubuntu/phoenix phoenix_build ./gradlew assemble`
+5. Built artifacts are in `.apk/release`

--- a/BUILD.md
+++ b/BUILD.md
@@ -35,18 +35,18 @@ You can check that the corresponding `.jar` file is present in your local maven 
 ## Deterministic build of Phoenix
 
 Phoenix supports deterministic builds on Linux OSs, this allows anyone to recreate from the sources the exact same APK that was published in the release page.
-The deterministic build uses a dockerized build environment and require you to have previously built (and published locally) the artifact for the `eclair-core`
-dependency, follow the instructions to build it.
+The deterministic build uses a self-contained dockerized environment, to run the build you must supply via docker build args the branch of eclair-core
+that is going to be used for the build. Each release of Phoenix is built against a specific revision of eclair-core, checkout the release notes to know
+which revision you need to use in the deterministic build.
 
 ### Prerequisites
 
 1. A linux machine running on x64 CPU.
 2. docker-ce installed
-3. Eclair-core published in your local maven repo, check out the instructions to build it.
 
 ### How to build phoenix deterministically
 
 1. Clone the phoenix project from https://github.com/ACINQ/phoenix
-3. Run `docker build -t phoenix_build .` to create the build environment
-4. Run `docker run --rm -v $HOME/.m2:/root/.m2 -v $(pwd):/home/ubuntu/phoenix/app/build -w /home/ubuntu/phoenix phoenix_build ./gradlew assemble`
+3. Run `docker build -t phoenix_build . --build-arg ECLAIR_TAG=<GIT_TAG_OF_ECLAIR_CORE>` to create the build environment
+4. Run `docker run --rm -v $(pwd):/home/ubuntu/phoenix/app/build -w /home/ubuntu/phoenix phoenix_build ./gradlew assemble`
 5. Built artifacts are in $(pwd)/outputs/apk/release

--- a/BUILD.md
+++ b/BUILD.md
@@ -54,7 +54,7 @@ Notes:
 
 Note: on Windows at least, it is strongly recommended to bump the resources allocation settings from the default values, especially for Memory.
 
-## How to build phoenix deterministically
+### Build the APK
 
 1. Clone the phoenix project from https://github.com/ACINQ/phoenix ;
 2. Open a terminal at the root of the cloned project ;

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,4 +1,8 @@
-# Building Phoenix
+# How-to build Phoenix
+
+This section explains how to install a development environment for Phoenix. If you simply want to build the Phoenix APK, check the [Release section below](#release-phoenix).
+
+First you'll have to build the various dependencies for the application.
 
 ## Building eclair-core for Phoenix
 
@@ -19,7 +23,7 @@ Phoenix uses a library to manage the communication with the tor binary. This lib
 ./gradlew :android:publishToMaven
 ```
 
-## Building Phoenix
+## Building the app proper
 
 [Android Studio](https://developer.android.com/studio) is the recommended development environment.
 
@@ -29,24 +33,43 @@ Phoenix uses a library to manage the communication with the tor binary. This lib
 4. Open Android Studio, and click on `File` > `Open...`, and open the cloned folder
 5. Project initialization will proceed.
 
-Note that if you have an error mentioning that the `eclair-core` library could not be found, it's because you need to build it first (see above).
-You can check that the corresponding `.jar` file is present in your local maven repository (`path/to/repo/fr/acinq/eclair/eclair-core_2.11/<version>/`).
+Note:
+- If you have an error mentioning that the `eclair-core` library could not be found, it's because you need to build it first (see above).
+- The version of eclair-core used by Phoenix often changes; tagged version of the app (aka releases) always depends on a tagged version of eclair-core. The current `android-phoenix` branch may be a SNAPSHOT version which does not correspond to what the current Phoenix `master` depends on.
+- You can check what eclair-core `.jar` file you have built by checking your local maven repository (`path/to/repo/fr/acinq/eclair/eclair-core_2.11/<version>/`). Default repository is `~/.m2`.
 
-## Deterministic build of Phoenix
+# Release Phoenix
 
-Phoenix supports deterministic builds on Linux OSs, this allows anyone to recreate from the sources the exact same APK that was published in the release page.
-The deterministic build uses a self-contained dockerized environment, to run the build you must supply via docker build args the branch of eclair-core
-that is going to be used for the build. Each release of Phoenix is built against a specific revision of eclair-core, checkout the release notes to know
-which revision you need to use in the deterministic build.
+Phoenix releases are deterministically built using a dockerized Linux environment. This allow anyone to recreate the same APK that is published in the release page (minus the release signing part which is obviously not public).
 
 ### Prerequisites
 
-1. A linux machine running on x64 CPU.
-2. docker-ce installed
+ You don't have to worry about installing any development tool, except:
 
-### How to build phoenix deterministically
+1. Docker (Community Edition)
 
-1. Clone the phoenix project from https://github.com/ACINQ/phoenix
-3. Run `docker build -t phoenix_build .` to create the build environment
-4. Run `docker run --rm -v $(pwd):/home/ubuntu/phoenix/app/build/outputs -w /home/ubuntu/phoenix phoenix_build ./gradlew assemble`
-5. Built artifacts are in `.apk/release`
+Note: on Windows at least, it is strongly recommended to bump the resources allocation settings from the default values, especially for Memory.
+
+## How to build phoenix deterministically
+
+1. Clone the phoenix project from https://github.com/ACINQ/phoenix ;
+2. Open a terminal at the root of the cloned project ;
+3. Checkout the tag you want to build, for example:
+```shell
+git checkout v1.3.1
+```
+4. Build the docker image mirroring the release environment (this typically takes ~20min):
+```shell
+docker build -t phoenix_build .
+```
+5. Build the APKs using the docker image (takes typically ~10min):
+If you're on linux:
+```shell
+docker run --rm -v $(pwd):/home/ubuntu/phoenix/app/build/outputs -w /home/ubuntu/phoenix phoenix_build ./gradlew assemble
+```
+If you're on Windows:
+
+```shell
+docker run --rm -v ${pwd}:/home/ubuntu/phoenix/app/build/outputs -w //home/ubuntu/phoenix phoenix_build ./gradlew assemble
+```
+6. Built artifacts are in `.apk/release`.

--- a/BUILD.md
+++ b/BUILD.md
@@ -40,7 +40,8 @@ Note:
 
 # Release Phoenix
 
-Phoenix releases are deterministically built using a dockerized Linux environment. This allow anyone to recreate the same APK that is published in the release page (minus the release signing part which is obviously not public). 
+Phoenix releases are deterministically built using a dockerized Linux environment. This allow anyone to recreate the same APK that is published in the release page (minus the release signing part which is obviously not public).
+
 Notes:
 - This tool works on Linux and Windows.
 - Following instructions only work for releases after v.1.3.1 (excluded).

--- a/BUILD.md
+++ b/BUILD.md
@@ -57,23 +57,32 @@ Note: on Windows at least, it is strongly recommended to bump the resources allo
 ### Build the APK
 
 1. Clone the phoenix project from https://github.com/ACINQ/phoenix ;
+
 2. Open a terminal at the root of the cloned project ;
+
 3. Checkout the tag you want to build, for example:
+
 ```shell
 git checkout v1.4.0
 ```
+
 4. Build the docker image mirroring the release environment (this typically takes ~20min):
+
 ```shell
 docker build -t phoenix_build .
 ```
+
 5. Build the APKs using the docker image (takes typically ~10min):
+
 If you're on linux:
 ```shell
 docker run --rm -v $(pwd):/home/ubuntu/phoenix/app/build/outputs -w /home/ubuntu/phoenix phoenix_build ./gradlew assemble
 ```
+
 If you're on Windows:
 
 ```shell
 docker run --rm -v ${pwd}:/home/ubuntu/phoenix/app/build/outputs -w //home/ubuntu/phoenix phoenix_build ./gradlew assemble
 ```
+
 6. Built artifacts are in `.apk/release`.

--- a/BUILD.md
+++ b/BUILD.md
@@ -74,14 +74,11 @@ docker build -t phoenix_build .
 
 5. Build the APKs using the docker image (takes typically ~10min):
 
-If you're on linux:
 ```shell
+# If you're on linux:
 docker run --rm -v $(pwd):/home/ubuntu/phoenix/app/build/outputs -w /home/ubuntu/phoenix phoenix_build ./gradlew assemble
-```
 
-If you're on Windows:
-
-```shell
+# If you're on Windows:
 docker run --rm -v ${pwd}:/home/ubuntu/phoenix/app/build/outputs -w //home/ubuntu/phoenix phoenix_build ./gradlew assemble
 ```
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -40,7 +40,10 @@ Note:
 
 # Release Phoenix
 
-Phoenix releases are deterministically built using a dockerized Linux environment. This allow anyone to recreate the same APK that is published in the release page (minus the release signing part which is obviously not public).
+Phoenix releases are deterministically built using a dockerized Linux environment. This allow anyone to recreate the same APK that is published in the release page (minus the release signing part which is obviously not public). 
+Notes:
+- This tool works on Linux and Windows.
+- Following instructions only work for releases after v.1.3.1 (excluded).
 
 ### Prerequisites
 
@@ -56,7 +59,7 @@ Note: on Windows at least, it is strongly recommended to bump the resources allo
 2. Open a terminal at the root of the cloned project ;
 3. Checkout the tag you want to build, for example:
 ```shell
-git checkout v1.3.1
+git checkout v1.4.0
 ```
 4. Build the docker image mirroring the release environment (this typically takes ~20min):
 ```shell

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN git clone https://github.com/ACINQ/Tor_Onion_Proxy_Library && \
 # copy eclair-core dependendency
 COPY --from=ECLAIR_CORE_BUILD /root/.m2/repository/fr/acinq/eclair /root/.m2/repository/fr/acinq/eclair
 # copy phoenix project over to docker image
-COPY . /home/ubuntu/phoenix 
+COPY . /home/ubuntu/phoenix
 # make sure we don't read properties the host environment
 RUN rm -f /home/ubuntu/phoenix/local.properties
 # make gradle wrapper executable

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,8 @@ RUN git clone https://github.com/ACINQ/Tor_Onion_Proxy_Library && \
 # copy eclair-core dependendency
 COPY --from=ECLAIR_CORE_BUILD /root/.m2/repository/fr/acinq/eclair /root/.m2/repository/fr/acinq/eclair
 
-# copy phoenix project over to docker image
-COPY . /home/ubuntu/phoenix
+# copy phoenix project over to docker image and make sure we don't read properties the host environment
+COPY . /home/ubuntu/phoenix && rm -f /home/ubuntu/phoenix/local.properties
 
 # make gradle wrapper executable
 RUN chmod +x /home/ubuntu/phoenix/gradlew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,32 @@
+# base image to build eclair-core
+FROM adoptopenjdk/openjdk11:jdk-11.0.3_7-alpine as ECLAIR_CORE_BUILD
+
+RUN apk add --no-cache curl tar bash git
+
+ARG ECLAIR_TAG=
+ARG MAVEN_VERSION=3.6.3
+ARG USER_HOME_DIR="/root"
+ARG SHA=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+# setup maven
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+# clone eclair at the specified branch
+RUN git clone https://github.com/ACINQ/eclair -b $ECLAIR_TAG
+
+# build eclair-core
+RUN cd eclair && mvn install -pl eclair-core -am -DskipTests
+
+# main build image
 FROM ubuntu:19.10
 
 ENV LC_ALL en_US.UTF-8
@@ -30,7 +59,18 @@ RUN mkdir /usr/local/android-sdk && \
 # install sdk packages
 RUN echo y | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" "cmake;${CMAKE_VERSION}" "ndk;${ANDROID_NDK_VERSION}" "patcher;v4" "platforms;${ANDROID_API_LEVELS}"
 
-# copy project over to docker image
+# build tor library
+RUN git clone https://github.com/ACINQ/Tor_Onion_Proxy_Library && \
+    cd Tor_Onion_Proxy_Library && \
+    ./gradlew install && \
+    ./gradlew :universal:build && \
+    ./gradlew :android:build && \
+    ./gradlew :android:publishToMaven
+
+# copy eclair-core dependendency
+COPY --from=ECLAIR_CORE_BUILD /root/.m2/repository/fr/acinq/eclair /root/.m2/repository/fr/acinq/eclair
+
+# copy phoenix project over to docker image
 COPY . /home/ubuntu/phoenix
 
 # make gradle wrapper executable

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update -y && \
     apt-get install -y software-properties-common locales && \
     apt-get update -y && \
     locale-gen en_US.UTF-8 && \
-    apt-get install -y openjdk-8-jdk wget git unzip
+    apt-get install -y openjdk-8-jdk wget git unzip dos2unix
 
 # fetch and unpack the android sdk
 RUN mkdir /usr/local/android-sdk && \
@@ -76,5 +76,7 @@ COPY --from=ECLAIR_CORE_BUILD /root/.m2/repository/fr/acinq/eclair /root/.m2/rep
 COPY . /home/ubuntu/phoenix
 # make sure we don't read properties the host environment
 RUN rm -f /home/ubuntu/phoenix/local.properties
+# make sure we use unix EOL files
+RUN find /home/ubuntu/phoenix -type f -print0 | xargs -0 dos2unix --
 # make gradle wrapper executable
 RUN chmod +x /home/ubuntu/phoenix/gradlew


### PR DESCRIPTION
This PR improves the deterministic build by **not** requiring the user to provide the dependencies for phoenix, instead we build eclair-core in an intermediate container and Tor-onion-library in the final container.

Note: in the first stage of the build we make the eclair-core artifact and we use the same base image as in the eclair Dockerfile (adoptopenjdk-11) because eclair doesn't compile with JDK8 anymore.
Digest hash of the artifacts @ 1dea4d6
```
baccaf7558f11575da9fb7890337f15a838136ab1d396d3385ed315959f4a723  apk/release/phoenix-7-1dea4d6-testnet-arm64-v8a-release.apk
0d4ab5ff44b4bd93d3f1b47a0179d50674129db23193a499b11027871614982a  apk/release/phoenix-7-1dea4d6-testnet-armeabi-v7a-release.apk
f4aeb7488765a8a1c81a83bf5c813112ad140bb4e5e728b39ea3cc2e15142d07  apk/release/phoenix-7-1dea4d6-testnet-universal-release.apk
3af1f598aeff13a9dd084274d60914ee2382dc67364bedfbd1eb6b4cca7d40b7  apk/release/phoenix-7-1dea4d6-testnet-x86_64-release.apk
4da0bc4a8d08ea831b510e3096c2a1ba78d8c4ef75baf08316dd92e898f87e15  apk/release/phoenix-7-1dea4d6-testnet-x86-release.apk
```
cc: @Giszmo