### PR TITLE
Rework seed display screen

### DIFF
--- a/app/src/main/java/fr/acinq/phoenix/security/PinDialog.kt
+++ b/app/src/main/java/fr/acinq/phoenix/security/PinDialog.kt
@@ -23,6 +23,7 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.view.HapticFeedbackConstants
 import android.view.LayoutInflater
+import android.view.WindowManager
 import android.widget.Button
 import androidx.databinding.DataBindingUtil
 import com.google.common.base.Strings
@@ -42,6 +43,9 @@ class PinDialog @JvmOverloads constructor(context: Context, themeResId: Int, pri
     setOnCancelListener { pinCallback.onPinCancel(this@PinDialog) }
     mBinding.pinTitle.text = Converter.html(getContext().getString(titleResId))
     setCancelable(cancelable)
+
+    // disable screen capture
+    window?.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
 
     // randomly sorted pin buttons
     val pinButtons = listOf(

--- a/app/src/main/java/fr/acinq/phoenix/settings/DisplaySeedFragment.kt
+++ b/app/src/main/java/fr/acinq/phoenix/settings/DisplaySeedFragment.kt
@@ -20,10 +20,7 @@ import android.app.AlertDialog
 import android.content.Context
 import android.os.Bundle
 import android.view.*
-import android.widget.CheckBox
-import android.widget.TableLayout
-import android.widget.TableRow
-import android.widget.TextView
+import android.widget.*
 import androidx.annotation.UiThread
 import androidx.biometric.BiometricManager
 import androidx.lifecycle.*
@@ -64,10 +61,10 @@ class DisplaySeedFragment : BaseFragment() {
     model.state.observe(viewLifecycleOwner, Observer { state ->
       when (state) {
         is DisplaySeedState.Error.Generic -> {
-          mBinding.errorView.text = getString(R.string.displayseed_error_generic)
+          context?.let { Toast.makeText(it, getString(R.string.displayseed_error_generic), Toast.LENGTH_SHORT).show() }
         }
         is DisplaySeedState.Error.WrongPassword -> {
-          mBinding.errorView.text = getString(R.string.displayseed_error_wrong_password)
+          context?.let { Toast.makeText(it, getString(R.string.displayseed_error_wrong_password), Toast.LENGTH_SHORT).show() }
         }
         is DisplaySeedState.Done -> {
           context?.run { getSeedDialog(this, state.words) }?.show()

--- a/app/src/main/java/fr/acinq/phoenix/settings/ForceCloseFragment.kt
+++ b/app/src/main/java/fr/acinq/phoenix/settings/ForceCloseFragment.kt
@@ -54,12 +54,12 @@ class ForceCloseFragment : BaseFragment() {
     super.onActivityCreated(savedInstanceState)
     model = ViewModelProvider(this).get(ForceCloseViewModel::class.java)
     mBinding.model = model
-    val finalAddress = try {
+    mBinding.instructions.text = Converter.html(getString(R.string.closechannels_force_instructions))
+    mBinding.destinationValue.text = try {
       app.kit!!.wallet().receiveAddress.value().get().get()
     } catch (e: Exception) {
       getString(R.string.utils_unknown)
     }
-    mBinding.actionBar.setSubtitle(Converter.html(getString(R.string.closechannels_force_instructions, finalAddress)))
   }
 
   override fun onStart() {

--- a/app/src/main/res/drawable/ic_key.xml
+++ b/app/src/main/res/drawable/ic_key.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright 2020 ACINQ SAS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+  <path
+    android:strokeColor="?attr/textColor"
+    android:strokeWidth="1"
+    android:pathData="M7.9,23c3.8,0 6.9,-3.1 6.9,-6.9c0,-0.8 -0.1,-1.6 -0.4,-2.3l1.8,-1.8V9.3h2.8V6.5h2.8V3.8H23V2.4C23,1.6 22.4,1 21.6,1h-4.1L9.1,9.4C8.7,9.3 8.3,9.3 7.9,9.3C4.1,9.3 1,12.3 1,16.1S4.1,23 7.9,23zM6.7,19.7c-1.1,0 -2.1,-0.9 -2.1,-2.1c0,-1.1 0.9,-2.1 2.1,-2.1s2.1,0.9 2.1,2.1C8.7,18.7 7.8,19.7 6.7,19.7z" />
+</vector>

--- a/app/src/main/res/layout/custom_switch_view.xml
+++ b/app/src/main/res/layout/custom_switch_view.xml
@@ -28,9 +28,9 @@
       android:paddingTop="@dimen/space_xxxs"
       android:paddingBottom="@dimen/space_xxxs"
       android:scaleType="fitCenter"
-      app:layout_constraintBottom_toBottomOf="@id/switch_button"
+      app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="@id/switch_button"
+      app:layout_constraintTop_toTopOf="parent"
       tools:ignore="ContentDescription" />
 
     <Switch
@@ -52,10 +52,10 @@
       android:lineSpacingMultiplier="1"
       android:textSize="@dimen/text_lg"
       app:layout_constrainedWidth="true"
-      app:layout_constraintBottom_toBottomOf="@id/switch_button"
+      app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toStartOf="@id/switch_button"
       app:layout_constraintHorizontal_bias="0"
       app:layout_constraintStart_toEndOf="@id/icon"
-      app:layout_constraintTop_toTopOf="@id/switch_button" />
+      app:layout_constraintTop_toTopOf="parent" />
   </merge>
 </layout>

--- a/app/src/main/res/layout/dialog_seed.xml
+++ b/app/src/main/res/layout/dialog_seed.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2019 ACINQ SAS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:fillViewport="true">
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+      android:id="@+id/seed_dialog_header"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:textAlignment="center"
+      android:layout_marginStart="@dimen/space_md_p"
+      android:layout_marginTop="@dimen/space_md_p"
+      android:layout_marginEnd="@dimen/space_md_p"
+      android:text="@string/displayseed_dialog_header"
+      app:layout_constraintTop_toTopOf="parent" />
+
+    <TableLayout
+      android:id="@+id/seed_dialog_words_table"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/space_md_p"
+      android:layout_marginEnd="@dimen/space_md_p"
+      android:layout_marginTop="@dimen/space_lg"
+      app:layout_constraintTop_toBottomOf="@id/seed_dialog_header" />
+
+    <TextView
+      android:id="@+id/seed_dialog_derivation_path"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="@dimen/space_md_p"
+      android:layout_marginStart="@dimen/space_md_p"
+      android:layout_marginEnd="@dimen/space_md_p"
+      android:textAlignment="center"
+      android:text="@string/displayseed_derivation_path"
+      android:textColor="?attr/mutedTextColor"
+      android:textSize="@dimen/text_sm"
+      app:layout_constraintTop_toBottomOf="@id/seed_dialog_words_table" />
+
+    <CheckBox
+      android:id="@+id/seed_dialog_backup_done_checkbox"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="@dimen/space_lg"
+      android:drawablePadding="@dimen/space_xs"
+      android:text="@string/displayseed_has_saved_seed_checkbox"
+      android:layout_marginStart="@dimen/space_md_p"
+      android:layout_marginEnd="@dimen/space_md_p"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintHorizontal_bias="0"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/seed_dialog_derivation_path" />
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_settings_about.xml
+++ b/app/src/main/res/layout/fragment_settings_about.xml
@@ -34,16 +34,14 @@
     <ScrollView
       android:layout_width="match_parent"
       android:layout_height="0dp"
-      android:fillViewport="true"
-      app:layout_constrainedHeight="true"
+      android:overScrollMode="never"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintTop_toBottomOf="@id/action_bar">
 
       <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/main_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent">
+        android:background="@drawable/square_border_hz">
 
         <TextView
           android:id="@+id/general"

--- a/app/src/main/res/layout/fragment_settings_display_seed.xml
+++ b/app/src/main/res/layout/fragment_settings_display_seed.xml
@@ -30,7 +30,6 @@
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:animateLayoutChanges="true"
     tools:context=".settings.DisplaySeedFragment">
 
     <fr.acinq.phoenix.utils.customviews.ActionBarView
@@ -43,58 +42,56 @@
     <ScrollView
       android:layout_width="match_parent"
       android:layout_height="0dp"
-      android:fillViewport="true"
-      app:layout_constrainedHeight="true"
+      android:overScrollMode="never"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintTop_toBottomOf="@id/action_bar">
 
       <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/main_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="@dimen/space_md_p"
-        app:layout_constraintTop_toTopOf="parent">
+        android:background="@drawable/square_border_hz">
 
         <TextView
           android:id="@+id/instructions"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/space_md"
+          android:layout_marginEnd="@dimen/space_md"
+          android:layout_marginStart="@dimen/space_md"
           android:text="@string/displayseed_instructions"
           app:layout_constraintTop_toTopOf="parent" />
 
+        <View
+          android:id="@+id/sep_1"
+          style="@style/HLineSeparator"
+          android:layout_marginTop="@dimen/space_lg"
+          android:layout_width="match_parent"
+          app:layout_constraintTop_toBottomOf="@id/instructions" />
+
         <fr.acinq.phoenix.utils.customviews.ButtonView
           android:id="@+id/unlock_button"
-          android:layout_width="wrap_content"
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_margin="@dimen/space_lg"
+          android:background="@drawable/button_bg_square"
           android:visibility="@{!(model.state instanceof DisplaySeedState.Unlocking)}"
+          android:padding="@dimen/space_md"
+          app:hz_bias="0"
           app:icon="@drawable/ic_key"
           app:layout_constrainedWidth="true"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@id/instructions"
+          app:layout_constraintTop_toBottomOf="@id/sep_1"
           app:text="@string/displayseed_authenticate_button" />
 
         <fr.acinq.phoenix.utils.customviews.ProgressTextView
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_margin="@dimen/space_lg"
-          android:padding="@dimen/space_sm"
-          android:visibility="@{model.state instanceof DisplaySeedState.Unlocking}"
-          app:layout_constraintTop_toBottomOf="@id/instructions"
-          app:text="@string/displayseed_loading" />
-
-        <TextView
-          android:id="@+id/error_view"
+          android:id="@+id/unlocking"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:padding="@dimen/space_md"
-          android:drawableStart="@drawable/ic_alert_triangle"
-          android:text="@string/displayseed_error_generic"
+          android:visibility="@{model.state instanceof DisplaySeedState.Unlocking}"
           app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintEnd_toEndOf="parent"
-          android:visibility="@{model.state instanceof DisplaySeedState.Error}"
-          app:layout_constraintTop_toBottomOf="@id/unlock_button" />
+          app:layout_constraintTop_toBottomOf="@id/sep_1"
+          app:text="@string/displayseed_loading" />
 
       </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/layout/fragment_settings_display_seed.xml
+++ b/app/src/main/res/layout/fragment_settings_display_seed.xml
@@ -40,41 +40,10 @@
       app:layout_constraintTop_toTopOf="parent"
       app:title="@string/displayseed_title" />
 
-    <fr.acinq.phoenix.utils.customviews.ButtonView
-      android:id="@+id/unlock_button"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_margin="@dimen/space_lg"
-      android:visibility="@{model.state == DisplaySeedState.INIT}"
-      app:icon="@drawable/ic_shield"
-      app:layout_constrainedWidth="true"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/action_bar"
-      app:text="@string/displayseed_authenticate_button" />
-
-    <fr.acinq.phoenix.utils.customviews.ProgressTextView
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:padding="@dimen/space_lg"
-      android:visibility="@{model.state == DisplaySeedState.UNLOCKING}"
-      app:layout_constraintTop_toBottomOf="@id/action_bar"
-      app:text="@string/displayseed_loading" />
-
-    <TextView
-      android:id="@+id/error_view"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:padding="@dimen/space_lg"
-      android:text="@string/displayseed_error"
-      android:visibility="@{model.state == DisplaySeedState.ERROR}"
-      app:layout_constraintTop_toBottomOf="@id/action_bar" />
-
     <ScrollView
       android:layout_width="match_parent"
       android:layout_height="0dp"
       android:fillViewport="true"
-      android:visibility="@{model.state == DisplaySeedState.DONE}"
       app:layout_constrainedHeight="true"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintTop_toBottomOf="@id/action_bar">
@@ -83,7 +52,7 @@
         android:id="@+id/main_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="@dimen/space_lg"
+        android:padding="@dimen/space_md_p"
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView
@@ -93,52 +62,39 @@
           android:text="@string/displayseed_instructions"
           app:layout_constraintTop_toTopOf="parent" />
 
-        <TableLayout
-          android:id="@+id/words_table"
+        <fr.acinq.phoenix.utils.customviews.ButtonView
+          android:id="@+id/unlock_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_margin="@dimen/space_lg"
+          android:visibility="@{!(model.state instanceof DisplaySeedState.Unlocking)}"
+          app:icon="@drawable/ic_key"
+          app:layout_constrainedWidth="true"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/instructions"
+          app:text="@string/displayseed_authenticate_button" />
+
+        <fr.acinq.phoenix.utils.customviews.ProgressTextView
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginTop="@dimen/space_lg"
-          app:layout_constraintTop_toBottomOf="@id/instructions" />
+          android:layout_margin="@dimen/space_lg"
+          android:padding="@dimen/space_sm"
+          android:visibility="@{model.state instanceof DisplaySeedState.Unlocking}"
+          app:layout_constraintTop_toBottomOf="@id/instructions"
+          app:text="@string/displayseed_loading" />
 
         <TextView
-          android:id="@+id/derivation_path"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginTop="@dimen/space_md_p"
-          android:text="@string/displayseed_derivation_path"
-          android:textAlignment="center"
-          android:textColor="?attr/mutedTextColor"
-          android:textSize="@dimen/text_sm"
-          app:layout_constraintTop_toBottomOf="@id/words_table" />
-
-        <androidx.constraintlayout.widget.Group
-          android:id="@+id/backgrup_warning_group"
+          android:id="@+id/error_view"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:visibility="@{model.showUserBackupWarning}"
-          app:constraint_referenced_ids="backup_warning_checkbox,backup_warning_button" />
-
-        <CheckBox
-          android:id="@+id/backup_warning_checkbox"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginTop="@dimen/space_lg"
-          android:text="@string/displayseed_has_saved_seed_checkbox"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintHorizontal_bias="0"
+          android:padding="@dimen/space_md"
+          android:drawableStart="@drawable/ic_alert_triangle"
+          android:text="@string/displayseed_error_generic"
           app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@id/derivation_path" />
-
-        <fr.acinq.phoenix.utils.customviews.ButtonView
-          android:id="@+id/backup_warning_button"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginTop="@dimen/space_md"
-          app:enableOrFade="@{model.userHasSavedSeed}"
-          app:icon="@drawable/ic_check_circle"
-          app:layout_constraintStart_toStartOf="@id/backup_warning_checkbox"
-          app:layout_constraintTop_toBottomOf="@id/backup_warning_checkbox"
-          app:text="@string/displayseed_has_saved_seed_button" />
+          app:layout_constraintEnd_toEndOf="parent"
+          android:visibility="@{model.state instanceof DisplaySeedState.Error}"
+          app:layout_constraintTop_toBottomOf="@id/unlock_button" />
 
       </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/layout/fragment_settings_electrum_server.xml
+++ b/app/src/main/res/layout/fragment_settings_electrum_server.xml
@@ -33,14 +33,13 @@
       android:layout_width="match_parent"
       android:layout_height="0dp"
       android:overScrollMode="never"
-      app:layout_constrainedHeight="true"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintTop_toBottomOf="@id/action_bar">
 
       <GridLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/bgColor"
+        android:background="@drawable/square_border_hz"
         android:columnCount="2">
 
         <View

--- a/app/src/main/res/layout/fragment_settings_force_close.xml
+++ b/app/src/main/res/layout/fragment_settings_force_close.xml
@@ -28,104 +28,159 @@
       type="fr.acinq.phoenix.settings.ForceCloseViewModel" />
   </data>
 
-  <ScrollView
-    android:id="@+id/scroll"
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:overScrollMode="never">
+    android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:id="@+id/main_layout"
+    <fr.acinq.phoenix.utils.customviews.ActionBarView
+      android:id="@+id/action_bar"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:paddingBottom="@dimen/space_xxl">
+      app:layout_constraintTop_toTopOf="parent"
+      app:title="@string/closechannels_force_title" />
 
-      <fr.acinq.phoenix.utils.customviews.ActionBarView
-        android:id="@+id/action_bar"
+    <ScrollView
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:overScrollMode="never"
+      android:clipToPadding="true"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/action_bar">
+
+      <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:subtitle="@string/closechannels_force_instructions"
-        app:title="@string/closechannels_force_title" />
+        android:background="@drawable/square_border_hz">
 
-      <fr.acinq.phoenix.utils.customviews.ProgressTextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/space_md"
-        android:padding="@dimen/space_md"
-        android:visibility="@{model.state == PreChannelsCloseState.CHECKING_CHANNELS}"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/action_bar"
-        app:text="@string/closechannels_checking_channels" />
+        <TextView
+          android:id="@+id/instructions"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:padding="@dimen/space_md"
+          android:textIsSelectable="true"
+          android:text="@string/closechannels_force_instructions"
+          app:layout_constraintTop_toTopOf="parent" />
 
-      <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/space_md"
-        android:background="?attr/bgColor"
-        android:padding="@dimen/space_md"
-        android:text="@string/closechannels_channels_none"
-        android:visibility="@{model.state == PreChannelsCloseState.NO_CHANNELS}"
-        app:layout_constraintTop_toBottomOf="@id/action_bar" />
+        <View
+          android:id="@+id/sep_1"
+          style="@style/HLineSeparator"
+          android:layout_width="50dp"
+          android:layout_marginTop="@dimen/space_xs"
+          android:layout_marginStart="@dimen/space_md"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/instructions" />
 
-      <TextView
-        android:id="@+id/force_error"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/space_md"
-        android:drawableStart="@drawable/ic_alert_triangle"
-        android:padding="@dimen/space_md"
-        android:text="@string/closechannels_message_error"
-        android:visibility="@{model.state == ForceCloseState.ERROR}"
-        app:layout_constraintTop_toBottomOf="@id/action_bar" />
+        <TextView
+          android:id="@+id/destination_label"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/space_md"
+          android:layout_marginStart="@dimen/space_md"
+          android:layout_marginEnd="@dimen/space_md"
+          android:text="@string/closechannels_force_destination"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/sep_1" />
 
-      <TextView
-        android:id="@+id/force_done"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/space_md"
-        android:layout_marginTop="@dimen/space_md"
-        android:background="@drawable/rounded"
-        android:backgroundTint="?attr/positiveColor"
-        android:drawableStart="@drawable/ic_check"
-        android:drawablePadding="@dimen/space_sm"
-        android:drawableTint="?attr/altTextColor"
-        android:paddingStart="@dimen/space_md"
-        android:paddingTop="@dimen/space_sm"
-        android:paddingEnd="@dimen/space_md"
-        android:paddingBottom="@dimen/space_sm"
-        android:text="@string/closechannels_message_done"
-        android:textColor="?attr/altTextColor"
-        android:visibility="@{model.state == ForceCloseState.DONE}"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/action_bar" />
+        <TextView
+          android:id="@+id/destination_value"
+          android:layout_width="match_parent"
+          android:fontFamily="monospace"
+          android:textIsSelectable="true"
+          android:textSize="@dimen/text_md"
+          android:layout_height="wrap_content"
+          android:drawableStart="@drawable/ic_chain"
+          android:drawablePadding="@dimen/space_xs"
+          android:layout_marginStart="@dimen/space_md"
+          android:layout_marginTop="@dimen/space_xs"
+          android:layout_marginEnd="@dimen/space_md"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toEndOf="@id/destination_label"
+          app:layout_constraintTop_toBottomOf="@id/destination_label" />
 
-      <fr.acinq.phoenix.utils.customviews.ProgressTextView
-        android:id="@+id/force_in_progress"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/space_md"
-        android:layout_marginTop="@dimen/space_md"
-        android:padding="@dimen/space_md"
-        android:visibility="@{model.state == ForceCloseState.IN_PROGRESS}"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/action_bar"
-        app:text="@string/closechannels_message_in_progress" />
+        <TextView
+          android:id="@+id/destination_desc"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="@string/closechannels_force_destination_desc"
+          android:textColor="?attr/mutedTextColor"
+          android:textSize="@dimen/text_md"
+          android:layout_marginTop="@dimen/space_xs"
+          android:layout_marginStart="@dimen/space_md"
+          android:layout_marginEnd="@dimen/space_md"
+          app:layout_constraintTop_toBottomOf="@id/destination_value" />
 
-      <fr.acinq.phoenix.utils.customviews.ButtonView
-        android:id="@+id/force_confirm_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/space_md"
-        android:layout_marginTop="@dimen/space_md"
-        android:visibility="@{model.state == PreChannelsCloseState.READY}"
-        app:hz_bias="0"
-        app:icon="@drawable/ic_cross_circle"
-        app:icon_tint="?attr/negativeColor"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/action_bar"
-        app:text="@string/closechannels_force_button" />
+        <View
+          android:id="@+id/sep_2"
+          style="@style/HLineSeparator"
+          android:layout_marginTop="@dimen/space_md"
+          android:layout_width="match_parent"
+          app:layout_constraintTop_toBottomOf="@id/destination_desc" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-  </ScrollView>
+        <fr.acinq.phoenix.utils.customviews.ProgressTextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:padding="@dimen/space_md"
+          android:visibility="@{model.state == PreChannelsCloseState.CHECKING_CHANNELS}"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/sep_2"
+          app:text="@string/closechannels_checking_channels" />
+
+        <TextView
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:padding="@dimen/space_md"
+          android:text="@string/closechannels_channels_none"
+          android:visibility="@{model.state == PreChannelsCloseState.NO_CHANNELS}"
+          app:layout_constraintTop_toBottomOf="@id/sep_2" />
+
+        <fr.acinq.phoenix.utils.customviews.ButtonView
+          android:id="@+id/force_confirm_button"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:visibility="@{model.state == PreChannelsCloseState.READY}"
+          android:padding="@dimen/space_md"
+          app:icon_tint="?attr/negativeColor"
+          android:background="@drawable/button_bg_square"
+          app:hz_bias="0"
+          app:icon="@drawable/ic_cross_circle"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/sep_2"
+          app:text="@string/closechannels_force_button" />
+
+        <fr.acinq.phoenix.utils.customviews.ProgressTextView
+          android:id="@+id/force_in_progress"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:padding="@dimen/space_md"
+          android:visibility="@{model.state == ForceCloseState.IN_PROGRESS}"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/sep_2"
+          app:text="@string/closechannels_message_in_progress" />
+
+        <TextView
+          android:id="@+id/force_done"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:drawableStart="@drawable/ic_check"
+          android:drawablePadding="@dimen/space_xs"
+          android:drawableTint="?attr/positiveColor"
+          android:padding="@dimen/space_md"
+          android:text="@string/closechannels_message_done"
+          android:visibility="@{model.state == ForceCloseState.DONE}"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/sep_2" />
+
+        <TextView
+          android:id="@+id/force_error"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:drawableStart="@drawable/ic_alert_triangle"
+          android:padding="@dimen/space_md"
+          android:text="@string/closechannels_message_error"
+          android:visibility="@{model.state == ForceCloseState.ERROR}"
+          app:layout_constraintTop_toBottomOf="@id/sep_2" />
+
+      </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_settings_logs.xml
+++ b/app/src/main/res/layout/fragment_settings_logs.xml
@@ -21,7 +21,6 @@
   <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:animateLayoutChanges="true"
     tools:context=".settings.LogsSettingsFragment">
 
     <fr.acinq.phoenix.utils.customviews.ActionBarView
@@ -35,13 +34,14 @@
     <ScrollView
       android:layout_width="match_parent"
       android:layout_height="0dp"
-      android:fillViewport="true"
+      android:overScrollMode="never"
+      app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintTop_toBottomOf="@id/action_bar">
 
       <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/bgColor">
+        android:background="@drawable/square_border_hz">
 
         <View
           android:id="@+id/instructions_sep"
@@ -54,6 +54,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:background="@drawable/button_bg_square_border"
+          android:padding="@dimen/space_md"
           app:hz_bias="0"
           app:icon="@drawable/ic_eye"
           app:layout_constraintTop_toBottomOf="@id/instructions_sep"
@@ -64,6 +65,7 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:background="@drawable/button_bg_square_border"
+          android:padding="@dimen/space_md"
           app:hz_bias="0"
           app:icon="@drawable/ic_share"
           app:layout_constraintTop_toBottomOf="@id/view_button"

--- a/app/src/main/res/layout/fragment_settings_mutual_close.xml
+++ b/app/src/main/res/layout/fragment_settings_mutual_close.xml
@@ -28,46 +28,36 @@
       type="fr.acinq.phoenix.settings.MutualCloseViewModel" />
   </data>
 
-  <ScrollView
+  <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fillViewport="true"
-    android:overScrollMode="never"
-    app:layout_constrainedHeight="true"
-    app:layout_constraintBottom_toBottomOf="parent">
+    android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <fr.acinq.phoenix.utils.customviews.ActionBarView
+      android:id="@+id/action_bar"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:paddingBottom="@dimen/space_xxl">
+      app:layout_constraintTop_toTopOf="parent"
+      app:subtitle="@string/closechannels_mutual_instructions"
+      app:title="@string/closechannels_mutual_title" />
 
-      <fr.acinq.phoenix.utils.customviews.ActionBarView
-        android:id="@+id/action_bar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:subtitle="@string/closechannels_mutual_instructions"
-        app:title="@string/closechannels_mutual_title" />
+    <ScrollView
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:overScrollMode="never"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/action_bar">
 
       <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/main_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/bgColor"
-        app:layout_constraintTop_toBottomOf="@id/action_bar">
-
-        <View
-          android:id="@+id/top_separator"
-          style="@style/HLineSeparator"
-          android:layout_width="match_parent"
-          app:layout_constraintTop_toTopOf="parent" />
+        android:background="@drawable/square_border_hz">
 
         <fr.acinq.phoenix.utils.customviews.ProgressTextView
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:padding="@dimen/space_md"
           android:visibility="@{model.state == PreChannelsCloseState.CHECKING_CHANNELS}"
-          app:layout_constraintTop_toBottomOf="@id/top_separator"
+          app:layout_constraintTop_toTopOf="parent"
           app:text="@string/closechannels_checking_channels" />
 
         <TextView
@@ -76,7 +66,7 @@
           android:layout_height="wrap_content"
           android:padding="@dimen/space_md"
           android:text="@string/closechannels_channels_none"
-          app:layout_constraintTop_toBottomOf="@id/top_separator" />
+          app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
           android:id="@+id/instructions"
@@ -122,19 +112,13 @@
 
         <TextView
           android:id="@+id/mutual_done"
-          android:layout_width="wrap_content"
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginStart="@dimen/space_md"
           android:layout_marginTop="@dimen/space_md_p"
-          android:background="@drawable/rounded"
-          android:backgroundTint="?attr/positiveColor"
           android:drawableStart="@drawable/ic_check"
           android:drawablePadding="@dimen/space_sm"
-          android:drawableTint="?attr/altTextColor"
-          android:paddingStart="@dimen/space_md"
-          android:paddingTop="@dimen/space_sm"
-          android:paddingEnd="@dimen/space_md"
-          android:paddingBottom="@dimen/space_sm"
+          android:drawableTint="?attr/positiveColor"
+          android:padding="@dimen/space_md"
           android:text="@string/closechannels_message_done"
           android:textColor="?attr/altTextColor"
           android:visibility="@{model.state == MutualCloseState.DONE}"
@@ -145,7 +129,6 @@
           android:id="@+id/mutual_in_progress"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginStart="@dimen/space_md"
           android:layout_marginTop="@dimen/space_md_p"
           android:padding="@dimen/space_md"
           android:visibility="@{model.state == MutualCloseState.IN_PROGRESS}"
@@ -153,33 +136,28 @@
           app:layout_constraintTop_toBottomOf="@id/mutual_close_address_layout"
           app:text="@string/closechannels_message_in_progress" />
 
+        <View
+          style="@style/HLineSeparator"
+          android:layout_width="match_parent"
+          android:visibility="@{model.state == PreChannelsCloseState.READY}"
+          app:layout_constraintBottom_toTopOf="@id/mutual_confirm_button" />
+
         <fr.acinq.phoenix.utils.customviews.ButtonView
           android:id="@+id/mutual_confirm_button"
-          android:layout_width="wrap_content"
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginStart="@dimen/space_md"
+          android:background="@drawable/button_bg_square"
           android:layout_marginTop="@dimen/space_md_p"
+          android:padding="@dimen/space_md"
           android:visibility="@{model.state == PreChannelsCloseState.READY}"
           app:enableOrFade="@{model.addressInput.length() > 0}"
+          app:hz_bias="0"
           app:icon="@drawable/ic_empty"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/mutual_close_address_layout"
           app:text="@string/closechannels_mutual_button" />
 
-        <androidx.constraintlayout.widget.Barrier
-          android:id="@+id/action_bottom"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          app:barrierDirection="bottom"
-          app:constraint_referenced_ids="mutual_confirm_button,mutual_error,mutual_in_progress,mutual_done" />
-
-        <View
-          style="@style/HLineSeparator"
-          android:layout_width="match_parent"
-          android:layout_marginTop="@dimen/space_md"
-          app:layout_constraintTop_toBottomOf="@+id/action_bottom" />
-
       </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
-  </ScrollView>
+    </ScrollView>
+  </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_settings_tor.xml
+++ b/app/src/main/res/layout/fragment_settings_tor.xml
@@ -40,20 +40,20 @@
       android:layout_width="match_parent"
       android:layout_height="0dp"
       android:overScrollMode="never"
-      app:layout_constrainedHeight="true"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintTop_toBottomOf="@id/action_bar">
 
       <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/bgColor">
+        android:background="@drawable/square_border_hz">
 
         <fr.acinq.phoenix.utils.customviews.SwitchView
           android:id="@+id/tor_switch"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           app:layout_constraintTop_toTopOf="parent"
+          app:icon="@drawable/ic_tor_shield"
           app:text="@string/tor_settings_disabled" />
 
         <View

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -225,10 +225,9 @@
     <br/><br/>
     Vynucené uzavření kanálů vás bude stát peníze (k zaplacení on-chain poplatků) a uzamkne vaše finance na několik dní. <b>Neodinstalovávejte tuto aplikaci, dokud nejsou vaše kanály plně uzavřené nebo přijdete o své peníze.</b>
     <br/><br/>
-    Finance budou odeslány na: %1$s
-    <br/><br/>
     <b>Nepoužívejte tuto funkci, pokud plně nechápete, jak funguje.</b>
   ]]></string>
+  <string name="closechannels_force_destination">Finance budou odeslány na:</string>
   <string name="closechannels_force_button">Vynutit uzavření kanálů</string>
   <string name="closechannels_confirm_dialog_message">Jste si jistí, že chcete pokračovat?</string>
   <string name="closechannels_message_error">Nastala chyba. Prosím, zkuste to znovu později.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -32,7 +32,7 @@
   <string name="restore_disclaimer_message">Neimportujte seed, který NEBYL vytvořen v této aplikaci. \n\nZároveň se ujistěte že nemáte spuštěnou jinou Phoenix peněženku se stejným seedem.</string>
   <string name="restore_disclaimer_checkbox">Ano, rozumím.</string>
   <string name="restore_disclaimer_next">Další</string>
-  <string name="restore_instructions">Seed vaší peněženky je seznam 12 anglických slov. Heslo peněženky není podporováno.</string>
+  <string name="restore_instructions">Seed vaší peněženky je seznam 12 anglických slov.</string>
   <string name="restore_mnemonics_label">Použijte klávesnici k zadání seedu:</string>
   <string name="restore_in_progress">Obnovování peněženky…</string>
   <string name="restore_import_button">Importovat</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -309,7 +309,6 @@
   <string name="displayseed_derivation_path">BIP39 seed se standardní BIP84 cestou derivace</string>
   <string name="displayseed_words_td"><![CDATA[<td><font color="rgba(100,100,100,.3)"><small>#%1$d</small></font> <b>%2$s</b></td>]]></string>
   <string name="displayseed_has_saved_seed_checkbox">Udělal jsem zálohu svého seedu</string>
-  <string name="displayseed_has_saved_seed_button">Potvrdit</string>
 
   <!-- //////////////// logs settings //////////////// -->
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -147,7 +147,6 @@
   <string name="scan_instructions">Umístěte QR kód platebního požadavku dovnitř obdélníčku, aby mohl být přečten</string>
   <string name="scan_state_reading">Čtení platebního požadavku</string>
 
-  <string name="scan_error_default">Toto není platná žádost o platbu.\n\nProsím, zkuste to znovu.</string>
   <string name="scan_error_expired">Platba vypršela.</string>
   <string name="scan_error_pay_to_self">Nemůžete platit sám sobě.</string>
   <string name="scan_error_invalid_chain">Tento požadavek nepoužívá stejný blockchain jako vaše peněženka.</string>
@@ -299,7 +298,8 @@
   <string name="displayseed_title">Seznam slov k obnovení peněženky</string>
   <string name="displayseed_authenticate_button">Zobrazit seed</string>
   <string name="displayseed_loading">Odemykám seed…</string>
-  <string name="displayseed_error">Seed nemohl být načten. Prosím, zkuste to znovu.\n\nDůvod: %1$s</string>
+  <string name="displayseed_error_generic">Seed nemohl být načten. Prosím, zkuste to znovu.</string>
+  <string name="displayseed_error_wrong_password">Chybný PIN kód.</string>
   <string name="displayseed_instructions"><![CDATA[
     Tento seznam slov je záloha vaší peněženky. Uložte je někam bezpečně (ne do tohoto telefonu)!
     <br /><br />

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -138,7 +138,6 @@
   <string name="scan_request_camera_access">Permitir acceso a la cámara</string>
   <string name="scan_instructions">Coloca un código QR de solicitud de pago\ndentro del rectángulo para escanearlo</string>
   <string name="scan_state_reading">Leyendo solicitud de pago</string>
-  <string name="scan_error_default">Esta no es una solicitud de pago válida.\n\nPor favor inténtalo de nuevo.</string>
   <string name="scan_error_expired">El pago ha expirado.</string>
   <string name="scan_error_pay_to_self">No puedes auto enviarte un pago.</string>
   <string name="scan_error_invalid_chain">Esta factura no usa la misma blockchain que tu wallet.</string>
@@ -285,7 +284,8 @@
   <string name="displayseed_title">Frase de recuperación de la wallet</string>
   <string name="displayseed_authenticate_button">Mostrar seed</string>
   <string name="displayseed_loading">Desbloquear seed…</string>
-  <string name="displayseed_error">Error al leer la seed. Por favor inténtalo de nuevo.\n\nRazón: %1$s</string>
+  <string name="displayseed_error_generic">Error al leer la seed. Por favor inténtalo de nuevo.</string>
+  <string name="displayseed_error_wrong_password">PIN incorrecto.</string>
   <string name="displayseed_instructions"><![CDATA[
     Esta lista de palabras es la copia de seguridad de tu wallet. ¡Guárdala en un lugar seguro (no en este teléfono)!
     <br /><br />

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -295,7 +295,6 @@
   <string name="displayseed_derivation_path">Seed BIP39 con ruta de derivación estándar BIP84</string>
   <string name="displayseed_words_td"><![CDATA[<td><font color="rgba(100,100,100,.3)"><small>#%1$d</small></font> <b>%2$s</b></td>]]></string>
   <string name="displayseed_has_saved_seed_checkbox">Ya hice una copia de seguridad de mi seed.</string>
-  <string name="displayseed_has_saved_seed_button">Confirmar</string>
 
   <!-- //////////////// logs settings //////////////// -->
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -212,10 +212,9 @@
     <br/><br/>
     Forzar el cierre de canales te costará dinero (para cubrir las tarifas en la cadena de bloques) y hará que tus fondos estén bloqueados durante días. <b>No desinstales la aplicación hasta que tus canales estén completamente cerrados, o perderás tu dinero.</b>
     <br/><br/>
-    Los fondos eventualmente se enviarán a: %1$s
-    <br/><br/>
     <b>No uses esta función si no entiendes exactamente las consecuencias.</b>
   ]]></string>
+  <string name="closechannels_force_destination">Los fondos eventualmente se enviarán a:</string>
   <string name="closechannels_force_button">Forzar el cierre de canales</string>
   <string name="closechannels_confirm_dialog_message">¿Aún así quieres proceder?</string>
   <string name="closechannels_message_error">Ha habido un problema. Por favor, inténtalo de nuevo más tarde.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -31,7 +31,7 @@
   <string name="restore_disclaimer_message">No importes una seed que NO haya sido creada por esta aplicación.\n\nAdemás, asegúrate de que no tienes otra wallet Phoenix siendo ejecutado con la misma seed.</string>
   <string name="restore_disclaimer_checkbox">Entiendo.</string>
   <string name="restore_disclaimer_next">Siguiente</string>
-  <string name="restore_instructions">La seed de tu wallet es una lista de 12 palabras en inglés. Ten en cuenta que las frases de contraseña BIP39 no son compatibles.</string>
+  <string name="restore_instructions">La seed de tu wallet es una lista de 12 palabras en inglés.</string>
   <string name="restore_mnemonics_label">Utiliza el teclado abajo para introducer la seed:</string>
   <string name="restore_in_progress">Recuperando tu wallet…</string>
   <string name="restore_import_button">Importar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -57,6 +57,7 @@
   <string name="startup_start_button">Redémarrer</string>
   <string name="startup_settings_button">Options</string>
   <string name="startup_error_generic">L\'application n\'a pas pu démarrer suite à une erreur interne.\n\nDétails: %1$s</string>
+  <string name="startup_error_electrum_address">L\'application n\'a pas pu démarrer. L\'adresse de votre serveur Electrum n\'est pas valide.\n\nVous pouvez corriger cela dans Configuration > Electrum.</string>
   <string name="startup_error_tor">Le service Tor n\'a pas pu démarrer. Vérifiez que votre connexion fonctionne et essayez de nouveau.\n\nDétails de l\'erreur: %1$s</string>
   <string name="startup_error_unreadable">Echec de la lecture des données du portefeuille. Veuillez redémarrer l\'application.</string>
   <string name="startup_error_network">L\'application n\'a pas accès à Internet. Veuillez vérifier votre connexion cellulaire ou WiFi.</string>
@@ -466,6 +467,7 @@
 
   <string name="electrum_dialog_checkbox">Utiliser un serveur Electrum particulier</string>
   <string name="electrum_dialog_ssl">Le serveur doit avoir un certificat valide</string>
+  <string name="electrum_dialog_ssl_tor">Également vérifier le certificat pour cette adresse en .onion</string>
   <string name="electrum_dialog_input">Addresse du serveur (host:port).</string>
   <string name="electrum_empty_custom_address">Veuillez saisir une addresse pour le serveur electrum</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -327,7 +327,6 @@
   <string name="displayseed_derivation_path">Seed BIP39 avec chemin de dérivation standard BIP84</string>
   <string name="displayseed_words_td"><![CDATA[<td><font color="rgba(100,100,100,.3)"><small>#%1$d</small></font> <b>%2$s</b></td>]]></string>
   <string name="displayseed_has_saved_seed_checkbox">J\'ai bien sauvegardé ma seed dans un endroit sûr.</string>
-  <string name="displayseed_has_saved_seed_button">Confirmer</string>
   <string name="displayseed_dialog_header">NE PAS PARTAGER.</string>
 
   <!-- //////////////// logs settings //////////////// -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -195,7 +195,7 @@
   <string name="settings_display_prefs">Affichage</string>
   <string name="settings_security_title">Sécurité</string>
   <string name="settings_display_seed">Phrase de sauvegarde</string>
-  <string name="settings_seed_security">Accès à l\'application</string>
+  <string name="settings_seed_security">Contrôle d\'accès</string>
   <string name="settings_advanced_title">Avancé</string>
   <string name="settings_fees">Configuration des frais de transaction</string>
   <string name="settings_list_channels">Mes canaux de paiement</string>
@@ -306,18 +306,28 @@
   <!-- //////////////// display seed //////////////// -->
 
   <string name="displayseed_title">Phrase de récupération du portefeuille</string>
-  <string name="displayseed_authenticate_button">Afficher la seed du portefeuille.</string>
+  <string name="displayseed_authenticate_button">Afficher ma seed</string>
   <string name="displayseed_loading">Déverrouillage de la seed…</string>
-  <string name="displayseed_error">La seed n\'a pas pu être lue. Veuillez réessayer.\n\nCause: %1$s</string>
+  <string name="displayseed_error_generic">Échec du déverrouillage.\nVeuillez réessayer.</string>
+  <string name="displayseed_error_wrong_password">Le code PIN est incorrect.</string>
   <string name="displayseed_instructions"><![CDATA[
-  Cette liste de 12 mots anglais est la graine (ou seed) de votre portefeuille. Vous devez la sauvegarder dans un endroit sûr (pas sur ce téléphone) !
-  <br /><br />
-  <b>Cette liste est personnelle et donne accès à vos fonds, ne la partagez avec personne. Ne la perdez pas.</b> Si vous perdez votre liste de mots et votre téléphone, vous ne pourrez plus accéder à vos fonds.
+    La seed (ou graine) est une liste de 12 mots anglais. C\'est la sauvegarde du portefeuille. Elle donne accès à vos fonds.
+    <br /><br />
+    <strong>Vous seul possédez cette seed. Elle doit rester personnelle.</strong>
+    <br /><br />
+    <strong>Ne la donnez à personne</strong>.
+    <br />
+    Prenez garde au hameçonnage. Les développeurs de Phoenix ne vous demanderont jamais votre seed.
+    <br /><br />
+    <strong>Ne la perdez pas</strong>.
+    <br />
+    Sauvegardez votre seed dans un endroit sûr (pas sur ce téléphone). Si vous perdez votre seed et votre téléphone, vous ne pourrez plus accéder à vos fonds.
   ]]></string>
   <string name="displayseed_derivation_path">Seed BIP39 avec chemin de dérivation standard BIP84</string>
   <string name="displayseed_words_td"><![CDATA[<td><font color="rgba(100,100,100,.3)"><small>#%1$d</small></font> <b>%2$s</b></td>]]></string>
   <string name="displayseed_has_saved_seed_checkbox">J\'ai bien sauvegardé ma seed dans un endroit sûr.</string>
   <string name="displayseed_has_saved_seed_button">Confirmer</string>
+  <string name="displayseed_dialog_header">NE PAS PARTAGER.</string>
 
   <!-- //////////////// logs settings //////////////// -->
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -235,10 +235,10 @@
     <br/><br/>
     Une fermeture forcée vous coûtera de l\'argent (pour payer les frais de transaction on-chain), et bloquera vos fonds pour plusieurs jours. <b>Ne désinstallez pas l\'application tant que vos canaux de paiements ne sont pas définitivement fermés, sous peine de perdre vos fonds.</b>
     <br/><br/>
-    Les fonds seront envoyés in-fine à l\'adresse: %1$s
-    <br/><br/>
     <b>N\'utilisez pas cette fonctionnalité si vous ne comprenez pas bien ce qu\'elle fait.</b>
   ]]></string>
+  <string name="closechannels_force_destination">Les fonds seront envoyés à:</string>
+  <string name="closechannels_force_destination_desc">Cette adresse est dérivée de votre seed et vous appartient.</string>
   <string name="closechannels_force_button">Forcer la clôture de mes canaux de paiement</string>
   <string name="closechannels_confirm_dialog_message">Etes-vous sûr de vouloir continuer?</string>
   <string name="closechannels_message_error">Un problème est survenu. Merci de réessayer plus tard.</string>
@@ -309,7 +309,7 @@
   <string name="displayseed_title">Phrase de récupération du portefeuille</string>
   <string name="displayseed_authenticate_button">Afficher ma seed</string>
   <string name="displayseed_loading">Déverrouillage de la seed…</string>
-  <string name="displayseed_error_generic">Échec du déverrouillage.\nVeuillez réessayer.</string>
+  <string name="displayseed_error_generic">Échec du déverrouillage, veuillez réessayer.</string>
   <string name="displayseed_error_wrong_password">Le code PIN est incorrect.</string>
   <string name="displayseed_instructions"><![CDATA[
     La seed (ou graine) est une liste de 12 mots anglais. C\'est la sauvegarde du portefeuille. Elle donne accès à vos fonds.

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -298,7 +298,7 @@
 
   <string name="inappnotif_set_up_pin">Votre portefeuille n\'est pas protégé.</string>
   <string name="inappnotif_set_up_pin_action">Définir un code d\'accès</string>
-  <string name="inappnotif_mnemonics_never_seen">Merci d\'utiliser Phoenix. Avez-vous sauvegardé votre portefeuille?</string>
+  <string name="inappnotif_mnemonics_never_seen">Merci d\'utiliser Phoenix. Veuillez sauvegarder votre portefeuille pour ne pas perdre vos bitcoins.</string>
   <string name="inappnotif_mnemonics_never_seen_action">Sauvegarder mon portefeuille</string>
   <string name="inappnotif_background_worker_cannot_run">Phoenix a besoin de pouvoir travailler en tâche de fond de temps en temps. Assurez vous que votre système ne tue pas cette appli à des finds d\'économie de batterie.</string>
   <string name="inappnotif_upgrade">Une mise à jour pour cette application est disponible.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -33,7 +33,7 @@
   <string name="restore_disclaimer_message">N\'importez pas ici une seed qui n\'aurait pas été créée avec une application Phoenix.\n\nPar ailleurs, pour éviter tout conflit, assurez vous que vous n\'avez une autre application Phoenix sur un autre téléphone qui utiliserait la même seed.</string>
   <string name="restore_disclaimer_checkbox">Je comprends.</string>
   <string name="restore_disclaimer_next">Suivant</string>
-  <string name="restore_instructions">La seed de votre portefeuille est une liste de 12 mots anglais. Notez que les passphrase additionnelles ne sont pas supportées.</string>
+  <string name="restore_instructions">La seed de votre portefeuille est une liste de 12 mots anglais.</string>
   <string name="restore_mnemonics_label">Utilisez le clavier virtuel ci-dessous pour entrer votre liste de mots, séparés par un espace:</string>
   <string name="restore_in_progress">Restauration du portefeuille…</string>
   <string name="restore_import_button">Restaurer</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -32,7 +32,7 @@
   <string name="restore_disclaimer_message">Non importare un seed che non è stato creato da quest\'app.\n\nInoltre, assicurati di non avere un altra app Phoenix aperta con lo stesso seed.</string>
   <string name="restore_disclaimer_checkbox">Ho capito.</string>
   <string name="restore_disclaimer_next">Avanti</string>
-  <string name="restore_instructions">Il seed del tuo wallet è una lista di 12 parole inglesi. Nota bene che l\'uso di una passphrase non è supportato.</string>
+  <string name="restore_instructions">Il seed del tuo wallet è una lista di 12 parole inglesi.</string>
   <string name="restore_mnemonics_label">Usa la seguente tastiera per inserire il tuo seed:</string>
   <string name="restore_in_progress">Ripristino del wallet…</string>
   <string name="restore_import_button">Importa</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -305,7 +305,6 @@
   <string name="displayseed_derivation_path">Seed BIP39 con path derivation standard BIP84</string>
   <string name="displayseed_words_td"><![CDATA[<td><font color="rgba(100,100,100,.3)"><small>#%1$d</small></font> <b>%2$s</b></td>]]></string>
   <string name="displayseed_has_saved_seed_checkbox">Ho fatto un backup del mio seed</string>
-  <string name="displayseed_has_saved_seed_button">Conferma</string>
 
   <!-- //////////////// logs settings //////////////// -->
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -144,7 +144,6 @@
   <string name="scan_instructions">Inquadta il QR di una richiesta di pagamento\nall\'interno del rettangolo.</string>
   <string name="scan_state_reading">Leggendo la richiesta di pagamento</string>
 
-  <string name="scan_error_default">Questa non è una richiesta di pagamento valida.\n\nPer favore prova di nuovo.</string>
   <string name="scan_error_expired">Il pagamento è scaduto.</string>
   <string name="scan_error_pay_to_self">Non puoi pagare te stesso.</string>
   <string name="scan_error_invalid_chain">Questa richesta di pagamento non usa la stessa blockchain del tuo wallet.</string>
@@ -295,7 +294,8 @@
   <string name="displayseed_title">Frase di recupero wallet</string>
   <string name="displayseed_authenticate_button">Mostra seed</string>
   <string name="displayseed_loading">Sbloccando il seed…</string>
-  <string name="displayseed_error">Impossibile leggere il seed. Per favore riprova.\n\nMotivo: %1$s</string>
+  <string name="displayseed_error_generic">Impossibile leggere il seed. Per favore riprova.</string>
+  <string name="displayseed_error_wrong_password">PIN errato.</string>
   <string name="displayseed_instructions"><![CDATA[
     Questa lista di parole è il backup del tuo wallet. Salvala in un luogo sicuro (non su questo telefono)!
     <br /><br />

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -222,10 +222,9 @@
     <br/><br/>
     La chiusura forzata dei canali comporta un costo aggiuntivo (le commissioni on-chain) e il blocco dei fondi per qualche giorno. <b> Non disinstallare l\'app finchè i tuoi canali sono completamente chiusi o perderai dei soldi.</b>
     <br/><br/>
-    I fondi verranno mandati a: %1$s
-    <br/><br/>
     <b>Non usare questa funzionalità se non comprendi appieno cosa fa.</b>
   ]]></string>
+  <string name="closechannels_force_destination">I fondi verranno mandati a:</string>
   <string name="closechannels_force_button">Chiusura forzata di tutti i canali</string>
   <string name="closechannels_confirm_dialog_message">Sei sicuro di voler procedere?</string>
   <string name="closechannels_message_error">C\'è stato un problema. Per favore riprova più tardi.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -145,7 +145,6 @@
   <string name="scan_instructions">Plaats een betalingsverzoek QR code\nin de rechthoek het om te scannen</string>
   <string name="scan_state_reading">Betalingsverzoek lezen</string>
 
-  <string name="scan_error_default">Dit is geen geldig betalingsverzoek.\n\nProbeer opnieuw.</string>
   <string name="scan_error_expired">Betaling is verlopen.</string>
   <string name="scan_error_pay_to_self">Je kan jezelf niet betalen.</string>
   <string name="scan_error_invalid_chain">Dit betalingsverzoek gebruikt niet dezelfde blockchain als je wallet.</string>
@@ -298,7 +297,8 @@
   <string name="displayseed_title">Wallet herstelzin</string>
   <string name="displayseed_authenticate_button">Laat seed zien</string>
   <string name="displayseed_loading">Seed ontgrendelen…</string>
-  <string name="displayseed_error">Kan seed niet lezen. Probeer opnieuw.\n\nFoutmelding: %1$s</string>
+  <string name="displayseed_error_generic">Kan seed niet lezen. Probeer opnieuw.</string>
+  <string name="displayseed_error_wrong_password">PIN is onjuist.</string>
   <string name="displayseed_instructions"><![CDATA[
     Deze woordenlijst is de backup van je wallet. Bewaar het op een veilige plek (niet op deze telefoon)!
     <br /><br />

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -308,7 +308,6 @@
   <string name="displayseed_derivation_path">BIP39 seed met standaard BIP84 derivation path</string>
   <string name="displayseed_words_td"><![CDATA[<td><font color="rgba(100,100,100,.3)"><small>#%1$d</small></font> <b>%2$s</b></td>]]></string>
   <string name="displayseed_has_saved_seed_checkbox">Ik heb een backup van mijn seed gemaakt</string>
-  <string name="displayseed_has_saved_seed_button">Bevestig</string>
 
   <!-- //////////////// logs settings //////////////// -->
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -32,7 +32,7 @@
   <string name="restore_disclaimer_message">Importeer geen seed die NIET door deze applicatie is aangemaakt.\n\nZorg er ook voor dat je geen andere Phoenix wallet hebt met dezelfde seed.</string>
   <string name="restore_disclaimer_checkbox">Ik begrijp het.</string>
   <string name="restore_disclaimer_next">Volgende</string>
-  <string name="restore_instructions">De seed van je wallet is een lijst met 12 Engelse woorden. Passphrases zijn niet ondersteund.</string>
+  <string name="restore_instructions">De seed van je wallet is een lijst met 12 Engelse woorden.</string>
   <string name="restore_mnemonics_label">Gebruik je toetsenbord om de seed in te voeren:</string>
   <string name="restore_in_progress">Wallet herstellen…</string>
   <string name="restore_import_button">Importeer</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -223,10 +223,9 @@
     <br/><br/>
     Het gedwongen sluiten van kanalen kost geld (om de on-chain vergoedingen te dekken) en zal ervoor zorgen dat je geld dagenlang vergrendeld zijn. <b>Verwijder de app niet totdat je kanalen volledig gesloten zijn of je zal geld kwijtraken</b>
     <br/><br/>
-    Fondsen zullen uiteindelijk verstuurd worden naar: %1$s
-    <br/><br/>
     <b>Gebruik deze functie niet als je niet volledig begrijpt wat het doet.</b>
   ]]></string>
+  <string name="closechannels_force_destination">Fondsen zullen uiteindelijk verstuurd worden naar:</string>
   <string name="closechannels_force_button">Kanalen gedwongen sluiten</string>
   <string name="closechannels_confirm_dialog_message">Weet je zeker dat je wilt verdergaan?</string>
   <string name="closechannels_message_error">Er is een probleem opgetreden. Prober het later opnieuw.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -155,7 +155,6 @@
   <string name="scan_instructions">Leia um código QR com solicitação de pagamento ou endereço Bitcoin</string>
   <string name="scan_state_reading">Lendo solicitação de pagamento</string>
 
-  <string name="scan_error_default">Esta não é uma solicitação de pagamento válida.\n\nTente novamente.</string>
   <string name="scan_error_expired">O pagamento expirou.</string>
   <string name="scan_error_pay_to_self">Você não pode pagar a si próprio.</string>
   <string name="scan_error_invalid_chain">Esta cobrança não usa o mesmo blockchain da sua carteira.</string>
@@ -307,7 +306,8 @@
   <string name="displayseed_title">Frase de recuperação da carteira</string>
   <string name="displayseed_authenticate_button">Mostrar seed</string>
   <string name="displayseed_loading">Desbloqueando seed…</string>
-  <string name="displayseed_error">A seed não pôde ser lida. Tente novamente.\n\nMotivo: %1$s</string>
+  <string name="displayseed_error_generic">A seed não pôde ser lida. Tente novamente.</string>
+  <string name="displayseed_error_wrong_password">PIN incorreto.</string>
   <string name="displayseed_instructions"><![CDATA[
     Esta lista de palavras, também conhecida como seed, é o backup da sua carteira. Salve as palavras em um local seguro (não neste telefone)!
     <br /><br />

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -232,10 +232,9 @@
     <br/><br/>
     Forçar o encerramento de canais irá lhe custar dinheiro (para cobrir as taxas da rede Bitcoin) além de fazer com que seus fundos fiquem bloqueados por dias. <b>Não desinstale o aplicativo até que seus canais estejam totalmente encerrados ou você perderá bitcoins.</b>
     <br/><br/>
-    Os valores serão eventualmente enviados para: %1$s
-    <br/><br/>
     <b>Não use esse recurso se você não entender completamente o que ele faz.</b>
   ]]></string>
+  <string name="closechannels_force_destination">Os valores serão eventualmente enviados para:</string>
   <string name="closechannels_force_button">Forçar encerramento de canais</string>
   <string name="closechannels_confirm_dialog_message">Tem certeza de que deseja continuar?</string>
   <string name="closechannels_message_error">Ocorreu um problema. Tente novamente.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -295,7 +295,7 @@
 
   <string name="inappnotif_set_up_pin">Sua carteira não está protegida.</string>
   <string name="inappnotif_set_up_pin_action">Insira um PIN</string>
-  <string name="inappnotif_mnemonics_never_seen">Obrigado por usar a Phoenix. Você já fez o backup da carteira?</string>
+  <string name="inappnotif_mnemonics_never_seen">Obrigado por usar a Phoenix. Faça o backup de sua carteira para não correr risco de perder seus bitcoins.</string>
   <string name="inappnotif_mnemonics_never_seen_action">Fazer backup</string>
   <string name="inappnotif_background_worker_cannot_run">De tempos em tempos a Phoenix precisa rodar em segundo plano. Verifique se ela não está sendo fechada automaticamente pelo aparelho para economizar energia.</string>
   <string name="inappnotif_upgrade">Uma atualização para este aplicativo está disponível.</string>
@@ -311,14 +311,20 @@
   <string name="displayseed_instructions"><![CDATA[
     Esta lista de palavras, também conhecida como seed, é o backup da sua carteira e permite o acesso total aos fundos contidos nela.
     <br /><br />
-    <b>Não compartilhe com ninguém. Qualquer pessoa que tenha acesso à sua lista de palavras pode roubar seus bitcoins.
+    <strong>Somente você possui esta seed. Mantenha-a privada.</strong>
     <br /><br />
-    <b>Não perca elas.</b> Se você perder sua lista de palavras e seu telefone, perderá seus bitcoins.
+    <strong>Não compartilhe esta seed com ninguém</strong>.
+    <br />
+    Cuidado com ataques phishing. Os desenvolvedores da Phoenix nunca pedirão sua seed.
+    <br /><br />
+    <strong>Não perca esta seed</strong>.
+    <br />
+    Salve-a em um local seguro (não neste telefone). Se você perder sua seed e seu telefone, você perderá seus fundos.
   ]]></string>
   <string name="displayseed_derivation_path">Seed BIP39 com caminho de derivação padrão BIP84</string>
   <string name="displayseed_words_td"><![CDATA[<td><font color="rgba(100,100,100,.3)"><small>#%1$d</small></font> <b>%2$s</b></td>]]></string>
-  <string name="displayseed_has_saved_seed_checkbox">Eu fiz o backup da minha seed</string>
-  <string name="displayseed_has_saved_seed_button">Confirmar</string>
+  <string name="displayseed_has_saved_seed_checkbox">Fiz o backup da minha seed, por exemplo, em um folha de papel.</string>
+  <string name="displayseed_dialog_header">MANTENHA ESTA SEED SEGURA.\nNÃO COMPARTILHE.</string>
 
   <!-- //////////////// logs settings //////////////// -->
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -309,7 +309,7 @@
   <string name="displayseed_error_generic">A seed não pôde ser lida. Tente novamente.</string>
   <string name="displayseed_error_wrong_password">PIN incorreto.</string>
   <string name="displayseed_instructions"><![CDATA[
-    Esta lista de palavras, também conhecida como seed, é o backup da sua carteira. Salve as palavras em um local seguro (não neste telefone)!
+    Esta lista de palavras, também conhecida como seed, é o backup da sua carteira e permite o acesso total aos fundos contidos nela.
     <br /><br />
     <b>Não compartilhe com ninguém. Qualquer pessoa que tenha acesso à sua lista de palavras pode roubar seus bitcoins.
     <br /><br />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
   <string name="restore_disclaimer_message">Do not import a seed that was NOT created by this application.\n\nAlso, make sure that you don\'t have another Phoenix wallet running with the same seed.</string>
   <string name="restore_disclaimer_checkbox">I understand.</string>
   <string name="restore_disclaimer_next">Next</string>
-  <string name="restore_instructions">Your wallet\'s seed is a list of 12 english words. Please note that passphrases are not supported.</string>
+  <string name="restore_instructions">Your wallet\'s seed is a list of 12 english words.</string>
   <string name="restore_mnemonics_label">Use the keyboard below to enter the seed:</string>
   <string name="restore_in_progress">Restoring your wallet…</string>
   <string name="restore_import_button">Import</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,7 +325,7 @@
   <string name="displayseed_error_generic">Could not unlock seed.\nPlease try again.</string>
   <string name="displayseed_error_wrong_password">PIN is incorrect.</string>
   <string name="displayseed_instructions"><![CDATA[
-    The seed of the wallet is a list of 12 english words. It is your wallet backup. It gives full access to the funds in the wallet.
+    The seed of the wallet is a list of 12 english words. It is your wallet backup and gives full access to the funds in the wallet.
     <br /><br />
     <strong>Only you alone possess this seed. Keep it private.</strong>
     <br /><br />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,10 +248,10 @@
     <br/><br/>
     Force closing channels will cost you money (to cover the on-chain fees) and will cause your funds to be locked for days. <b>Do not uninstall the app until your channels are fully closed or you will lose money.</b>
     <br/><br/>
-    Funds will eventually be sent to: %1$s
-    <br/><br/>
     <b>Do not use this feature if you don\'t fully understand what it does.</b>
   ]]></string>
+  <string name="closechannels_force_destination">Funds will eventually be sent to:</string>
+  <string name="closechannels_force_destination_desc">This address is derived from your seed and belongs to you.</string>
   <string name="closechannels_force_button">Force close channels</string>
   <string name="closechannels_confirm_dialog_message">Are you sure you want to proceed?</string>
   <string name="closechannels_message_error">There was a problem. Please try again later.</string>
@@ -322,7 +322,7 @@
   <string name="displayseed_title">Wallet recovery phrase</string>
   <string name="displayseed_authenticate_button">Display seed</string>
   <string name="displayseed_loading">Unlocking seed…</string>
-  <string name="displayseed_error_generic">Could not unlock seed.\nPlease try again.</string>
+  <string name="displayseed_error_generic">Could not unlock seed, please try again.</string>
   <string name="displayseed_error_wrong_password">PIN is incorrect.</string>
   <string name="displayseed_instructions"><![CDATA[
     The seed of the wallet is a list of 12 english words. It is your wallet backup and gives full access to the funds in the wallet.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,7 +340,6 @@
   <string name="displayseed_derivation_path">BIP39 seed with standard BIP84 derivation path</string>
   <string name="displayseed_words_td"><![CDATA[<td><font color="rgba(100,100,100,.3)"><small>#%1$d</small></font> <b>%2$s</b></td>]]></string>
   <string name="displayseed_has_saved_seed_checkbox">I have made a backup of my seed, for example on a piece of paper.</string>
-  <string name="displayseed_has_saved_seed_button">Confirm</string>
   <string name="displayseed_dialog_header">KEEP THIS SEED SAFE.\nDO NOT SHARE.</string>
 
   <!-- //////////////// logs settings //////////////// -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -292,7 +292,7 @@
 
   <!-- //////////////// init wallet //////////////// -->
 
-  <string name="initwallet_create">New Wallet</string>
+  <string name="initwallet_create">Create new wallet</string>
   <string name="initwallet_restore">Restore my wallet</string>
 
   <!-- //////////////// main //////////////////// -->
@@ -322,17 +322,26 @@
   <string name="displayseed_title">Wallet recovery phrase</string>
   <string name="displayseed_authenticate_button">Display seed</string>
   <string name="displayseed_loading">Unlocking seed…</string>
-  <string name="displayseed_error">Seed could not be read. Please try again.\n\nReason: %1$s</string>
+  <string name="displayseed_error_generic">Could not unlock seed.\nPlease try again.</string>
+  <string name="displayseed_error_wrong_password">PIN is incorrect.</string>
   <string name="displayseed_instructions"><![CDATA[
-    This list of words is your wallet backup. Save it somewhere safe (not on this phone)!
+    The seed of the wallet is a list of 12 english words. It is your wallet backup. It gives full access to the funds in the wallet.
     <br /><br />
-    <b>Do not share it with anyone.</b>
-    <b>Do not lose it.</b> If you lose your words list and your phone, you\'ve lost your funds.
+    <strong>Only you alone possess this seed. Keep it private.</strong>
+    <br /><br />
+    <strong>Do not share this seed with anyone</strong>.
+    <br />
+    Beware of phishing. The developers of Phoenix will never ask for your seed.
+    <br /><br />
+    <strong>Do not lose this seed</strong>.
+    <br />
+    Save it somewhere safe (not on this phone). If you lose your seed and your phone, you\'ve lost your funds.
   ]]></string>
   <string name="displayseed_derivation_path">BIP39 seed with standard BIP84 derivation path</string>
   <string name="displayseed_words_td"><![CDATA[<td><font color="rgba(100,100,100,.3)"><small>#%1$d</small></font> <b>%2$s</b></td>]]></string>
-  <string name="displayseed_has_saved_seed_checkbox">I have made a backup of my seed</string>
+  <string name="displayseed_has_saved_seed_checkbox">I have made a backup of my seed, for example on a piece of paper.</string>
   <string name="displayseed_has_saved_seed_button">Confirm</string>
+  <string name="displayseed_dialog_header">KEEP THIS SEED SAFE.\nDO NOT SHARE.</string>
 
   <!-- //////////////// logs settings //////////////// -->
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -311,7 +311,7 @@
 
   <string name="inappnotif_set_up_pin">Your wallet is not protected.</string>
   <string name="inappnotif_set_up_pin_action">Set a PIN</string>
-  <string name="inappnotif_mnemonics_never_seen">Thanks for using Phoenix. Have you made a backup of your wallet?</string>
+  <string name="inappnotif_mnemonics_never_seen">Thanks for using Phoenix. Please backup your wallet so that you don\'t lose your bitcoins.</string>
   <string name="inappnotif_mnemonics_never_seen_action">Backup my wallet</string>
   <string name="inappnotif_background_worker_cannot_run">Phoenix needs to be able to run in background from time to time. Make sure your device does not aggressively kill this app for battery savings.</string>
   <string name="inappnotif_upgrade">An update for this app is available.</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -209,7 +209,7 @@
   <style name="HLineSeparator">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">1dp</item>
-    <item name="android:background">?attr/mutedBgColor</item>
+    <item name="android:background">?attr/borderColor</item>
   </style>
 
   <style name="VSeparator" parent="HLineSeparator">
@@ -290,7 +290,6 @@
     <item name="android:hapticFeedbackEnabled">true</item>
     <item name="android:textColor">?attr/textColor</item>
     <item name="iconTint">?attr/mutedTextColor</item>
-
     <item name="android:textSize">20sp</item>
   </style>
 


### PR DESCRIPTION
This PR reworks the screen displaying the seed. The wording has been updated for FR/EN, and stresses the importance of backup and warns of phishing attempts. The seed itself is now displayed in a separate dialog, which simplifies the layout and should drive the user to actually read the disclaimer. 

Also, this lets us apply a specific security rule to the dialog that display the seed, preventing screen capture.

Supersedes #39 and #61 