### PR TITLE
change eclair_version to snapshot

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -133,7 +133,7 @@ dependencies {
 
   // eclair core
   def libsecp256k1_version = "1.3"
-  def eclair_version = "0.3.8-android-phoenix"
+  def eclair_version = "0.3.9-android-phoenix-SNAPSHOT"
   implementation "fr.acinq.bitcoin:secp256k1-jni:$libsecp256k1_version"
   implementation("fr.acinq.eclair:eclair-core_2.11:$eclair_version") {
     exclude group: 'fr.acinq.bitcoin', module: 'secp256k1-jni'


### PR DESCRIPTION
https://github.com/ACINQ/phoenix/blob/master/BUILD.md refers to instructions to build eclair as a snapshot, so then building phoenix fails because eclair is not found.

I'm not sure how the releases are build, yet that would need be a adjusted slightly... Here I'm fixing the common case.