### PR TITLE
Add support for LNURL pay

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,9 +19,10 @@ apply plugin: 'maven'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: "androidx.navigation.safeargs.kotlin"
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.squareup.sqldelight'
+apply plugin: 'kotlinx-serialization'
 
 def gitCommitHash = 'git rev-parse --verify --short HEAD'.execute().text.trim()
 
@@ -32,7 +33,7 @@ android {
     applicationId "fr.acinq.phoenix.testnet"
     minSdkVersion 24
     targetSdkVersion 30
-    versionCode 23
+    versionCode 25
     versionName "${gitCommitHash}"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
@@ -88,6 +89,15 @@ android {
   }
 }
 
+sqldelight {
+  Database {
+    packageName = "fr.acinq.phoenix.db"
+    sourceFolders = ["sqldelight"]
+    schemaOutputDirectory = file("src/main/sqldelight/databases")
+//    verifyMigrations = true
+  }
+}
+
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
 
@@ -95,6 +105,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
   implementation 'androidx.core:core-ktx:1.3.2'
   implementation "androidx.appcompat:appcompat:1.2.0"
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.1.0")
 
   // ANDROIDX - material
   def material_version = "1.3.0-rc01"

--- a/app/src/main/java/fr/acinq/phoenix/background/EclairNodeService.kt
+++ b/app/src/main/java/fr/acinq/phoenix/background/EclairNodeService.kt
@@ -56,6 +56,7 @@ import fr.acinq.eclair.payment.send.PaymentInitiator
 import fr.acinq.eclair.wire.*
 import fr.acinq.phoenix.*
 import fr.acinq.phoenix.db.AppDb
+import fr.acinq.phoenix.db.Database
 import fr.acinq.phoenix.db.PayToOpenMetaRepository
 import fr.acinq.phoenix.db.PaymentMetaRepository
 import fr.acinq.phoenix.utils.*

--- a/app/src/main/java/fr/acinq/phoenix/db/AppDb.kt
+++ b/app/src/main/java/fr/acinq/phoenix/db/AppDb.kt
@@ -17,8 +17,8 @@
 package fr.acinq.phoenix.db
 
 import android.content.Context
+import com.squareup.sqldelight.EnumColumnAdapter
 import com.squareup.sqldelight.android.AndroidSqliteDriver
