### PR TITLE
Adding ability to edit payment description, and add notes

### DIFF
--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions.swift
@@ -34,7 +34,7 @@ extension WalletPaymentOrderRow: Identifiable {
 
 extension WalletPaymentInfo {
 	
-	func paymentDescription() -> String? {
+	func paymentDescription(includingUserDescription: Bool = true) -> String? {
 		
 		let sanitize = { (input: String?) -> String? in
 			
@@ -47,8 +47,10 @@ extension WalletPaymentInfo {
 			return nil
 		}
 		
-		if let description = sanitize(metadata.userDescription) {
-			return description
+		if includingUserDescription {
+			if let description = sanitize(metadata.userDescription) {
+				return description
+			}
 		}
 		if let description = sanitize(metadata.lnurl?.description_) {
 			return description
@@ -85,8 +87,10 @@ extension WalletPaymentMetadata {
 	
 	static func empty() -> WalletPaymentMetadata {
 		return WalletPaymentMetadata(
+			lnurl: nil,
 			userDescription: nil,
-			lnurl: nil
+			userNotes: nil,
+			modifiedAt: nil
 		)
 	}
 }

--- a/phoenix-ios/phoenix-ios/sync/SyncManager.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncManager.swift
@@ -1817,16 +1817,11 @@ class SyncManager {
 		_ metadata: WalletPaymentMetadata
 	) -> URL? {
 		
-		guard let lnurlPay = metadata.lnurl?.pay else {
+		guard let row = WalletPaymentMetadataRow.companion.serialize(metadata: metadata) else {
 			return nil
 		}
 		
-		let cleartext = WalletPaymentMetadataRow.companion.serialize(
-			pay: lnurlPay,
-			successAction: metadata.lnurl?.successAction
-		)
-		.cloudSerialize()
-		.toSwiftData()
+		let cleartext = row.cloudSerialize().toSwiftData()
 		
 		let ciphertext: Data
 		do {

--- a/phoenix-ios/phoenix-ios/views/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/HomeView.swift
@@ -32,7 +32,7 @@ struct HomeView : MVIView, ViewName {
 	
 	@EnvironmentObject var currencyPrefs: CurrencyPrefs
 	
-	let paymentsPagerPublisher = phoenixBusiness.paymentsManager.paymentsPagePublisher()
+	let paymentsPagePublisher = phoenixBusiness.paymentsManager.paymentsPagePublisher()
 	@State var paymentsPage = PaymentsManager.PaymentsPage(offset: 0, count: 0, rows: [])
 	
 	let lastCompletedPaymentPublisher = phoenixBusiness.paymentsManager.lastCompletedPaymentPublisher()
@@ -78,7 +78,7 @@ struct HomeView : MVIView, ViewName {
 		.onChange(of: mvi.model) { newModel in
 			onModelChange(model: newModel)
 		}
-		.onReceive(paymentsPagerPublisher) {
+		.onReceive(paymentsPagePublisher) {
 			paymentsPageChanged($0)
 		}
 		.onReceive(lastCompletedPaymentPublisher) {

--- a/phoenix-ios/phoenix-ios/views/PaymentView.swift
+++ b/phoenix-ios/phoenix-ios/views/PaymentView.swift
@@ -6,7 +6,7 @@ import os.log
 #if DEBUG && false
 fileprivate var log = Logger(
 	subsystem: Bundle.main.bundleIdentifier!,
-	category: "TransactionView"
+	category: "PaymentView"
 )
 #else
 fileprivate var log = Logger(OSLog.disabled)
@@ -55,6 +55,20 @@ fileprivate struct SummaryView: View {
 	
 	@EnvironmentObject var currencyPrefs: CurrencyPrefs
 	
+	enum ButtonWidth: Preference {}
+	let buttonWidthReader = GeometryPreferenceReader(
+		key: AppendValue<ButtonWidth>.self,
+		value: { [$0.size.width] }
+	)
+	@State var buttonWidth: CGFloat? = nil
+	
+	enum ButtonHeight: Preference {}
+	let buttonHeightReader = GeometryPreferenceReader(
+		key: AppendValue<ButtonHeight>.self,
+		value: { [$0.size.height] }
+	)
+	@State var buttonHeight: CGFloat? = nil
+	
 	init(paymentInfo: WalletPaymentInfo, closeSheet: @escaping () -> Void) {
 	//	self.payment = payment
 		// ^^^ This compiles on Xcode 12.5, but crashes on the device.
@@ -69,7 +83,9 @@ fileprivate struct SummaryView: View {
 		
 		ZStack {
 
-			self.main
+			ScrollView {
+				self.main
+			}
 
 			// Close button in upper right-hand corner
 			VStack {
@@ -120,6 +136,8 @@ fileprivate struct SummaryView: View {
 		let payment = paymentInfo.payment
 		
 		VStack {
+			Spacer(minLength: 90)
+			
 			switch payment.state() {
 			case .success:
 				Image("ic_payment_sent")
@@ -250,13 +268,33 @@ fileprivate struct SummaryView: View {
 				explainFeesPopoverVisible: $explainFeesPopoverVisible
 			)
 			
-			NavigationLink(destination: DetailsView(
-				paymentInfo: $paymentInfo,
-				closeSheet: closeSheet
-			)) {
-				Text("Details")
+			HStack(alignment: VerticalAlignment.center, spacing: 16) {
+			
+				NavigationLink(destination: DetailsView(
+					paymentInfo: $paymentInfo,
+					closeSheet: closeSheet
+				)) {
+					Text("Details")
+						.frame(minWidth: buttonWidth, alignment: Alignment.trailing)
+						.read(buttonWidthReader)
+						.read(buttonHeightReader)
+				}
+				
+				Divider()
+					.frame(height: buttonHeight)
+				
+				NavigationLink(destination: EditInfoView(
+					paymentInfo: $paymentInfo
+				)) {
+					Text("Edit")
+						.frame(minWidth: buttonWidth, alignment: Alignment.leading)
+						.read(buttonWidthReader)
+						.read(buttonHeightReader)
+				}
 			}
 			.padding([.top, .bottom])
+			.assignMaxPreference(for: buttonWidthReader.key, to: $buttonWidth)
+			.assignMaxPreference(for: buttonHeightReader.key, to: $buttonHeight)
 		}
 	}
 	
@@ -333,6 +371,7 @@ fileprivate struct SummaryInfoGrid: InfoGridView {
 			paymentServiceRow
 			paymentDescriptionRow
 			paymentMessaegRow
+			paymentNotesRow
 			paymentTypeRow
 			channelClosingRow
 			paymentFeesRow
@@ -501,6 +540,27 @@ fileprivate struct SummaryInfoGrid: InfoGridView {
 						Text("<decryption error>")
 					}
 				}
+			}
+		}
+	}
+	
+	@ViewBuilder
+	var paymentNotesRow: some View {
+		let identifier: String = #function
+		
+		if let notes = paymentInfo.metadata.userNotes, notes.count > 0 {
+			
+			InfoGridRow(
+				identifier: identifier,
+				hSpacing: horizontalSpacingBetweenColumns,
+				keyColumnWidth: keyColumnWidth(identifier: identifier)
+			) {
+				
+				keyColumn(NSLocalizedString("Notes", comment: "Label in SummaryInfoGrid"))
+				
+			} valueColumn: {
+				
+				Text(notes)
 			}
 		}
 	}
@@ -1966,5 +2026,217 @@ extension Lightning_kmpWalletPayment {
 		}
 		
 		return nil
+	}
+}
+
+fileprivate struct EditInfoView: View, ViewName {
+	
+	@Binding var paymentInfo: WalletPaymentInfo
+	
+	let defaultDescText: String
+	let originalDescText: String?
+	@State var descText: String
+	
+	let maxDescCount: Int = 64
+	@State var remainingDescCount: Int
+	
+	let originalNotesText: String?
+	@State var notesText: String
+	
+	let maxNotesCount: Int = 280
+	@State var remainingNotesCount: Int
+	
+	@Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+	
+	init(paymentInfo: Binding<WalletPaymentInfo>) {
+		_paymentInfo = paymentInfo
+		
+		let pi = paymentInfo.wrappedValue
+		
+		defaultDescText = pi.paymentDescription(includingUserDescription: false) ?? ""
+		let realizedDesc = pi.paymentDescription(includingUserDescription: true) ?? ""
+		
+		if realizedDesc == defaultDescText {
+			originalDescText = nil
+			_descText = State(initialValue: "")
+			_remainingDescCount = State(initialValue: maxDescCount)
+		} else {
+			originalDescText = realizedDesc
+			_descText = State(initialValue: realizedDesc)
+			_remainingDescCount = State(initialValue: maxDescCount - realizedDesc.count)
+		}
+		
+		originalNotesText = pi.metadata.userNotes
+		let notes = pi.metadata.userNotes ?? ""
+		
+		_notesText = State(initialValue: notes)
+		_remainingNotesCount = State(initialValue: maxNotesCount - notes.count)
+	}
+	
+	@ViewBuilder
+	var body: some View {
+		
+		VStack(alignment: HorizontalAlignment.center, spacing: 0) {
+			
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				Button {
+					saveButtonTapped()
+				} label: {
+					HStack(alignment: .center, spacing: 4) {
+						Image(systemName: "chevron.left")
+							.imageScale(.medium)
+						Text("Save")
+					}
+				}
+				Spacer()
+				Button {
+					cancelButtonTapped()
+				} label: {
+					Text("Cancel")
+				}
+			}
+			.font(.title3)
+			.padding()
+			
+			ScrollView {
+				content
+			}
+		}
+		.navigationBarTitle(
+			NSLocalizedString("Edit Info", comment: "Navigation bar title"),
+			displayMode: .inline
+		)
+		.navigationBarHidden(true)
+	}
+	
+	@ViewBuilder
+	var content: some View {
+		
+		VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
+			
+			Text("Description:")
+				.padding(.leading, 8)
+				.padding(.bottom, 4)
+			
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				TextField(defaultDescText, text: $descText)
+				
+				// Clear button (appears when TextField's text is non-empty)
+				Button {
+					descText = ""
+				} label: {
+					Image(systemName: "multiply.circle.fill")
+						.foregroundColor(.secondary)
+				}
+				.isHidden(descText == "")
+			}
+			.padding(.all, 8)
+			.overlay(
+				RoundedRectangle(cornerRadius: 8)
+					.stroke(Color(UIColor.separator), lineWidth: 1)
+			)
+			
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				Spacer()
+				
+				Text("\(remainingDescCount) remaining")
+					.font(.callout)
+					.foregroundColor(remainingDescCount >= 0 ? Color.secondary : Color.appNegative)
+			}
+			.padding([.leading, .trailing], 8)
+			.padding(.top, 4)
+			
+			Text("Notes:")
+				.padding(.top, 20)
+				.padding(.leading, 8)
+				.padding(.bottom, 4)
+				
+			TextEditor(text: $notesText)
+				.frame(minHeight: 80, maxHeight: 320)
+				.padding(.all, 8)
+				.overlay(
+					RoundedRectangle(cornerRadius: 8)
+						.stroke(Color(UIColor.separator), lineWidth: 1)
+				)
+			
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				Spacer()
+				
+				Text("\(remainingNotesCount) remaining")
+					.font(.callout)
+					.foregroundColor(remainingNotesCount >= 0 ? Color.secondary : Color.appNegative)
+			}
+			.padding([.leading, .trailing], 8)
+			.padding(.top, 4)
+		}
+		.padding(.top)
+		.padding([.leading, .trailing])
+		.onChange(of: descText) {
+			descTextDidChange($0)
+		}
+		.onChange(of: notesText) {
+			notesTextDidChange($0)
+		}
+	}
+	
+	func descTextDidChange(_ newText: String) {
+		log.trace("[\(viewName)] descTextDidChange()")
+		
+		remainingDescCount = maxDescCount - newText.count
+	}
+	
+	func notesTextDidChange(_ newText: String) {
+		log.trace("[\(viewName)] notesTextDidChange()")
+		
+		remainingNotesCount = maxNotesCount - newText.count
+	}
+	
+	func cancelButtonTapped() {
+		log.trace("[\(viewName)] cancelButtonTapped()")
+		
+		presentationMode.wrappedValue.dismiss()
+	}
+	
+	func saveButtonTapped() {
+		log.trace("[\(viewName)] saveButtonTapped()")
+		
+		let paymentId = paymentInfo.id()
+		var desc = descText.trimmingCharacters(in: .whitespacesAndNewlines)
+		
+		if desc.count > maxDescCount {
+			let endIdx = desc.index(desc.startIndex, offsetBy: maxDescCount)
+			let substr = desc[desc.startIndex ..< endIdx]
+			desc = String(substr)
+		}
+		
+		let newDesc = (desc == defaultDescText) ? nil : (desc.count == 0 ? nil : desc)
+		
+		var notes = notesText.trimmingCharacters(in: .whitespacesAndNewlines)
+		
+		if notes.count > maxNotesCount {
+			let endIdx = notes.index(notes.startIndex, offsetBy: maxNotesCount)
+			let substr = notes[notes.startIndex ..< endIdx]
+			notes = String(substr)
+		}
+		
+		let newNotes = notes.count == 0 ? nil : notes
+		
+		if (originalDescText != newDesc) || (originalNotesText != newNotes) {
+		
+			let business = AppDelegate.get().business
+			business.databaseManager.paymentsDb { (paymentsDb: SqlitePaymentsDb?, _) in
+				
+				paymentsDb?.updateMetadata(id: paymentId, userDescription: newDesc, userNotes: newNotes) { (_, err) in
+					
+					if let err = err {
+						log.error("paymentsDb.updateMetadata: \(String(describing: err))")
+					}
+				}
+			}
+		} else {
+			log.debug("[\(viewName)] no changes - nothing to save")
+		}
+		
+		presentationMode.wrappedValue.dismiss()
 	}
 }

--- a/phoenix-shared/src/androidMain/kotlin/fr/acinq/phoenix/db/SqlPaymentHooks.kt
+++ b/phoenix-shared/src/androidMain/kotlin/fr/acinq/phoenix/db/SqlPaymentHooks.kt
@@ -5,6 +5,8 @@ import fr.acinq.phoenix.db.payments.CloudKitInterface
 
 actual fun didCompleteWalletPayment(id: WalletPaymentId, database: PaymentsDatabase) {}
 
+actual fun didUpdateWalletPaymentMetadata(id: WalletPaymentId, database: PaymentsDatabase) {}
+
 actual fun makeCloudKitDb(database: PaymentsDatabase): CloudKitInterface? {
     return null
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/WalletPayment.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/WalletPayment.kt
@@ -99,8 +99,10 @@ data class WalletPaymentInfo(
  * Represents information from the `payments_metadata` table.
  */
 data class WalletPaymentMetadata(
-    val userDescription: String? = null,
     val lnurl: LnurlPayMetadata? = null,
+    val userDescription: String? = null,
+    val userNotes: String? = null,
+    val modifiedAt: Long? = null
 )
 
 data class LnurlPayMetadata(

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudAsset.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudAsset.kt
@@ -1,5 +1,6 @@
 package fr.acinq.phoenix.db.cloud
 
+import fr.acinq.lightning.utils.currentTimestampMillis
 import fr.acinq.phoenix.db.payments.LNUrlBase
 import fr.acinq.phoenix.db.payments.LNUrlMetadata
 import fr.acinq.phoenix.db.payments.LNUrlSuccessAction
@@ -23,7 +24,8 @@ data class CloudAsset(
     val lnurl_metadata: LNUrlMetadataWrapper?,
     val lnurl_successAction: LNUrlSuccessActionWrapper?,
     val lnurl_description: String?,
-    val user_description: String?
+    val user_description: String?,
+    val user_notes: String?,
 ) {
     @Serializable
     @OptIn(ExperimentalSerializationApi::class)
@@ -69,7 +71,8 @@ fun WalletPaymentMetadataRow.cloudSerialize(): ByteArray {
             CloudAsset.LNUrlSuccessActionWrapper(it.first.name, it.second)
         },
         lnurl_description = lnurl_description,
-        user_description = user_description
+        user_description = user_description,
+        user_notes = user_notes
     )
     return Cbor.encodeToByteArray(wrapper)
 }
@@ -77,7 +80,9 @@ fun WalletPaymentMetadataRow.cloudSerialize(): ByteArray {
 @OptIn(ExperimentalSerializationApi::class)
 fun CloudAsset.Companion.cloudDeserialize(blob: ByteArray): WalletPaymentMetadataRow? {
     val wrapper: CloudAsset = try {
-        Cbor.decodeFromByteArray(blob)
+        Cbor {
+            ignoreUnknownKeys = true
+        }.decodeFromByteArray(blob)
     } catch (e: Throwable) {
         return null
     }
@@ -93,6 +98,8 @@ fun CloudAsset.Companion.cloudDeserialize(blob: ByteArray): WalletPaymentMetadat
             Pair(it.typeVersion, it.blob)
         },
         lnurl_description = wrapper.lnurl_description,
-        user_description = wrapper.user_description
+        user_description = wrapper.user_description,
+        user_notes = wrapper.user_notes,
+        modified_at = currentTimestampMillis()
     )
 }

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/AggregatedQueries.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/AggregatedQueries.sq
@@ -81,26 +81,34 @@ LIMIT :limit OFFSET :offset;
 -- 17: completed_at                     payment completion timestamp
 
 listAllPaymentsOrder:
-SELECT *
+SELECT
+    combined_payments.type         AS type,
+    combined_payments.id           AS id,
+    combined_payments.created_at   AS created_at,
+    combined_payments.completed_at AS completed_at,
+    payments_metadata.modified_at  AS metadata_modified_at
 FROM (
     SELECT
-        'outgoing'              AS direction,
-        id                      AS outgoing_payment_id,
-        NULL                    AS incoming_payment_id,
-        created_at              AS created_at,
-        completed_at            AS completed_at
+        2            AS type,
+        id           AS id,
+        created_at   AS created_at,
+        completed_at AS completed_at
     FROM outgoing_payments
 UNION ALL
     SELECT
-        'incoming'              AS direction,
-        NULL                    AS outgoing_payment_id,
-        payment_hash            AS incoming_payment_id,
-        created_at              AS created_at,
-        received_at             AS completed_at
+        1                        AS type,
+        lower(hex(payment_hash)) AS id,
+        created_at               AS created_at,
+        received_at              AS completed_at
     FROM incoming_payments
-    WHERE received_at IS NOT NULL
-)
-ORDER BY COALESCE(completed_at, created_at) DESC
+    WHERE incoming_payments.received_at IS NOT NULL
+ORDER BY created_at DESC
+-- ^^^^^ Within a UNION ALL statement, the ORDER BY clause is applied to
+-- the combined result set, not within the individual result set.
+) combined_payments
+LEFT OUTER JOIN payments_metadata ON
+    payments_metadata.type = combined_payments.type AND
+    payments_metadata.id = combined_payments.id
 LIMIT :limit OFFSET :offset;
 
 listAllPaymentsCount:

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/IncomingPayments.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/IncomingPayments.sq
@@ -17,7 +17,11 @@ CREATE TABLE IF NOT EXISTS incoming_payments (
     received_with_blob BLOB DEFAULT NULL
 );
 
--- The received_amount_msat column is used regularly as a filter within AggragateQueries.
+-- The created_at column is used by AggregatedQueries.listAllPaymentsOrder for sorting.
+-- And that query is used constantly by the app.
+CREATE INDEX IF NOT EXISTS incoming_payments_created_at_idx ON incoming_payments(created_at);
+
+-- The received_amount_msat column is used regularly as a filter within AggregatedQueries.
 CREATE INDEX IF NOT EXISTS received_amount_msat_idx ON incoming_payments(received_amount_msat);
 
 -- queries

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/OutgoingPayments.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/OutgoingPayments.sq
@@ -23,6 +23,10 @@ CREATE TABLE IF NOT EXISTS outgoing_payments (
     status_blob BLOB DEFAULT NULL
 );
 
+-- The created_at column is used by AggregatedQueries.listAllPaymentsOrder for sorting.
+-- And that query is used constantly by the app.
+CREATE INDEX IF NOT EXISTS outgoing_payments_created_at_idx ON outgoing_payments(created_at);
+
 CREATE TABLE IF NOT EXISTS outgoing_payment_parts (
     part_id TEXT NOT NULL PRIMARY KEY,
     part_parent_id TEXT NOT NULL,

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/PaymentsMetadata.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/PaymentsMetadata.sq
@@ -17,6 +17,8 @@ CREATE TABLE IF NOT EXISTS payments_metadata (
     lnurl_successAction_type TEXT AS LNUrlSuccessAction.TypeVersion,
     lnurl_successAction_blob BLOB,
     user_description TEXT,
+    user_notes TEXT DEFAULT NULL,
+    modified_at INTEGER DEFAULT NULL,
     PRIMARY KEY (type, id)
 );
 
@@ -32,12 +34,15 @@ INSERT INTO payments_metadata (
             lnurl_description,
             lnurl_metadata_type, lnurl_metadata_blob,
             lnurl_successAction_type, lnurl_successAction_blob,
-            user_description)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            user_description, user_notes,
+            modified_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
-updateUserDescription:
+updateUserInfo:
 UPDATE payments_metadata
-SET    user_description = ?
+SET    user_description = ?,
+       user_notes = ?,
+       modified_at = ?
 WHERE  type = ? AND id = ?;
 
 fetchDescriptions:
@@ -49,3 +54,7 @@ WHERE  type = ? AND id = ?;
 fetchMetadata:
 SELECT * FROM payments_metadata
 WHERE type = ? AND id = ?;
+
+-- use this in a `transaction` block to know how many rows were changed after an UPDATE
+changes:
+SELECT changes();

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/3.sqm
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/3.sqm
@@ -1,0 +1,12 @@
+-- Migration: v3 -> v4
+--
+-- Changes:
+-- * Added column: payments_metadata.user_notes
+-- * Added column: payments_metadata.modified_at
+-- * Added indexes to improve performance of listAllPaymentsOrder query
+
+ALTER TABLE payments_metadata ADD COLUMN user_notes TEXT DEFAULT NULL;
+ALTER TABLE payments_metadata ADD COLUMN modified_at INTEGER DEFAULT NULL;
+
+CREATE INDEX IF NOT EXISTS incoming_payments_created_at_idx ON incoming_payments(created_at);
+CREATE INDEX IF NOT EXISTS outgoing_payments_created_at_idx ON outgoing_payments(created_at);

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/CloudKitDb.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/CloudKitDb.kt
@@ -446,7 +446,9 @@ class CloudKitDb(
                             lnurl_successAction_type = row.lnurl_successAction?.first,
                             lnurl_successAction_blob = row.lnurl_successAction?.second,
                             lnurl_description = row.lnurl_description,
-                            user_description = row.user_description
+                            user_description = row.user_description,
+                            user_notes = row.user_notes,
+                            modified_at = row.modified_at
                         )
                     }
                 } // </payments_metadata table>

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/SqlPaymentHooks.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/SqlPaymentHooks.kt
@@ -7,9 +7,19 @@ import fracinqphoenixdb.Cloudkit_payments_queue
 
 
 actual fun didCompleteWalletPayment(id: WalletPaymentId, database: PaymentsDatabase) {
-    val now = currentTimestampMillis()
-    val ckq = database.cloudKitPaymentsQueries
-    ckq.addToQueue(type = id.dbType.value, id = id.dbId, date_added = now)
+    database.cloudKitPaymentsQueries.addToQueue(
+        type = id.dbType.value,
+        id = id.dbId,
+        date_added = currentTimestampMillis()
+    )
+}
+
+actual fun didUpdateWalletPaymentMetadata(id: WalletPaymentId, database: PaymentsDatabase) {
+    database.cloudKitPaymentsQueries.addToQueue(
+        type = id.dbType.value,
+        id = id.dbId,
+        date_added = currentTimestampMillis()
+    )
 }
 
 actual fun makeCloudKitDb(database: PaymentsDatabase): CloudKitInterface? {


### PR DESCRIPTION
<img height="600" src="https://user-images.githubusercontent.com/304604/138321118-11fe71f3-f05f-4384-a033-332ef57b726a.png">

<img height="600" src="https://user-images.githubusercontent.com/304604/138321293-3083a530-949e-438a-9dcf-810fe7ab4c0e.png">

#### Major changes:

The `payments_metadata` table now has both:

- user_description
- user_notes

These are modified according to user actions. And are part of the metadata that gets synced to the cloud (if cloud backup is enabled).

There's a new `expect/actual` function that gets called when these fields are modified, which allows us to queue the os-specific sync stuff.

The real problem we encountered was, when the `payments_metadata` table is updated, it didn't trigger updates in other parts of the app. Because most everything else was using the `listAllPaymentsOrderFlow`. So that's been modified too (see `AggragatedQueries.sq`), with the end result being that we can update the `payments_metadata.modified_at` column, and it will trigger the associated updates throughout the app.

Because of the increased complexity within the query, I ran [EXPLAIN QUERY PLAN](https://sqlite.org/eqp.html) on a couple different versions of the query, and ended up adding a few indexes.


