### PR TITLE
Ignore certain syncing channels when computing the wallet's balance

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/ScanController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/ScanController.kt
@@ -1,16 +1,13 @@
 package fr.acinq.phoenix.controllers.payments
 
-import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.lightning.Feature
 import fr.acinq.lightning.Features
 import fr.acinq.lightning.MilliSatoshi
-import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.io.SendPayment
 import fr.acinq.lightning.payment.PaymentRequest
 import fr.acinq.lightning.utils.Either
 import fr.acinq.lightning.utils.UUID
-import fr.acinq.lightning.utils.sum
 import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.controllers.AppController
 import fr.acinq.phoenix.data.Chain
@@ -21,7 +18,7 @@ import fr.acinq.phoenix.managers.*
 import fr.acinq.phoenix.managers.Utilities.BitcoinAddressInfo
 import fr.acinq.phoenix.utils.PublicSuffixList
 import fr.acinq.phoenix.utils.chain
-import fr.acinq.phoenix.utils.localCommitmentSpec
+import fr.acinq.phoenix.utils.calculateBalance
 import io.ktor.http.*
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.delay
@@ -79,18 +76,6 @@ class AppScanController(
                 }}
             }
         }
-    }
-
-    private fun calculateBalance(channels: Map<ByteVector32, ChannelState>): MilliSatoshi {
-        return channels.values.map {
-            when (it) {
-                is Closing -> MilliSatoshi(0)
-                is Closed -> MilliSatoshi(0)
-                is Aborted -> MilliSatoshi(0)
-                is ErrorInformationLeak -> MilliSatoshi(0)
-                else -> it.localCommitmentSpec?.toLocal ?: MilliSatoshi(0)
-            }
-        }.sum()
     }
 
     private suspend fun getBalance(): MilliSatoshi {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/channelStates.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/channelStates.kt
@@ -1,10 +1,10 @@
 package fr.acinq.phoenix.utils
 
-import fr.acinq.lightning.channel.ChannelState
-import fr.acinq.lightning.channel.ChannelStateWithCommitments
-import fr.acinq.lightning.channel.Offline
-import fr.acinq.lightning.channel.Syncing
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.lightning.MilliSatoshi
+import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.transactions.CommitmentSpec
+import fr.acinq.lightning.utils.sum
 
 
 val ChannelState.localCommitmentSpec: CommitmentSpec? get() =
@@ -14,3 +14,30 @@ val ChannelState.localCommitmentSpec: CommitmentSpec? get() =
         is Syncing -> state.localCommitmentSpec
         else -> null
     }
+
+fun calculateBalance(channels: Map<ByteVector32, ChannelState>): MilliSatoshi {
+    return channels.values.map {
+        // If the channel is offline, we want to display the underlying balance.
+        // The alternative is to display a zero balance whenever the user is offline.
+        // And if there's one sure way to make user's freak out,
+        // it's showing them a zero balance...
+        val channel = when (it) {
+            is Offline -> it.state
+            is Syncing -> {
+                // https://github.com/ACINQ/phoenix-kmm/issues/195
+                when (val underlying = it.state) {
+                    is WaitForFundingConfirmed -> null
+                    else -> underlying
+                }
+            }
+            else -> it
+        }
+        when (channel) {
+            is Closing -> MilliSatoshi(0)
+            is Closed -> MilliSatoshi(0)
+            is Aborted -> MilliSatoshi(0)
+            is ErrorInformationLeak -> MilliSatoshi(0)
+            else -> channel?.localCommitmentSpec?.toLocal ?: MilliSatoshi(0)
+        }
+    }.sum()
+}


### PR DESCRIPTION
This addresses issue #198, and is based on https://github.com/ACINQ/phoenix-kmm/issues/195