### PR TITLE
differentiate lnurl-auth keys per subdomain.

### DIFF
--- a/app/src/main/java/fr/acinq/phoenix/lnurl/LNUrl.kt
+++ b/app/src/main/java/fr/acinq/phoenix/lnurl/LNUrl.kt
@@ -76,7 +76,7 @@ interface LNUrl {
         if (k1 == null) {
           throw LNUrlAuthMissingK1()
         } else {
-          LNUrlAuth(url.topPrivateDomain()!!, url.toString(), k1)
+          LNUrlAuth(url.host()!!, url.toString(), k1)
         }
       } else {
         // otherwise execute GET to url to retrieve details from remote server
@@ -130,7 +130,7 @@ interface LNUrl {
 }
 
 @Parcelize
-class LNUrlAuth(val topDomain: String, val authEndpoint: String, val k1: String) : LNUrl, Parcelable
+class LNUrlAuth(val host: String, val authEndpoint: String, val k1: String) : LNUrl, Parcelable
 
 @Parcelize
 class LNUrlWithdraw(val origin: String, val callback: String, val walletIdentifier: String,

--- a/app/src/main/java/fr/acinq/phoenix/lnurl/LNUrlAuthFragment.kt
+++ b/app/src/main/java/fr/acinq/phoenix/lnurl/LNUrlAuthFragment.kt
@@ -104,7 +104,7 @@ class LNUrlAuthFragment : BaseFragment() {
     }) {
       model.state.postValue(LNUrlAuthState.InProgress)
       val url = tryWith(InvalidAuthEndpoint) { HttpUrl.parse(args.url.authEndpoint)!! }
-      val key = getAuthLinkingKey(url.topPrivateDomain()!!)
+      val key = getAuthLinkingKey(url.host)
       val signedK1 = Crypto.compact2der(Crypto.sign(ByteVector32.fromValidHex(args.url.k1).bytes(), key)).toHex()
       val request = Request.Builder().url(url.newBuilder()
         .addQueryParameter("sig", signedK1)

--- a/app/src/main/java/fr/acinq/phoenix/lnurl/LNUrlAuthFragment.kt
+++ b/app/src/main/java/fr/acinq/phoenix/lnurl/LNUrlAuthFragment.kt
@@ -66,13 +66,13 @@ class LNUrlAuthFragment : BaseFragment() {
   override fun onActivityCreated(savedInstanceState: Bundle?) {
     super.onActivityCreated(savedInstanceState)
     model = ViewModelProvider(this).get(LNUrlAuthViewModel::class.java)
-    mBinding.instructions.text = Converter.html(getString(R.string.lnurl_auth_instructions, args.url.topDomain))
-    mBinding.progress.setText(Converter.html(getString(R.string.lnurl_auth_in_progress, args.url.topDomain)))
+    mBinding.instructions.text = Converter.html(getString(R.string.lnurl_auth_instructions, args.url.host))
+    mBinding.progress.setText(Converter.html(getString(R.string.lnurl_auth_in_progress, args.url.host)))
     model.state.observe(viewLifecycleOwner, Observer { state ->
       when (state) {
         is LNUrlAuthState.Error -> {
           val details = when (state.cause) {
-            is LNUrlRemoteFailure.CouldNotConnect -> getString(R.string.lnurl_auth_failure_remote_io, args.url.topDomain)
+            is LNUrlRemoteFailure.CouldNotConnect -> getString(R.string.lnurl_auth_failure_remote_io, args.url.host)
             is LNUrlRemoteFailure.Detailed -> getString(R.string.lnurl_auth_failure_remote_details, state.cause.reason)
             is LNUrlRemoteFailure.Code -> "HTTP ${state.cause.code}"
             else -> state.cause.localizedMessage ?: state.cause.javaClass.simpleName
@@ -104,7 +104,7 @@ class LNUrlAuthFragment : BaseFragment() {
     }) {
       model.state.postValue(LNUrlAuthState.InProgress)
       val url = tryWith(InvalidAuthEndpoint) { HttpUrl.parse(args.url.authEndpoint)!! }
-      val key = getAuthLinkingKey(url.host)
+      val key = getAuthLinkingKey(url.host())
       val signedK1 = Crypto.compact2der(Crypto.sign(ByteVector32.fromValidHex(args.url.k1).bytes(), key)).toHex()
       val request = Request.Builder().url(url.newBuilder()
         .addQueryParameter("sig", signedK1)


### PR DESCRIPTION
Currently Phoenix will cause the same key to be used in filemarket.bigsun.xyz and lnurl.bigsun.xyz, which should be different domain names. Also test.etleneum.com and etleneum.com. Fortunately these are the only examples of this happening in the real world today, so there's no harm in changing this now before it is too late.