### PR TITLE
Adding support for LUD-10: AES successAction in payRequest

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		DC72C32F25A51797008A927A /* UserDefaults+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC72C32E25A51797008A927A /* UserDefaults+Codable.swift */; };
 		DC72C33425A51AAC008A927A /* CurrencyPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC72C33325A51AAC008A927A /* CurrencyPrefs.swift */; };
 		DC72C33925A663CA008A927A /* QRCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC72C33825A663CA008A927A /* QRCode.swift */; };
+		DC74174B270F332700F7E3E3 /* KotlinTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC74174A270F332700F7E3E3 /* KotlinTypes.swift */; };
+		DC74174D270F455D00F7E3E3 /* AES256.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC74174C270F455D00F7E3E3 /* AES256.swift */; };
 		DC8107D3255F1FC1002084A3 /* RecoverySeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8107D2255F1FC1002084A3 /* RecoverySeedView.swift */; };
 		DC81B79F25BF2AA200F5A52C /* MVI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC81B79E25BF2AA200F5A52C /* MVI.swift */; };
 		DC89857F25914747007B253F /* UIApplicationState+Phoenix.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC89857E25914747007B253F /* UIApplicationState+Phoenix.swift */; };
@@ -229,6 +231,8 @@
 		DC72C32E25A51797008A927A /* UserDefaults+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Codable.swift"; sourceTree = "<group>"; };
 		DC72C33325A51AAC008A927A /* CurrencyPrefs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyPrefs.swift; sourceTree = "<group>"; };
 		DC72C33825A663CA008A927A /* QRCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCode.swift; sourceTree = "<group>"; };
+		DC74174A270F332700F7E3E3 /* KotlinTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinTypes.swift; sourceTree = "<group>"; };
+		DC74174C270F455D00F7E3E3 /* AES256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AES256.swift; sourceTree = "<group>"; };
 		DC8107D2255F1FC1002084A3 /* RecoverySeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoverySeedView.swift; sourceTree = "<group>"; };
 		DC81B79E25BF2AA200F5A52C /* MVI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MVI.swift; sourceTree = "<group>"; };
 		DC89857E25914747007B253F /* UIApplicationState+Phoenix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplicationState+Phoenix.swift"; sourceTree = "<group>"; };
@@ -353,6 +357,7 @@
 				DCB04684260D162C007FDA37 /* ViewName.swift */,
 				DCED09D32625DBC4005D5EE2 /* AnimationCompletion.swift */,
 				DCD777D126DE9FE800979A12 /* DelayedSave.swift */,
+				DC74174C270F455D00F7E3E3 /* AES256.swift */,
 			);
 			path = utils;
 			sourceTree = "<group>";
@@ -483,6 +488,7 @@
 				DC46BAEE26CACCF700E760A6 /* KotlinFlow.swift */,
 				DC46BAF026CACCF700E760A6 /* KotlinFutures.swift */,
 				DC46BAEF26CACCF700E760A6 /* KotlinPublishers.swift */,
+				DC74174A270F332700F7E3E3 /* KotlinTypes.swift */,
 			);
 			path = kotlin;
 			sourceTree = "<group>";
@@ -851,6 +857,7 @@
 				DCB493CF269F859E001B0F09 /* SyncManagerState.swift in Sources */,
 				DCB493C92694F69B001B0F09 /* CloudOptionsView.swift in Sources */,
 				7555FF7F242A565900829871 /* AppDelegate.swift in Sources */,
+				DC74174B270F332700F7E3E3 /* KotlinTypes.swift in Sources */,
 				DC142135261E72320075857A /* AboutHTML.swift in Sources */,
 				DC1706D926A71D8E00BAFCD0 /* ErrorView.swift in Sources */,
 				7555FF81242A565900829871 /* SceneDelegate.swift in Sources */,
@@ -927,6 +934,7 @@
 				F4AED297257A50CD009485C1 /* LogsConfigurationViewerView.swift in Sources */,
 				DCD5FF4326A0D34B009CC666 /* EqualSizes.swift in Sources */,
 				F4AED298257A50CD009485C1 /* LogsConfigurationView.swift in Sources */,
