### PR TITLE
Fix for issue #217

### DIFF
--- a/phoenix-ios/phoenix-ios/kotlin/KotlinTypes.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinTypes.swift
@@ -43,6 +43,7 @@ extension Scan {
 	
 	typealias Intent_LnurlAuthFlow_Login = IntentLnurlAuthFlowLogin
 	
+	typealias LNUrlPay_Error = LNUrlPayError
 	typealias LNUrlPay_Error_RemoteError = LNUrlPayErrorRemoteError
 	typealias LNUrlPay_Error_BadResponseError = LNUrlPayErrorBadResponseError
 	typealias LNUrlPay_Error_ChainMismatch = LNUrlPayErrorChainMismatch
@@ -71,4 +72,10 @@ extension LNUrl {
 	typealias Error_RemoteFailure_Detailed = ErrorRemoteFailureDetailed
 	typealias Error_RemoteFailure_Unreadable = ErrorRemoteFailureUnreadable
 	typealias Error_RemoteFailure_CouldNotConnect = ErrorRemoteFailureCouldNotConnect
+	
+	typealias Error_PayInvoice = ErrorPayInvoice
+	typealias Error_PayInvoice_InvalidAmount = ErrorPayInvoiceInvalidAmount
+	typealias Error_PayInvoice_InvalidHash = ErrorPayInvoiceInvalidHash
+	typealias Error_PayInvoice_Malformed = ErrorPayInvoiceMalformed
+	
 }

--- a/phoenix-ios/phoenix-ios/views/SendView.swift
+++ b/phoenix-ios/phoenix-ios/views/SendView.swift
@@ -2059,7 +2059,7 @@ struct CommentSheet: View, ViewName {
 
 struct LnurlPayErrorNotice: View, ViewName {
 	
-	let error: Scan.LNUrlPayError
+	let error: Scan.LNUrlPay_Error
 	
 	@Environment(\.popoverState) var popoverState: PopoverState
 	
@@ -2115,19 +2115,19 @@ struct LnurlPayErrorNotice: View, ViewName {
 			
 			if let err = error as? Scan.LNUrlPay_Error_RemoteError {
 				
-				if let _ = err.err as? LNUrl.ErrorRemoteFailureCouldNotConnect {
+				if let _ = err.err as? LNUrl.Error_RemoteFailure_CouldNotConnect {
 					
 					Text("Could not connect to host:")
 					Text(err.err.origin)
 						.font(.system(.subheadline, design: .monospaced))
 				
-				} else if let details = err.err as? LNUrl.ErrorRemoteFailureCode {
+				} else if let details = err.err as? LNUrl.Error_RemoteFailure_Code {
 					
 					Text("Host returned status code \(details.code.value):")
 				 	Text(err.err.origin)
 						.font(.system(.subheadline, design: .monospaced))
 				 
-				} else if let details = err.err as? LNUrl.ErrorRemoteFailureDetailed {
+				} else if let details = err.err as? LNUrl.Error_RemoteFailure_Detailed {
 				
 					Text("Host returned error response.")
 					Text("Host: \(details.origin)")
@@ -2135,7 +2135,7 @@ struct LnurlPayErrorNotice: View, ViewName {
 					Text("Error: \(details.reason)")
 						.font(.system(.subheadline, design: .monospaced))
 			 
-				} else if let _ = err.err as? LNUrl.ErrorRemoteFailureUnreadable {
+				} else if let _ = err.err as? LNUrl.Error_RemoteFailure_Unreadable {
 				
 					Text("Host returned unreadable response:", comment: "error details")
 				 	Text(err.err.origin)
@@ -2147,28 +2147,21 @@ struct LnurlPayErrorNotice: View, ViewName {
 				
 			} else if let err = error as? Scan.LNUrlPay_Error_BadResponseError {
 				
-				if let details = err.err as? LNUrl.ErrorPayInvoiceMissingPr {
+				if let details = err.err as? LNUrl.Error_PayInvoice_Malformed {
 					
 					Text("Host: \(details.origin)")
 						.font(.system(.subheadline, design: .monospaced))
-					Text("Error: missing payment request")
+					Text("Malformed: \(details.context)")
 						.font(.system(.subheadline, design: .monospaced))
 					
-				} else if let details = err.err as? LNUrl.ErrorPayInvoiceMalformedPr {
-					
-					Text("Host: \(details.origin)")
-						.font(.system(.subheadline, design: .monospaced))
-					Text("Error: malformed payment request")
-						.font(.system(.subheadline, design: .monospaced))
-					
-				} else if let details = err.err as? LNUrl.ErrorPayInvoiceInvalidHash {
+				} else if let details = err.err as? LNUrl.Error_PayInvoice_InvalidHash {
 					
 					Text("Host: \(details.origin)")
 						.font(.system(.subheadline, design: .monospaced))
 					Text("Error: invalid hash")
 						.font(.system(.subheadline, design: .monospaced))
 					
-				} else if let details = err.err as? LNUrl.ErrorPayInvoiceInvalidAmount {
+				} else if let details = err.err as? LNUrl.Error_PayInvoice_InvalidAmount {
 				 
 					Text("Host: \(details.origin)")
 						.font(.system(.subheadline, design: .monospaced))
@@ -2204,20 +2197,20 @@ struct LnurlPayErrorNotice: View, ViewName {
 	
 	func title() -> String {
 		
-		if let err = error as? Scan.LNUrlPayErrorRemoteError {
-			if err.err is LNUrl.ErrorRemoteFailureCouldNotConnect {
+		if let err = error as? Scan.LNUrlPay_Error_RemoteError {
+			if err.err is LNUrl.Error_RemoteFailure_CouldNotConnect {
 				return NSLocalizedString("Connection failure", comment: "Error title")
 			} else {
 				return NSLocalizedString("Invalid response", comment: "Error title")
 			}
 			
-		} else if let _ = error as? Scan.LNUrlPayErrorBadResponseError {
+		} else if let _ = error as? Scan.LNUrlPay_Error_BadResponseError {
 			return NSLocalizedString("Invalid response", comment: "Error title")
 			
-		} else if let _ = error as? Scan.LNUrlPayErrorChainMismatch {
+		} else if let _ = error as? Scan.LNUrlPay_Error_ChainMismatch {
 			return NSLocalizedString("Chain mismatch", comment: "Error title")
 			
-		} else if let _ = error as? Scan.LNUrlPayErrorAlreadyPaidInvoice {
+		} else if let _ = error as? Scan.LNUrlPay_Error_AlreadyPaidInvoice {
 			return NSLocalizedString("Already paid", comment: "Error title")
 			
 		} else {


### PR DESCRIPTION
The LNURL response was:
```json
{"pr":"lnbc1...","routes":[],"successAction":null}
```

This line threw an unexpected exception:
```kotlin
val obj = json["successAction"]?.jsonObject ?: return null
```
Because `jsonObject` request throws `IllegalArgumentException` if it encounters `JsonNull`. Fix:
```
val obj = try {
    json["successAction"]?.jsonObject // throws on Non-JsonObject (e.g. JsonNull)
} catch (t: Throwable) { null } ?: return null
```

I also improved the quality of the error messages while debugging this. So instead of "please try again", it should say something like: "malformed: successAction.message: bad length", which should help fellow developers who are testing with Phoenix.