-import fr.acinq.phoenix.Database
 
 object AppDb {
   @Volatile
@@ -29,11 +29,14 @@ object AppDb {
 
   fun getInstance(context: Context): Database {
     return instance ?: synchronized(this) {
-      instance ?: Database(AndroidSqliteDriver(
-        schema = Database.Schema,
-        context = context,
-        name = "phoenix-meta.db"
-      )).also { instance = it }
+      instance ?: Database(
+        driver = AndroidSqliteDriver(
+          schema = Database.Schema,
+          context = context,
+          name = "phoenix-meta.db"
+        ),
+        PaymentMetaAdapter = PaymentMeta.Adapter(EnumColumnAdapter())
+      ).also { instance = it }
     }
   }
 }

--- a/app/src/main/java/fr/acinq/phoenix/lnurl/LNUrlAuthFragment.kt
+++ b/app/src/main/java/fr/acinq/phoenix/lnurl/LNUrlAuthFragment.kt
@@ -83,7 +83,7 @@ class LNUrlAuthFragment : BaseFragment() {
           val details = when (state.cause) {
             is LNUrlError.RemoteFailure.CouldNotConnect -> getString(R.string.lnurl_auth_failure_remote_io, model.domainToSignIn)
             is LNUrlError.RemoteFailure.Detailed -> getString(R.string.lnurl_auth_failure_remote_details, state.cause.reason)
-            is LNUrlError.RemoteFailure.Code -> "HTTP ${state.cause.code}"
+            is LNUrlError.RemoteFailure.Code -> getString(R.string.lnurl_auth_failure_remote_details, "HTTP ${state.cause.code}")
             else -> state.cause.localizedMessage ?: state.cause.javaClass.simpleName
           }
           mBinding.errorMessage.text = getString(R.string.lnurl_auth_failure, details)

--- a/app/src/main/java/fr/acinq/phoenix/lnurl/LNUrlPayFragment.kt
+++ b/app/src/main/java/fr/acinq/phoenix/lnurl/LNUrlPayFragment.kt
@@ -17,105 +17,343 @@
 package fr.acinq.phoenix.lnurl
 
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.util.Base64
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.DialogFragment
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import androidx.annotation.UiThread
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.Crypto
+import fr.acinq.eclair.*
 import fr.acinq.eclair.payment.PaymentRequest
-import fr.acinq.phoenix.AppViewModel
+import fr.acinq.phoenix.BaseFragment
+import fr.acinq.phoenix.R
 import fr.acinq.phoenix.databinding.FragmentLnurlPayBinding
+import fr.acinq.phoenix.db.AppDb
+import fr.acinq.phoenix.db.LNUrlPayActionData
+import fr.acinq.phoenix.db.PaymentMetaRepository
+import fr.acinq.phoenix.utils.AlertHelper
+import fr.acinq.phoenix.utils.Converter
+import fr.acinq.phoenix.utils.Prefs
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import okhttp3.HttpUrl
+import okhttp3.Request
+import org.json.JSONObject
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import scala.Option
+import scodec.bits.ByteVector
+import java.io.IOException
+import java.util.*
+import kotlin.random.Random
 
-class LNUrlPayFragment : DialogFragment() {
-  val log: Logger = LoggerFactory.getLogger(this::class.java)
-
+class LNUrlPayFragment : BaseFragment() {
+  override val log: Logger = LoggerFactory.getLogger(this::class.java)
   private lateinit var mBinding: FragmentLnurlPayBinding
-  private lateinit var app: AppViewModel
   private lateinit var model: LNUrlPayViewModel
   private val args: LNUrlPayFragmentArgs by navArgs()
 
+  private lateinit var unitList: List<String>
+
   override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-    mBinding = FragmentLnurlPayBinding.inflate(inflater, container, true)
+    mBinding = FragmentLnurlPayBinding.inflate(inflater, container, false)
     mBinding.lifecycleOwner = this
     return mBinding.root
   }
 
   override fun onActivityCreated(savedInstanceState: Bundle?) {
     super.onActivityCreated(savedInstanceState)
-    activity?.let {
-      app = ViewModelProvider(it).get(AppViewModel::class.java)
-      model = ViewModelProvider(this).get(LNUrlPayViewModel::class.java)
-      mBinding.model = model
-      model.baseUrl.value = HttpUrl.get(args.url)
-    } ?: dismiss()
+    val callbackUrl = try {
+      HttpUrl.parse(args.url.callbackUrl)!!
+    } catch (e: Exception) {
+      log.error("could not parse url=${args.url.callbackUrl}: ", e)
+      findNavController().popBackStack()
+      return
+    }
+
+    model = ViewModelProvider(this, LNUrlPayViewModel.Factory(
+      callbackUrl,
+      args.url.minSendable,
+      args.url.maxSendable,
+      args.url.rawMetadata,
+      args.url.maxCommentLength,
+      PaymentMetaRepository.getInstance(AppDb.getInstance(requireContext()).paymentMetaQueries)
+    )).get(LNUrlPayViewModel::class.java)
+
+    context?.let { ctx ->
+      unitList = listOf(SatUnit.code(), BitUnit.code(), MBtcUnit.code(), BtcUnit.code(), Prefs.getFiatCurrency(ctx))
+      ArrayAdapter(ctx, android.R.layout.simple_spinner_item, unitList).also { adapter ->
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        mBinding.unit.adapter = adapter
+      }
+      val unit = Prefs.getCoinUnit(ctx)
+      mBinding.unit.setSelection(unitList.indexOf(unit.code()))
+      mBinding.amount.setText(Converter.printAmountRaw(model.minSendable, ctx))
+      mBinding.amount.addTextChangedListener(object : TextWatcher {
+        override fun afterTextChanged(s: Editable?) = Unit
+
+        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+          checkAndGetAmount()
+        }
+      })
+      mBinding.unit.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        override fun onNothingSelected(parent: AdapterView<*>?) = Unit
+
+        override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+          checkAndGetAmount()
+        }
+      }
+      mBinding.metadata.text = model.metadata.plainText
+      mBinding.domain.text = Converter.html(getString(R.string.lnurl_pay_domain, callbackUrl.topPrivateDomain()))
+    }
+
+    model.state.observe(viewLifecycleOwner, { state ->
+      when (state) {
+        is LNUrlPayState.Error -> mBinding.errorMessage.text = when (state.cause) {
+          is LNUrlPayInvalidResponse -> getString(R.string.lnurl_pay_error_invalid_invoice, model.callbackUrl.topPrivateDomain(), state.cause.message)
+          is LNUrlError.RemoteFailure.CouldNotConnect -> getString(R.string.lnurl_pay_error_unreachable, model.callbackUrl.topPrivateDomain())
+          is LNUrlError.RemoteFailure.Detailed -> getString(R.string.lnurl_pay_error_remote_error, model.callbackUrl.topPrivateDomain(), state.cause.reason)
+          is LNUrlError.RemoteFailure.Code -> getString(R.string.lnurl_pay_error_remote_error, model.callbackUrl.topPrivateDomain(), "HTTP ${state.cause.code}")
+          else -> getString(R.string.lnurl_pay_error_remote_error, model.callbackUrl.topPrivateDomain(), state.cause.localizedMessage ?: state.cause.javaClass.simpleName)
+        }
+        is LNUrlPayState.RequestingInvoice -> mBinding.sendingPaymentProgress.setText(getString(R.string.lnurl_pay_sending_payment))
+        is LNUrlPayState.ValidInvoice -> {
+          mBinding.sendingPaymentProgress.setText(getString(R.string.lnurl_pay_checking_invoice))
+          sendPayment(state.paymentRequest)
+        }
+        is LNUrlPayState.SendingPayment -> mBinding.sendingPaymentProgress.setText(getString(R.string.lnurl_pay_sending_payment))
+        else -> Unit
+      }
+    })
+
+    model.amountState.observe(viewLifecycleOwner, { state ->
+      val ctx = requireContext()
+      mBinding.amountError.text = when (state) {
+        LNUrlPayAmountState.Pristine -> ""
+        LNUrlPayAmountState.Error.Empty -> getString(R.string.lnurl_pay_amount_empty)
+        LNUrlPayAmountState.Error.BelowMin -> getString(R.string.lnurl_pay_amount_below_min, Converter.printAmountPretty(model.minSendable, ctx, withUnit = true))
+        LNUrlPayAmountState.Error.AboveMax -> getString(R.string.lnurl_pay_amount_above_max, Converter.printAmountPretty(model.maxSendable, ctx, withUnit = true))
+        LNUrlPayAmountState.Error.AboveBalance -> getString(R.string.lnurl_pay_amount_above_balance)
+        LNUrlPayAmountState.Error.Invalid -> getString(R.string.lnurl_pay_amount_invalid)
+      }
+    })
+
+    if (model.metadata.image != null) {
+      mBinding.metadataImage.setImageBitmap(model.metadata.image)
+    } else {
+      mBinding.metadataImage.visibility = View.GONE
+    }
+
+    mBinding.model = model
   }
 
   override fun onStart() {
     super.onStart()
+    mBinding.actionBar.setOnBackAction { findNavController().navigate(R.id.action_lnurl_pay_to_main) }
+    mBinding.startPaymentButton.setOnClickListener {
+      if (model.maxCommentLength ?: 0 > 0) {
+        AlertHelper.buildWithInput(layoutInflater, title = getString(R.string.lnurl_pay_comment_title), message = getString(R.string.lnurl_pay_comment_message),
+          callback = { comment -> requestInvoice(comment) },
+          defaultValue = "",
+          hint = getString(R.string.lnurl_pay_comment_hint))
+          .show()
+      } else {
+        requestInvoice(null)
+      }
+    }
+    mBinding.tryAgainButton.setOnClickListener { model.state.value = LNUrlPayState.Init }
   }
 
