### PR TITLE
Electrum: use protocol://host:port URIs for custom servers

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -429,7 +429,7 @@
 
   <string name="electrum_dialog_checkbox">Použít vlastní Electrum server</string>
   <string name="electrum_dialog_ssl">Server musí mít platný certifikát</string>
-  <string name="electrum_dialog_input">Adresa serveru (host:port).</string>
+  <string name="electrum_dialog_input">Adresa serveru ([tcp | ssl]://host:port).</string>
   <string name="electrum_empty_custom_address">Prosím, vložte adresu electrum serveru</string>
 
   <!-- ////////////// virtual keyboard hints //////////////// -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -439,7 +439,7 @@
 
   <string name="electrum_dialog_checkbox">Utiliser un serveur Electrum particulier</string>
   <string name="electrum_dialog_ssl">Le serveur doit avoir un certificat valide</string>
-  <string name="electrum_dialog_input">Addresse du serveur (host:port).</string>
+  <string name="electrum_dialog_input">Addresse du serveur ([tcp | ssl]://host:port).</string>
   <string name="electrum_empty_custom_address">Veuillez saisir une addresse pour le serveur electrum</string>
 
   <!-- ////////////// virtual keyboard hints //////////////// -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -445,7 +445,7 @@
 
   <string name="electrum_dialog_checkbox">Usa un electrum server personalizzato</string>
   <string name="electrum_dialog_ssl">Il server deve avere un certificato valido</string>
-  <string name="electrum_dialog_input">Server address (host:port).</string>
+  <string name="electrum_dialog_input">Server address ([tcp | ssl]://host:port).</string>
   <string name="electrum_empty_custom_address">Per favore inserisci l\'indirizzo di un eletrum server</string>
 
   <!-- //////////////// Tor setting //////////////// -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -437,7 +437,7 @@
 
   <string name="electrum_dialog_checkbox">Gebruik een aangepaste server</string>
   <string name="electrum_dialog_ssl">Server moet een geldig certificaat hebben</string>
-  <string name="electrum_dialog_input">Serveradres (host:port).</string>
+  <string name="electrum_dialog_input">Serveradres ([tcp | ssl]://host:port).</string>
   <string name="electrum_empty_custom_address">Voer een Electrum-serveradres in</string>
 
   <!-- ////////////// virtual keyboard hints //////////////// -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -436,7 +436,7 @@
 
   <string name="electrum_dialog_checkbox">Usar um servidor Electrum personalizado</string>
   <string name="electrum_dialog_ssl">O servidor deve possuir um certificado válido</string>
-  <string name="electrum_dialog_input">Endereço do servidor (host:port).</string>
+  <string name="electrum_dialog_input">Endereço do servidor ([tcp | ssl]://host:port).</string>
   <string name="electrum_empty_custom_address">Insira um endereço de servidor Electrum</string>
 
   <!-- ////////////// virtual keyboard hints //////////////// -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -463,7 +463,7 @@
 
   <string name="electrum_dialog_checkbox">Use a custom server</string>
   <string name="electrum_dialog_ssl">Server must have a valid certificate</string>
-  <string name="electrum_dialog_input">Server address (host:port).</string>
+  <string name="electrum_dialog_input">Server address ([tcp | ssl]://host:port).</string>
   <string name="electrum_empty_custom_address">Please enter an electrum server address</string>
 
   <!-- //////////////// fees settings //////////////// -->


### PR DESCRIPTION
URI can be either tcp://host:port or ssl://host:port for now