+				DC74174D270F455D00F7E3E3 /* AES256.swift in Sources */,
 				53BEF98CDD61115030E87C12 /* uikitAppearance.swift in Sources */,
 				C8D7AB09E80CE2B6AE270A97 /* TorConfigurationView.swift in Sources */,
 			);
@@ -1215,8 +1223,8 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = XD77LN4376;
 				INFOPLIST_FILE = "phoenix-iosTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1225,8 +1233,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "orgIdentifier.phoenix-iosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/phoenix-ios.app/phoenix-ios";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Phoenix.app/Phoenix";
 			};
 			name = Debug;
 		};
@@ -1236,8 +1243,8 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = XD77LN4376;
 				INFOPLIST_FILE = "phoenix-iosTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1246,8 +1253,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "orgIdentifier.phoenix-iosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/phoenix-ios.app/phoenix-ios";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Phoenix.app/Phoenix";
 			};
 			name = Release;
 		};

--- a/phoenix-ios/phoenix-ios/extensions/Data+Hexadecimal.swift
+++ b/phoenix-ios/phoenix-ios/extensions/Data+Hexadecimal.swift
@@ -1,13 +1,46 @@
 import Foundation
 
 extension Data {
-	struct HexEncodingOptions: OptionSet {
-		let rawValue: Int
-		static let upperCase = HexEncodingOptions(rawValue: 1 << 0)
+	enum HexOptions {
+		case lowerCase
+		case upperCase
 	}
 
-	func hexEncodedString(options: HexEncodingOptions = []) -> String {
-		let format = options.contains(.upperCase) ? "%02hhX" : "%02hhx"
+	func toHex(options: HexOptions = .lowerCase) -> String {
+		let format = options == .upperCase ? "%02hhX" : "%02hhx"
 		return map { String(format: format, $0) }.joined()
+	}
+	
+	init?(fromHex string: String) {
+
+		// Convert 0 ... 9, a ... f, A ...F to their decimal value,
+		// return nil for all other input characters
+		func decodeNibble(u: UInt16) -> UInt8? {
+			switch(u) {
+			case 0x30 ... 0x39:
+				return UInt8(u - 0x30)
+			case 0x41 ... 0x46:
+				return UInt8(u - 0x41 + 10)
+			case 0x61 ... 0x66:
+				return UInt8(u - 0x61 + 10)
+			default:
+				return nil
+			}
+		}
+		
+		self.init(capacity: string.utf16.count/2)
+		var even = true
+		var byte: UInt8 = 0
+		for c in string.utf16 {
+			guard let val = decodeNibble(u: c) else { return nil }
+			if even {
+				byte = val << 4
+			} else {
+				byte += val
+				self.append(byte)
+			}
+			even = !even
+		}
+		guard even else { return nil }
 	}
 }

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinTypes.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinTypes.swift
@@ -1,0 +1,50 @@
+import Foundation
+import PhoenixShared
+
+// Making Kotlin types more readable
+
+extension Scan {
+	typealias Model_Ready = ModelReady
+	typealias Model_BadRequest = ModelBadRequest
+	
+	typealias Model_InvoiceFlow_DangerousRequest = ModelInvoiceFlowDangerousRequest
+	typealias Model_InvoiceFlow_InvoiceRequest = ModelInvoiceFlowInvoiceRequest
+	typealias Model_InvoiceFlow_Sending = ModelInvoiceFlowSending
+	
+	typealias Model_LnurlServiceFetch = ModelLnurlServiceFetch
+	
+	typealias Model_LnurlPayFlow_LnurlPayRequest = ModelLnurlPayFlowLnurlPayRequest
+	typealias Model_LnurlPayFlow_LnUrlPayFetch = ModelLnurlPayFlowLnUrlPayFetch
+	typealias Model_LnurlPayFlow_Sending = ModelLnurlPayFlowSending
+	
+	typealias Model_LnurlAuthFlow_LoginRequest = ModelLnurlAuthFlowLoginRequest
+	typealias Model_LnurlAuthFlow_LoggingIn = ModelLnurlAuthFlowLoggingIn
+	typealias Model_LnurlAuthFlow_LoginResult = ModelLnurlAuthFlowLoginResult
+	
+	typealias Intent_Parse = IntentParse
+	
+	typealias Intent_InvoiceFlow_ConfirmDangerousRequest = IntentInvoiceFlowConfirmDangerousRequest
+	typealias Intent_InvoiceFlow_SendInvoicePayment = IntentInvoiceFlowSendInvoicePayment
+	
+	typealias Intent_CancelLnurlServiceFetch = IntentCancelLnurlServiceFetch
+	
+	typealias Intent_LnurlPayFlow_SendLnurlPayment = IntentLnurlPayFlowSendLnurlPayment
+	typealias Intent_LnurlPayFlow_CancelLnurlPayment = IntentLnurlPayFlowCancelLnurlPayment
+	
+	typealias Intent_LnurlAuthFlow_Login = IntentLnurlAuthFlowLogin
+	
+	typealias LNUrlPay_Error_RemoteError = LNUrlPayErrorRemoteError
+	typealias LNUrlPay_Error_BadResponseError = LNUrlPayErrorBadResponseError
+	typealias LNUrlPay_Error_ChainMismatch = LNUrlPayErrorChainMismatch
+	typealias LNUrlPay_Error_AlreadyPaidInvoice = LNUrlPayErrorAlreadyPaidInvoice
+}
+
+extension LNUrl {
+	
+	typealias PayInvoice_SuccessAction = PayInvoiceSuccessAction
+	typealias PayInvoice_SuccessAction_Message = PayInvoiceSuccessActionMessage
+	typealias PayInvoice_SuccessAction_Url = PayInvoiceSuccessActionUrl
+	typealias PayInvoice_SuccessAction_Aes = PayInvoiceSuccessActionAes
+	
+	typealias PayInvoice_SuccessAction_Aes_Decrypted = PayInvoiceSuccessActionAesDecrypted
+}

--- a/phoenix-ios/phoenix-ios/utils/AES256.swift
+++ b/phoenix-ios/phoenix-ios/utils/AES256.swift
@@ -1,0 +1,79 @@
+import Foundation
+import CommonCrypto
+
+struct AES256 {
+	
+	private var key: Data
+	private var iv: Data
+	
+	public init(key: Data, iv: Data) throws {
+		guard key.count == kCCKeySizeAES256 else {
+			throw Error.badKeyLength
+		}
+		guard iv.count == kCCBlockSizeAES128 else {
+			throw Error.badInputVectorLength
+		}
+		self.key = key
+		self.iv = iv
+	}
+	
+	enum Error: Swift.Error {
+		case badKeyLength
+		case badInputVectorLength
+		case keyGeneration(status: Int)
+		case cryptoFailed(status: CCCryptorStatus)
+	}
+	
+	enum Padding {
+		case None
+		case PKCS7
+	}
+	
+	func encrypt(_ digest: Data, padding: Padding = .PKCS7) throws -> Data {
+		return try crypt(
+			input: digest,
+			operation: CCOperation(kCCEncrypt),
+			options: padding == .PKCS7 ? CCOptions(kCCOptionPKCS7Padding) : CCOptions()
+		)
+	}
+	
+	func decrypt(_ encrypted: Data, padding: Padding = .PKCS7) throws -> Data {
+		return try crypt(
+			input: encrypted,
+			operation: CCOperation(kCCDecrypt),
+			options: padding == .PKCS7 ? CCOptions(kCCOptionPKCS7Padding) : CCOptions()
+		)
+	}
+	
+	private func crypt(
+		input: Data,
+		operation: CCOperation,
+		options: CCOptions
+	) throws -> Data {
+		
+		var outLength = Int(0)
+		var outBytes = [UInt8](repeating: 0, count: input.count + kCCBlockSizeAES128)
+		var status: CCCryptorStatus = CCCryptorStatus(kCCSuccess)
+		input.withUnsafeBytes { (encryptedBytes: UnsafeRawBufferPointer) in
+			iv.withUnsafeBytes { (ivBytes: UnsafeRawBufferPointer) in
+				key.withUnsafeBytes { (keyBytes: UnsafeRawBufferPointer) in
+					status = CCCrypt(operation,
+					                 CCAlgorithm(kCCAlgorithmAES), // algorithm
+					                 options,                      // options
+					                 keyBytes.baseAddress,         // key: UnsafeRawPointer!
+					                 key.count,                    // keylength
+					                 ivBytes.baseAddress,          // iv: UnsafeRawPointer!
+					                 encryptedBytes.baseAddress,   // dataIn: UnsafeRawPointer!
+					                 input.count,                  // dataInLength
+					                 &outBytes,                    // dataOut
+					                 outBytes.count,               // dataOutAvailable
+					                 &outLength)                   // dataOutMoved : UnsafeMutablePointer<Int>!
+				}
+			}
+		}
+		guard status == kCCSuccess else {
+			throw Error.cryptoFailed(status: status)
+		}
+		return Data(bytes: outBytes, count: outLength)
+	}
+}

--- a/phoenix-ios/phoenix-ios/views/SendView.swift
+++ b/phoenix-ios/phoenix-ios/views/SendView.swift
@@ -14,42 +14,6 @@ fileprivate var log = Logger(
 fileprivate var log = Logger(OSLog.disabled)
 #endif
 
-extension Scan {
-	typealias Model_Ready = ModelReady
-	typealias Model_BadRequest = ModelBadRequest
-	
-	typealias Model_InvoiceFlow_DangerousRequest = ModelInvoiceFlowDangerousRequest
-	typealias Model_InvoiceFlow_InvoiceRequest = ModelInvoiceFlowInvoiceRequest
-	typealias Model_InvoiceFlow_Sending = ModelInvoiceFlowSending
-	
-	typealias Model_LnurlServiceFetch = ModelLnurlServiceFetch
-	
-	typealias Model_LnurlPayFlow_LnurlPayRequest = ModelLnurlPayFlowLnurlPayRequest
-	typealias Model_LnurlPayFlow_LnUrlPayFetch = ModelLnurlPayFlowLnUrlPayFetch
-	typealias Model_LnurlPayFlow_Sending = ModelLnurlPayFlowSending
-	
-	typealias Model_LnurlAuthFlow_LoginRequest = ModelLnurlAuthFlowLoginRequest
-	typealias Model_LnurlAuthFlow_LoggingIn = ModelLnurlAuthFlowLoggingIn
-	typealias Model_LnurlAuthFlow_LoginResult = ModelLnurlAuthFlowLoginResult
-	
-	typealias Intent_Parse = IntentParse
-	
-	typealias Intent_InvoiceFlow_ConfirmDangerousRequest = IntentInvoiceFlowConfirmDangerousRequest
-	typealias Intent_InvoiceFlow_SendInvoicePayment = IntentInvoiceFlowSendInvoicePayment
-	
-	typealias Intent_CancelLnurlServiceFetch = IntentCancelLnurlServiceFetch
-	
-	typealias Intent_LnurlPayFlow_SendLnurlPayment = IntentLnurlPayFlowSendLnurlPayment
-	typealias Intent_LnurlPayFlow_CancelLnurlPayment = IntentLnurlPayFlowCancelLnurlPayment
-	
-	typealias Intent_LnurlAuthFlow_Login = IntentLnurlAuthFlowLogin
-	
-	typealias LNUrlPay_Error_RemoteError = LNUrlPayErrorRemoteError
-	typealias LNUrlPay_Error_BadResponseError = LNUrlPayErrorBadResponseError
-	typealias LNUrlPay_Error_ChainMismatch = LNUrlPayErrorChainMismatch
-	typealias LNUrlPay_Error_AlreadyPaidInvoice = LNUrlPayErrorAlreadyPaidInvoice
-}
-
 
 struct SendView: MVIView {
 	

--- a/phoenix-ios/phoenix-iosTests/phoenix-iosTests.swift
+++ b/phoenix-ios/phoenix-iosTests/phoenix-iosTests.swift
@@ -1,26 +1,85 @@
 import XCTest
-@testable import appName
+@testable import Phoenix
+import SwiftUI
 
 class appNameTests: XCTestCase {
 
-    override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
+	override func setUp() {
+		// Put setup code here.
+		// This method is called before the invocation of each test method in the class.
+	}
+	
+	override func tearDown() {
+		// Put teardown code here.
+		// This method is called after the invocation of each test method in the class.
+	}
+	
+	struct TestVectors {
+		let key: Data
+		let iv: Data
+		let plaintext: Data
+		let ciphertext: Data
+	}
+	
+	func testVectors() -> TestVectors {
+		/**
+		 * Source:
+		 * https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf
+		 * Section: F.2.5 - CBC-AES256.Encrypt
+		 */
+		
+		let key = Data(fromHex: "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4")!
+		let iv = Data(fromHex: "000102030405060708090a0b0c0d0e0f")!
+		 
+		let plaintext = Data(fromHex:
+		  "6bc1bee22e409f96e93d7e117393172a" + // block 1
+		  "ae2d8a571e03ac9c9eb76fac45af8e51" + // block 2
+		  "30c81c46a35ce411e5fbc1191a0a52ef" + // block 3
+		  "f69f2445df4f9b17ad2b417be66c3710")! // block 4
+		
+		let ciphertext = Data(fromHex:
+		  "f58c4c04d6e5f1ba779eabfb5f7bfbd6" + // block 1
+		  "9cfc4e967edb808d679f777bc6702c7d" + // block 2
+		  "39f23369a9d9bacfa530e26304231461" + // block 3
+		  "b2eb05e2c39be9fcda6c19078c6a9d1b")! // block 4
+		
+		return TestVectors(key: key, iv: iv, plaintext: plaintext, ciphertext: ciphertext)
+	}
+	
+	func testEncryptionDecryption() {
+		
+		let v = testVectors()
+		let aes = try? AES256(key: v.key, iv: v.iv)
+		
+		let encrypted = try? aes?.encrypt(v.plaintext, padding: .None)
+		XCTAssert(encrypted == v.ciphertext)
+		
+		let decrypted = try? aes?.decrypt(v.ciphertext, padding: .None)
+		XCTAssert(decrypted == v.plaintext)
+	}
+	
+	func testPadding() {
+		
+		let v = testVectors()
+		let aes = try? AES256(key: v.key, iv: v.iv)
+		
+		// We should be able to drop bytes from the end of the plaintext,
+		// without experiencing any problems while encrypting / decrypting.
+		//
+		// That is, the PKCS7 padding should work properly.
+		
+		var length = v.plaintext.count
+		while length > 2 {
+			
+			let plaintext = v.plaintext.prefix(length - 1)
+			
+			let encrypted = try? aes?.encrypt(plaintext, padding: .PKCS7)
+			let decrypted = try? aes?.decrypt(encrypted!, padding: .PKCS7)
+			
+			XCTAssert(decrypted == plaintext)
+			
+			length -= 1
+		}
+	}
+		
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/LNUrl.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/LNUrl.kt
@@ -112,7 +112,12 @@ sealed class LNUrl {
                 val description: String,
                 val ciphertext: ByteVector,
                 val iv: ByteVector
-            ): SuccessAction()
+            ): SuccessAction() {
+                data class Decrypted(
+                    val description: String,
+                    val plaintext: String
+                )
+            }
 
             enum class Tag(val label: String) {
                 Message("message"),


### PR DESCRIPTION
We previously had confusion about [LUD-10](https://github.com/fiatjaf/lnurl-rfc/blob/luds/10.md), which has now been clarified:

> The decrypted content must be a string, to be presented to the user along with description. It could be, for example, a pin code to be provided elsewhere, or just a secret word or phrase the user can then use to perform something in the world with.

Notes:

My current understanding is that there isn't support for AES within Kotlin native, either thru the standard libraries, our libraries, or thru 3rd party libraries that we're currently using. (Please correct me if I'm wrong about this.) However, there is good support within iOS & the JVM. So I've added the appropriate iOS encryption/decryption routines, along with unit tests.

In the future, when the corresponding JVM code is added, we can migrate the AES decryption into the shared library via Kotlin `expect/actual` routines.

Also, LUD-10 still mentions a URL for some reason. So the UI checks to see if the decrypted string is a URL. And, if so, displays it as a tappable link.