-  private fun handleError(errorMessage: String) {
-    model.state.postValue(LNUrlPayState.ERROR)
-    mBinding.error.text = errorMessage
+  /**
+   * 1) Check that the amount is within the LNUrlPay min/max, and below the wallet's balance.
+   * 2) Refresh the converted amount display.
+   * 3) Update the amount error state accordingly.
+   * Return the amount if valid, null otherwise.
+   */
+  private fun checkAndGetAmount(): MilliSatoshi? {
+    return try {
+      val ctx = requireContext()
+      val unit = mBinding.unit.selectedItem.toString()
+      val amountInput = mBinding.amount.text.toString()
+      val balance = appContext(requireContext()).balance.value
+      model.amountState.value = LNUrlPayAmountState.Pristine
+      val fiat = Prefs.getFiatCurrency(ctx)
+      val amountOpt = if (unit == fiat) {
+        Option.apply(Converter.convertFiatToMsat(ctx, amountInput))
+      } else {
+        Converter.string2Msat_opt(amountInput, unit)
+      }
+      if (amountOpt.isDefined) {
+        val amount = amountOpt.get()
+        if (unit == fiat) {
+          mBinding.amountConverted.text = getString(R.string.utils_converted_amount, Converter.printAmountPretty(amount, ctx, withUnit = true))
+        } else {
+          mBinding.amountConverted.text = getString(R.string.utils_converted_amount, Converter.printFiatPretty(ctx, amount, withUnit = true))
+        }
+        if (balance != null && amount.`$greater`(balance.sendable)) {
+          model.amountState.value = LNUrlPayAmountState.Error.AboveBalance
+          null
+        } else if (amount.`$less`(model.minSendable)) {
+          model.amountState.value = LNUrlPayAmountState.Error.BelowMin
+          null
+        } else if (amount.`$greater`(model.maxSendable)) {
+          model.amountState.value = LNUrlPayAmountState.Error.AboveMax
+          null
+        } else {
+          amount
+        }
+      } else {
+        model.amountState.value = LNUrlPayAmountState.Error.Empty
+        mBinding.amountConverted.text = ""
+        null
+      }
+    } catch (e: Exception) {
+      log.debug("could not check amount: ${e.message}")
+      mBinding.amountConverted.text = ""
+      model.amountState.value = LNUrlPayAmountState.Error.Invalid
+      null
+    }
   }
 
-  //  private fun getInvoiceFromRemote() {
-  //    if (model.state.value == LNUrlPayState.IN_PROGRESS) {
-  //      if (model.callbackUrl.value == null) {
-  //        log.error("missing callback url when fetching invoice from lnurl-pay remote")
-  //        handleError(getString(R.string.lnurl_pay_error_missing_callback))
-  //      } else {
-  //        val callbackUrl = model.callbackUrl.value!!
-  //        log.info("fetching lnurl-pay invoice from remote $callbackUrl")
-  //        Wallet.httpClient.newCall(Request.Builder().url(callbackUrl).build()).enqueue(object : Callback {
-  //          override fun onFailure(call: Call, e: IOException) {
-  //            log.error("failure when retrieving lnurl-pay invoice from callback url=${callbackUrl}: ", e)
-  //            handleError(getString(R.string.lnurl_pay_error_remote, callbackUrl.host()))
-  //          }
-  //
-  //          override fun onResponse(call: Call, response: Response) {
-  //            val body = response.body()
-  //            if (response.isSuccessful && body != null) {
-  //              try {
-  //                val json = JSONObject(body.string())
-  //                log.debug("lnurl-pay invoice returns {}", json.toString(2))
-  //                model.invoice.postValue(PaymentRequest.read(json.getString("pr")))
-  //                model.state.postValue(LNUrlPayState.DONE)
-  //              } catch (e: JSONException) {
-  //                log.error("could not read lnurl-pay server response body: ", e)
-  //                handleError(getString(R.string.lnurl_pay_error_remote, callbackUrl.host()))
-  //              }
-  //            } else {
-  //              log.warn("could not retrieve lnurl-pay meta from remote, code=${response.code()}")
-  //              handleError(getString(R.string.lnurl_pay_error_remote_code, callbackUrl.host(), response.code().toString()))
-  //            }
-  //          }
-  //        })
-  //      }
-  //    }
-  //  }
+  @UiThread
+  private fun requestInvoice(comment: String?) {
+    model.state.value = LNUrlPayState.RequestingInvoice
+    val amount = checkAndGetAmount()
+    if (amount != null) {
+      lifecycleScope.launch(Dispatchers.IO + CoroutineExceptionHandler { _, e ->
+        log.error("error when requesting invoice from url=${model.callbackUrl}: ", e)
+        model.state.postValue(LNUrlPayState.Error(e))
+      }) {
+        val request = Request.Builder().url(model.callbackUrl.newBuilder()
+          .addQueryParameter("amount", amount.toLong().toString())
+          .addQueryParameter("nonce", Random.nextBytes(8).toString(Charsets.UTF_8))
+          .addQueryParameter("comment", comment)
+          .build())
+          .get()
+          .build()
+        val response = try {
+          LNUrl.httpClient.newCall(request).execute()
+        } catch (e: IOException) {
+          log.error("io error when requesting invoice from url=${model.callbackUrl}: ", e)
+          throw LNUrlError.RemoteFailure.CouldNotConnect(model.callbackUrl.toString())
+        }
+        val json = LNUrl.handleLNUrlRemoteResponse(response)
+        val pr = PaymentRequest.read(json.getString("pr"))
+        val action = json.optJSONObject("successAction")?.run { extractAction(this) }
+        if (pr.amount().isEmpty) {
+          throw IllegalArgumentException("invoice does not define an amount")
+        } else if (!pr.amount().get().equals(amount)) {
+          throw InvoiceAmountDoesNotMatch(pr, amount)
+        } else if (!pr.description().isRight) {
+          throw InvoiceNoDescriptionHash(pr)
+        } else if (!pr.description().right().get().equals(Crypto.sha256().apply(ByteVector.encodeUtf8(model.metadata.raw).right().get()))) {
+          throw InvoiceDescriptionHashDoesNotMatch(pr, model.metadata.raw)
+        } else {
+          action?.let { model.saveSuccessAction(pr.paymentHash(), it) }
+          model.state.postValue(LNUrlPayState.ValidInvoice(pr))
+        }
+      }
+    } else {
+      model.state.postValue(LNUrlPayState.Init)
+    }
+  }
+
+  private fun extractAction(json: JSONObject): LNUrlPayActionData = when (json.getString("tag").toLowerCase(Locale.US)) {
+    "url" -> LNUrlPayActionData.Url.V0(description = json.getString("description"), url = json.getString("url"))
+    "message" -> LNUrlPayActionData.Message.V0(message = json.getString("message"))
+    "aes" -> LNUrlPayActionData.Aes.V0(description = json.getString("description"), cipherText = json.getString("ciphertext"), iv = json.getString("iv").run {
+      if (length != 24) {
+        throw IllegalArgumentException("invalid length")
+      } else {
+        Base64.decode(this, Base64.DEFAULT)
+        this
+      }
+    })
+    else -> throw UnhandledLNUrlPaySuccessAction(json.toString())
+  }
+
+  private fun sendPayment(pr: PaymentRequest) {
+    model.state.value = LNUrlPayState.SendingPayment(pr)
+    lifecycleScope.launch(Dispatchers.Main + CoroutineExceptionHandler { _, e ->
+      log.error("error when sending payment in state=${model.state}: ", e)
+      model.state.value = LNUrlPayState.Error(e)
+    }) {
+      log.info("sending payment for invoice=$pr")
+      app.requireService.sendPaymentRequest(amount = pr.amount().get(), paymentRequest = pr, subtractFee = false)
+      findNavController().navigate(R.id.action_lnurl_pay_to_main)
+    }
+  }
+
 }
 
-enum class LNUrlPayState {
-  INIT, IN_PROGRESS, DONE, ERROR
+sealed class LNUrlPayInvalidResponse(override val message: String) : IllegalArgumentException(message)
+data class UnhandledLNUrlPaySuccessAction(val json: String) : LNUrlPayInvalidResponse("unhandled success action=$json")
+data class InvoiceNoDescriptionHash(val pr: PaymentRequest) : LNUrlPayInvalidResponse("invoice must have a description hash")
+data class InvoiceDescriptionHashDoesNotMatch(val pr: PaymentRequest, val expected: String) : LNUrlPayInvalidResponse("invoice description does not match metadata")
+data class InvoiceAmountDoesNotMatch(val pr: PaymentRequest, val expected: MilliSatoshi) :
+  LNUrlPayInvalidResponse("invoice does not match expected amount [ expected=$expected actual=${pr.amount()} ]")
+
+sealed class LNUrlPayAmountState {
+  object Pristine : LNUrlPayAmountState()
+  sealed class Error : LNUrlPayAmountState() {
+    object BelowMin : Error()
+    object AboveMax : Error()
+    object AboveBalance : Error()
+    object Invalid : Error()
+    object Empty : Error()
+  }
 }
 
-enum class LNUrlPayMetadataTypes(paramType: String) {
-  PLAIN_TEXT("text/plain"), IMAGE_JPG("image/png;base64"), IMAGE_PNG("image/jpeg;base64")
+sealed class LNUrlPayState {
+  object Init : LNUrlPayState()
+  object RequestingInvoice : LNUrlPayState()
+  data class ValidInvoice(val paymentRequest: PaymentRequest) : LNUrlPayState()
+  data class SendingPayment(val paymentRequest: PaymentRequest) : LNUrlPayState()
+  data class Error(val cause: Throwable) : LNUrlPayState()
 }
 
-class LNUrlPayViewModel : ViewModel() {
+class LNUrlPayViewModel(
+  val callbackUrl: HttpUrl,
+  val minSendable: MilliSatoshi,
+  val maxSendable: MilliSatoshi,
+  val metadata: LNUrlPayMetadata,
+  val maxCommentLength: Long?,
+  private val paymentMetaRepository: PaymentMetaRepository,
+) : ViewModel() {
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  val state = MutableLiveData(LNUrlPayState.INIT)
-  val baseUrl = MutableLiveData<HttpUrl>()
+  val state = MutableLiveData<LNUrlPayState>(LNUrlPayState.Init)
+  val amountState = MutableLiveData<LNUrlPayAmountState>(LNUrlPayAmountState.Pristine)
 
-  // payment invoice
-  val invoice = MutableLiveData<PaymentRequest>()
+  suspend fun saveSuccessAction(paymentHash: ByteVector32, action: LNUrlPayActionData) {
+    paymentMetaRepository.saveLNUrlPaySuccessAction(paymentHash.toString(), action)
+  }
+
+  class Factory(
+    val url: HttpUrl,
+    val minSendable: MilliSatoshi,
+    val maxSendable: MilliSatoshi,
+    val metadata: LNUrlPayMetadata,
+    val maxCommentLength: Long?,
+    val paymentMetaRepository: PaymentMetaRepository,
+  ) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+      return LNUrlPayViewModel(url, minSendable, maxSendable, metadata, maxCommentLength, paymentMetaRepository) as T
+    }
+  }
 }

--- a/app/src/main/java/fr/acinq/phoenix/lnurl/LNUrlWithdrawFragment.kt
+++ b/app/src/main/java/fr/acinq/phoenix/lnurl/LNUrlWithdrawFragment.kt
@@ -126,7 +126,7 @@ class LNUrlWithdrawFragment : BaseFragment() {
         model.state.value = LNUrlWithdrawState.Error.Internal
       }
     }
-    mBinding.actionBar.setOnBackAction(View.OnClickListener { findNavController().navigate(R.id.action_lnurl_withdraw_to_main) })
+    mBinding.actionBar.setOnBackAction { findNavController().navigate(R.id.action_lnurl_withdraw_to_main) }
   }
 
   private fun checkAmount(): Option<MilliSatoshi> {

--- a/app/src/main/java/fr/acinq/phoenix/paymentdetails/PaymentDetailsFragment.kt
+++ b/app/src/main/java/fr/acinq/phoenix/paymentdetails/PaymentDetailsFragment.kt
@@ -77,8 +77,11 @@ class PaymentDetailsFragment : BaseFragment() {
   private val model: PaymentDetailsViewModel by navGraphViewModels(R.id.nav_graph_payment_details) {
     val appContext = appContext(requireContext())
     AppDb.getInstance(appContext.applicationContext).run {
-      PaymentDetailsViewModel.Factory(appContext.applicationContext, args.identifier, PaymentMetaRepository.getInstance(paymentMetaQueries),
-        PayToOpenMetaRepository.getInstance(payToOpenMetaQueries), NodeMetaRepository.getInstance(nodeMetaQueries))
+      PaymentDetailsViewModel.Factory(appContext.applicationContext,
+        paymentId = args.identifier,
+        paymentMetaRepository = PaymentMetaRepository.getInstance(paymentMetaQueries),
+        payToOpenMetaRepository = PayToOpenMetaRepository.getInstance(payToOpenMetaQueries),
+        nodeMetaRepository = NodeMetaRepository.getInstance(nodeMetaQueries))
     }
   }
 
@@ -299,10 +302,10 @@ sealed class PaymentDetailsState {
 }
 
 sealed class OutgoingFailure {
-  data class Generic(val message: String): OutgoingFailure()
-  object RecipientUnknownOrNeedsLiquidity: OutgoingFailure()
-  object TrampolineFee: OutgoingFailure()
-  object IncorrectPaymentDetails: OutgoingFailure()
+  data class Generic(val message: String) : OutgoingFailure()
+  object RecipientUnknownOrNeedsLiquidity : OutgoingFailure()
+  object TrampolineFee : OutgoingFailure()
+  object IncorrectPaymentDetails : OutgoingFailure()
 }
 
 class PaymentDetailsViewModel(
@@ -524,6 +527,9 @@ class PaymentDetailsViewModel(
     }
   }
 
+  /**
+   * @param paymentId payment Hash if incoming, parentId if outgoing.
+   */
   class Factory(
     private val appContext: Context,
     private val paymentId: String,

--- a/app/src/main/java/fr/acinq/phoenix/send/ReadInputFragment.kt
+++ b/app/src/main/java/fr/acinq/phoenix/send/ReadInputFragment.kt
@@ -42,6 +42,7 @@ import fr.acinq.phoenix.R
 import fr.acinq.phoenix.databinding.FragmentReadInvoiceBinding
 import fr.acinq.phoenix.lnurl.LNUrlAuth
 import fr.acinq.phoenix.lnurl.LNUrlError
+import fr.acinq.phoenix.lnurl.LNUrlPay
 import fr.acinq.phoenix.lnurl.LNUrlWithdraw
 import fr.acinq.phoenix.utils.*
 import fr.acinq.phoenix.utils.customviews.ButtonView
@@ -141,6 +142,7 @@ class ReadInputFragment : BaseFragment() {
           when (it.url) {
             is LNUrlWithdraw -> findNavController().navigate(ReadInputFragmentDirections.actionReadInputToLnurlWithdraw(it.url))
             is LNUrlAuth -> findNavController().navigate(ReadInputFragmentDirections.actionReadInputToLnurlAuth(it.url))
+            is LNUrlPay -> findNavController().navigate(ReadInputFragmentDirections.actionReadInputToLnurlPay(it.url))
             else -> model.inputState.value = ReadInputState.Error.UnhandledLNURL
           }
         }

--- a/app/src/main/java/fr/acinq/phoenix/send/ReadInputFragment.kt
+++ b/app/src/main/java/fr/acinq/phoenix/send/ReadInputFragment.kt
@@ -99,7 +99,7 @@ class ReadInputFragment : BaseFragment() {
             model.inputState.value = ReadInputState.Error.PayToSelf
           } else if (it.pr.isExpired) {
             model.inputState.value = ReadInputState.Error.PaymentExpired
-          } else if (acceptedPrefix.isEmpty || acceptedPrefix.get() != it.pr.prefix()) {
+          } else if (!Wallet.isSupportedPrefix(it.pr)) {
             model.inputState.value = ReadInputState.Error.InvalidChain
           } else if (it.pr.amount().isEmpty && !it.pr.features().allowTrampoline()) {
             // Payment request is pre-trampoline and SHOULD specify an amount. Show warning to user.

--- a/app/src/main/java/fr/acinq/phoenix/utils/customviews/ProgressTextView.kt
+++ b/app/src/main/java/fr/acinq/phoenix/utils/customviews/ProgressTextView.kt
@@ -53,4 +53,8 @@ class ProgressTextView @JvmOverloads constructor(context: Context, attrs: Attrib
   fun setText(s: Spanned) {
     mBinding.label.text = s
   }
+
+  fun setText(s: String) {
+    mBinding.label.text = s
+  }
 }

--- a/app/src/main/res/layout/fragment_lnurl_pay.xml
+++ b/app/src/main/res/layout/fragment_lnurl_pay.xml
@@ -22,6 +22,8 @@
 
     <import type="fr.acinq.phoenix.lnurl.LNUrlPayState" />
 
+    <import type="fr.acinq.phoenix.lnurl.LNUrlPayAmountState" />
+
     <variable
       name="model"
       type="fr.acinq.phoenix.lnurl.LNUrlPayViewModel" />
@@ -35,30 +37,257 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:padding="@dimen/space_md_p">
+      android:paddingBottom="@dimen/space_xl"
+      android:layout_height="wrap_content">
+
+      <fr.acinq.phoenix.utils.customviews.ActionBarView
+        android:id="@+id/action_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/transparent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+      <TextView
+        android:id="@+id/domain"
+        android:layout_width="wrap_content"
+        android:textAlignment="center"
+        android:maxWidth="@dimen/max_width_sm"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/space_md_p"
+        android:layout_marginStart="@dimen/space_lg"
+        android:layout_marginEnd="@dimen/space_lg"
+        android:text="@string/lnurl_pay_domain"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/action_bar" />
+
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/form_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/space_lg_p"
+        android:layout_marginStart="@dimen/space_lg"
+        android:layout_marginEnd="@dimen/space_lg"
+        android:padding="@dimen/space_lg"
+        android:background="@drawable/rounded"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/domain"
+        app:layout_constraintWidth_max="@dimen/max_width_md"
+        app:visible="@{!(model.state instanceof LNUrlPayState.Error)}">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+          android:id="@+id/amount_layout"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          app:enableOrFade="@{model.state instanceof LNUrlPayState.Init}"
+          app:layout_constrainedWidth="true"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent"
+          app:layout_constraintWidth_max="@dimen/max_width_md">
+
+          <EditText
+            android:id="@+id/amount"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@null"
+            android:fontFamily="sans-serif-light"
+            android:importantForAutofill="no"
+            android:inputType="numberDecimal"
+            android:minWidth="48dp"
+            android:overScrollMode="always"
+            android:paddingStart="@dimen/space_xs"
+            android:paddingEnd="@dimen/space_xs"
+            android:singleLine="true"
+            android:text=""
+            android:textAlignment="viewEnd"
+            android:textSize="48sp"
+            app:layout_constrainedHeight="true"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintEnd_toStartOf="@id/unit"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="LabelFor" />
+
+          <Spinner
+            android:id="@+id/unit"
+            style="@style/default_spinnerStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBaseline_toBaselineOf="@+id/amount"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/amount"
+            tools:ignore="RtlHardcoded" />
+
+          <View
+            android:id="@+id/amount_underline"
+            android:layout_width="0dp"
+            android:layout_height="2dp"
+            android:background="@drawable/line_dots"
+            android:backgroundTint="?attr/colorPrimary"
+            android:layerType="software"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintBottom_toBottomOf="@id/amount"
+            app:layout_constraintEnd_toEndOf="@id/unit"
+            app:layout_constraintStart_toStartOf="@id/amount" />
+
+          <TextView
+            android:id="@+id/amount_converted"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_xs"
+            android:visibility="@{!(model.amountState instanceof LNUrlPayAmountState.Error)}"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/amount_underline" />
+
+          <TextView
+            android:id="@+id/amount_error"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/space_xs"
+            android:text="@string/lnurl_pay_amount_invalid"
+            android:textAlignment="center"
+            android:textColor="?attr/negativeColor"
+            android:textSize="@dimen/text_md"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/amount" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <ImageView
+          android:id="@+id/metadata_image"
+          android:layout_width="110dp"
+          android:layout_height="110dp"
+          android:contentDescription="@null"
+          android:layout_marginTop="@dimen/space_md_p"
+          android:adjustViewBounds="true"
+          android:scaleType="fitCenter"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/amount_layout" />
+
+        <TextView
+          android:id="@+id/metadata_label"
+          style="@style/MutedLabelView"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/space_md_p"
+          android:layout_marginStart="@dimen/space_lg"
+          android:layout_marginEnd="@dimen/space_lg"
+          android:text="@string/lnurl_pay_meta_description"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/metadata_image" />
+
+        <TextView
+          android:id="@+id/metadata"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/space_xs"
+          android:textAlignment="center"
+          app:layout_constraintTop_toBottomOf="@id/metadata_label" />
+
+      </androidx.constraintlayout.widget.ConstraintLayout>
+
+      <fr.acinq.phoenix.utils.customviews.ButtonView
+        android:id="@+id/start_payment_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:backgroundTint="?attr/colorPrimary"
+        android:layout_marginTop="@dimen/space_lg"
+        app:layout_goneMarginTop="@dimen/space_lg"
+        android:visibility="@{model.state instanceof LNUrlPayState.Init}"
+        app:enableOrFade="@{!(model.amountState instanceof LNUrlPayAmountState.Error)}"
+        app:icon="@drawable/ic_send"
+        app:icon_tint="?attr/altTextColor"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/form_layout"
+        app:text="@string/lnurl_pay_pay_button"
+        app:text_color="?attr/altTextColor" />
 
       <fr.acinq.phoenix.utils.customviews.ProgressTextView
-        android:layout_width="match_parent"
+        android:id="@+id/sending_payment_progress"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:visibility="@{model.state == LNUrlPayState.IN_PROGRESS}"
-        app:layout_constraintTop_toTopOf="parent"
-        app:text="@string/lnurl_pay_wait" />
+        android:layout_marginTop="@dimen/space_lg"
+        android:padding="@dimen/space_sm"
+        android:visibility="@{model.state instanceof LNUrlPayState.RequestingInvoice || model.state instanceof LNUrlPayState.ValidInvoice || model.state instanceof LNUrlPayState.SendingPayment}"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/form_layout"
+        app:text="@string/lnurl_pay_requesting_invoice" />
 
-      <TextView
-        android:id="@+id/error"
-        android:layout_width="match_parent"
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/error_layout"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:drawableStart="@drawable/ic_alert_triangle"
-        android:drawableTint="?attr/negativeColor"
-        android:visibility="@{model.state == LNUrlPayState.ERROR}"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_marginTop="@dimen/space_lg"
+        android:layout_marginStart="@dimen/space_lg"
+        android:layout_marginEnd="@dimen/space_lg"
+        android:background="@drawable/rounded"
+        android:padding="@dimen/space_md_p"
+        android:visibility="@{model.state instanceof LNUrlPayState.Error}"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/form_layout"
+        app:layout_constraintWidth_max="@dimen/max_width_md">
 
-      <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="@{model.state == LNUrlPayState.DONE}"
-        app:layout_constraintTop_toTopOf="parent" />
+        <ImageView
+          android:id="@+id/error_icon"
+          android:layout_width="24dp"
+          android:layout_height="24dp"
+          android:src="@drawable/ic_alert_triangle"
+          android:contentDescription="@null"
+          app:layout_constraintBaseline_toBaselineOf="@id/error_message"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintEnd_toStartOf="@id/error_header"
+          app:layout_constraintHorizontal_chainStyle="packed"
+          app:tint="?attr/negativeColor" />
+
+        <TextView
+          android:id="@+id/error_header"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="@dimen/space_sm"
+          android:text="@string/lnurl_pay_error_header"
+          android:fontFamily="sans-serif-medium"
+          app:layout_constrainedWidth="true"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toEndOf="@id/error_icon"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+          android:id="@+id/error_message"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/space_xs"
+          app:layout_constrainedWidth="true"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintHorizontal_bias="0"
+          android:textAlignment="center"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/error_header" />
+
+        <fr.acinq.phoenix.utils.customviews.ButtonView
+          android:id="@+id/try_again_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/space_md_p"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/error_message"
+          app:text="@string/lnurl_pay_error_try_again_button" />
+
+      </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
   </ScrollView>
 </layout>

--- a/app/src/main/res/layout/fragment_settings_logs.xml
+++ b/app/src/main/res/layout/fragment_settings_logs.xml
@@ -67,7 +67,6 @@
           android:layout_height="wrap_content"
           android:background="@drawable/button_bg_square"
           android:padding="@dimen/space_md"
-          android:filterTouchesWhenObscured="true"
           app:hz_bias="0"
           app:icon="@drawable/ic_share"
           app:layout_constraintTop_toBottomOf="@id/view_button"

--- a/app/src/main/res/navigation/nav_graph_main.xml
+++ b/app/src/main/res/navigation/nav_graph_main.xml
@@ -280,14 +280,19 @@
   </fragment>
 
   <!-- LNURL: pay -->
-  <dialog
+  <fragment
     android:id="@+id/lnurl_pay"
     android:name="fr.acinq.phoenix.lnurl.LNUrlPayFragment"
     android:label="LNUrlPayFragment">
     <argument
       android:name="url"
-      app:argType="string" />
-  </dialog>
+      app:argType="fr.acinq.phoenix.lnurl.LNUrlPay" />
+    <action
+      android:id="@+id/action_lnurl_pay_to_main"
+      app:destination="@id/main_fragment"
+      app:popUpTo="@id/main_fragment"
+      app:popUpToInclusive="true" />
+  </fragment>
 
   <!-- LNURL: withdraw -->
   <fragment

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -457,6 +457,30 @@
   <string name="lnurl_auth_failure_remote_io">La connexion au service %1$s a échoué.</string>
   <string name="lnurl_auth_failure_remote_details">Le service a renvoyé l\'erreur suivante: %1$s</string>
 
+  <!-- //////////////// ln url pay //////////////// -->
+
+  <string name="lnurl_pay_domain"><![CDATA[Paiement demandé par<br/><b>%1$s</b>]]></string>
+  <string name="lnurl_pay_meta_description">Description</string>
+  <string name="lnurl_pay_comment_title">Commentaire (optionnel)</string>
+  <string name="lnurl_pay_comment_message">Vous pouvez ajouter un commentaire au paiement si vous le souhaitez</string>
+  <string name="lnurl_pay_comment_hint">Aucun commentaire</string>
+  <string name="lnurl_pay_pay_button">Payer</string>
+  <string name="lnurl_pay_requesting_invoice">Récupèration du paiement…</string>
+  <string name="lnurl_pay_checking_invoice">Vérification du paiement…</string>
+  <string name="lnurl_pay_sending_payment">Envoi du paiement…</string>
+
+  <string name="lnurl_pay_amount_empty">Le montant ne doit pas être vide</string>
+  <string name="lnurl_pay_amount_below_min">Le montant doit être d\'au moins %1$s</string>
+  <string name="lnurl_pay_amount_above_max">Le montant ne peut excéder %1$s</string>
+  <string name="lnurl_pay_amount_above_balance">Le montant excède votre balance</string>
+  <string name="lnurl_pay_amount_invalid">Montant invalide</string>
+
+  <string name="lnurl_pay_error_header">Le paiement n\'a pas fonctionné</string>
+  <string name="lnurl_pay_error_unreachable">Le service %1$s n\'est pas joignable. Vérifiez votre connexion.</string>
+  <string name="lnurl_pay_error_invalid_invoice">Le service %1$s a fourni une requête de paiement invalide (%2$s).</string>
+  <string name="lnurl_pay_error_remote_error">Le service %1$s a retourné une erreur (%2$s).</string>
+  <string name="lnurl_pay_error_try_again_button">Réessayer.</string>
+
   <!-- //////////////// ln url withdraw //////////////// -->
 
   <string name="lnurl_withdraw_amount_label">Montant à recevoir</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -348,13 +348,6 @@
   <string name="accessctrl_auth_hw_unavailable">Il dispositivo per il rilevamento biometrico non è disponibile. Riprova prova più tardi.</string>
   <string name="accessctrl_auth_none_enrolled">Per favore prima attiva l\'autenticazione biometrica.</string>
 
-  <!-- //////////////// ln url pay //////////////// -->
-
-  <string name="lnurl_pay_wait">Recuperando i dettagli del pagamento…</string>
-  <string name="lnurl_pay_error_remote">Impossibile ottenere una richiesta di pagamento valida da %1$s.\n\nPotresti riprovare più tardi.</string>
-  <string name="lnurl_pay_error_remote_code">Impossibile ottenere una richiesta di pagamento valida da %1$s (code %2$s).\n\nPotresti riprovare più tardi.</string>
-  <string name="lnurl_pay_error_missing_callback">C\'è stato un errore con questa richiesta di pagamento. Per favore riprova più tardi.</string>
-
   <!-- //////////////// ln url withdraw //////////////// -->
 
   <string name="lnurl_withdraw_amount_label">Importo da ricevere</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -494,13 +494,6 @@
   <string name="lnurl_auth_failure_remote_io">Não foi possível conectar a %1$s</string>
   <string name="lnurl_auth_failure_remote_details">Servidor respondeu com %1$s</string>
 
-  <!-- //////////////// ln url pay //////////////// -->
-
-  <string name="lnurl_pay_wait" translatable="false">Retrieving payment details…</string>
-  <string name="lnurl_pay_error_remote" translatable="false">Could not get a valid invoice from %1$s.\n\nYou may want to try again later.</string>
-  <string name="lnurl_pay_error_remote_code" translatable="false">Could not get a valid invoice from %1$s (code %2$s).\n\nYou may want to try again later.</string>
-  <string name="lnurl_pay_error_missing_callback" translatable="false">There was an error when handling this invoice. Please try again later.</string>
-
   <!-- //////////////// ln url withdraw //////////////// -->
 
   <string name="lnurl_withdraw_amount_label">Valor a receber</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -490,14 +490,31 @@
   <string name="lnurl_auth_success">Authentication success.</string>
   <string name="lnurl_auth_failure">Authentication failure.\n\nDetails: %1$s</string>
   <string name="lnurl_auth_failure_remote_io">Could not connect to %1$s</string>
-  <string name="lnurl_auth_failure_remote_details">Server responded with %1$s</string>
+  <string name="lnurl_auth_failure_remote_details">Service responded with %1$s</string>
 
   <!-- //////////////// ln url pay //////////////// -->
 
-  <string name="lnurl_pay_wait" translatable="false">Retrieving payment details…</string>
-  <string name="lnurl_pay_error_remote" translatable="false">Could not get a valid invoice from %1$s.\n\nYou may want to try again later.</string>
-  <string name="lnurl_pay_error_remote_code" translatable="false">Could not get a valid invoice from %1$s (code %2$s).\n\nYou may want to try again later.</string>
-  <string name="lnurl_pay_error_missing_callback" translatable="false">There was an error when handling this invoice. Please try again later.</string>
+  <string name="lnurl_pay_domain"><![CDATA[Payment requested by<br/><b>%1$s</b>]]></string>
+  <string name="lnurl_pay_meta_description">Description</string>
+  <string name="lnurl_pay_comment_title">Add optional comment</string>
+  <string name="lnurl_pay_comment_message">You can attach a comment to the payment if you want</string>
+  <string name="lnurl_pay_comment_hint">No comment</string>
+  <string name="lnurl_pay_pay_button">Pay</string>
+  <string name="lnurl_pay_requesting_invoice">Requesting invoice…</string>
+  <string name="lnurl_pay_checking_invoice">Checking invoice…</string>
+  <string name="lnurl_pay_sending_payment">Sending payment…</string>
+
+  <string name="lnurl_pay_amount_empty">Amount must not be empty</string>
+  <string name="lnurl_pay_amount_below_min">Amount must be at least %1$s</string>
+  <string name="lnurl_pay_amount_above_max">Amount must be at most %1$s</string>
+  <string name="lnurl_pay_amount_above_balance">Amount exceeds your balance</string>
+  <string name="lnurl_pay_amount_invalid">Invalid amount</string>
+
+  <string name="lnurl_pay_error_header">No payment sent.</string>
+  <string name="lnurl_pay_error_unreachable">The service %1$s is not reachable, please check your connection.</string>
+  <string name="lnurl_pay_error_invalid_invoice">The service %1$s provided an invalid invoice (%2$s).</string>
+  <string name="lnurl_pay_error_remote_error">The service %1$s returned an error (%2$s).</string>
+  <string name="lnurl_pay_error_try_again_button">Try again.</string>
 
   <!-- //////////////// ln url withdraw //////////////// -->
 

--- a/app/src/main/sqldelight/1.sqm
+++ b/app/src/main/sqldelight/1.sqm
@@ -1,0 +1,10 @@
+import fr.acinq.phoenix.db.LNUrlPayActionTypeVersion;
+
+-- Migration file from version 1 to version 2
+--
+-- Adds columns for lnurl-pay to the payment_meta database:
+--  - lnurlpay_action_typeversion
+--  - lnurlpay_action_data
+
+ALTER TABLE PaymentMeta ADD COLUMN lnurlpay_action_typeversion TEXT AS LNUrlPayActionTypeVersion DEFAULT NULL;
+ALTER TABLE PaymentMeta ADD COLUMN lnurlpay_action_data TEXT DEFAULT NULL;

--- a/app/src/main/sqldelight/fr/acinq/phoenix/db/PaymentMeta.sq
+++ b/app/src/main/sqldelight/fr/acinq/phoenix/db/PaymentMeta.sq
@@ -1,3 +1,5 @@
+import fr.acinq.phoenix.db.LNUrlPayActionTypeVersion;
+
 --
 -- Contain details/metadata that cannot be stored in the core payment database,
 -- such as the final closing transaction, or swap data.
@@ -25,7 +27,10 @@ CREATE TABLE PaymentMeta (
   closing_main_output_script TEXT DEFAULT NULL,
   closing_cause TEXT DEFAULT NULL,
 
-  custom_desc TEXT DEFAULT NULL
+  custom_desc TEXT DEFAULT NULL,
+
+  lnurlpay_action_typeversion TEXT AS LNUrlPayActionTypeVersion DEFAULT NULL,
+  lnurlpay_action_data TEXT DEFAULT NULL
 );
 
 CREATE INDEX IF NOT EXISTS payment_closing_channel_id_index ON PaymentMeta(closing_channel_id);
@@ -51,6 +56,11 @@ VALUES (?, ?, ?, ?);
 insertClosing:
 INSERT INTO PaymentMeta(id, closing_type, closing_channel_id, closing_spending_txs, closing_main_output_script)
 VALUES (?, ?, ?, ?, ?);
+
+setLNUrlPayAction:
+UPDATE PaymentMeta
+SET lnurlpay_action_typeversion=?, lnurlpay_action_data=?
+WHERE id=?;
 
 setDesc:
 UPDATE PaymentMeta

--- a/build.gradle
+++ b/build.gradle
@@ -17,20 +17,22 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.4.21'
+  ext.kotlin_version = '1.4.32'
   ext.safeargs_version = '2.1.0-beta02'
   repositories {
     google()
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.2'
+    classpath 'com.android.tools.build:gradle:4.1.3'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     // plugin to generate args classes for the androidx navigation component
     classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$safeargs_version"
     // plugin for firebase cloud messaging
     classpath "com.google.gms:google-services:4.3.5"
     classpath 'com.squareup.sqldelight:gradle-plugin:1.4.4'
+    // kotlinx serialization
+    classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
   }
 }
 


### PR DESCRIPTION
This PR adds support for the LNURL-pay protocol (see https://github.com/fiatjaf/lnurl-rfc/blob/master/lnurl-pay.md), which is a way to offer static invoices. Note that this does not mean that Phoenix can receive payments with LNURL-pay links, only that it can pay them.

This includes support for the comment field and the success actions, which are stored in the payment meta database.