### PR TITLE
Allows user to configure the maximum fee

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val lightningKmp = "1.2.0"
+    const val lightningKmp = "1.3.0-SNAPSHOT"
     const val secp256k1 = "0.6.0"
 
     const val kotlin = "1.5.31"

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		DC27E4CB2791D17A00C777CC /* RecoveryPhraseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC27E4C92791D17A00C777CC /* RecoveryPhraseView.swift */; };
 		DC27E4CC2791D17A00C777CC /* CloudBackupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC27E4CA2791D17A00C777CC /* CloudBackupView.swift */; };
 		DC27E4CF2792079600C777CC /* CenterTopLineAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC27E4CE2792079500C777CC /* CenterTopLineAlignment.swift */; };
+		DC27E4D1279753EC00C777CC /* TextFieldNumberParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC27E4D0279753EC00C777CC /* TextFieldNumberParser.swift */; };
 		DC2CFA93273C7874007AACB9 /* Currencies.strings in Resources */ = {isa = PBXBuildFile; fileRef = DC2CFA91273C7874007AACB9 /* Currencies.strings */; };
 		DC33369826BAF721000E3F49 /* ShortSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC33369726BAF721000E3F49 /* ShortSheet.swift */; };
 		DC34399F276CEFB600CAA73A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7555FF84242A565B00829871 /* Assets.xcassets */; };
@@ -229,6 +230,7 @@
 		DC27E4C92791D17A00C777CC /* RecoveryPhraseView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoveryPhraseView.swift; sourceTree = "<group>"; };
 		DC27E4CA2791D17A00C777CC /* CloudBackupView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudBackupView.swift; sourceTree = "<group>"; };
 		DC27E4CE2792079500C777CC /* CenterTopLineAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterTopLineAlignment.swift; sourceTree = "<group>"; };
+		DC27E4D0279753EC00C777CC /* TextFieldNumberParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldNumberParser.swift; sourceTree = "<group>"; };
 		DC2CFA92273C7874007AACB9 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Currencies.strings; sourceTree = "<group>"; };
 		DC33369726BAF721000E3F49 /* ShortSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortSheet.swift; sourceTree = "<group>"; };
 		DC384D7C265BE41900131772 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = fr; path = fr.lproj/about.html; sourceTree = "<group>"; };
@@ -561,6 +563,7 @@
 				DCD5FF4226A0D34B009CC666 /* EqualSizes.swift */,
 				DCCC7FD426B0A006008ACD9B /* SquareSize.swift */,
 				DCAEF8F4276131A600015993 /* CheckboxToggleStyle.swift */,
+				DC27E4D0279753EC00C777CC /* TextFieldNumberParser.swift */,
 			);
 			path = style;
 			sourceTree = "<group>";
@@ -1019,6 +1022,7 @@
 				DC71E7332728645B0063613D /* CurrencyConverterView.swift in Sources */,
 				DCACF6F02566D0A60009B01E /* Data+Hexadecimal.swift in Sources */,
 				DCACF7092566D0F00009B01E /* AppAccessView.swift in Sources */,
+				DC27E4D1279753EC00C777CC /* TextFieldNumberParser.swift in Sources */,
 				F4AED297257A50CD009485C1 /* LogsConfigurationViewerView.swift in Sources */,
 				DCD5FF4326A0D34B009CC666 /* EqualSizes.swift in Sources */,
 				F4AED298257A50CD009485C1 /* LogsConfigurationView.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/utils/Prefs+Codable.swift
+++ b/phoenix-ios/phoenix-ios/utils/Prefs+Codable.swift
@@ -64,3 +64,22 @@ struct ElectrumConfigPrefs: Codable {
 		return Lightning_kmpServerAddress(host: host, port: Int32(port), tls: Lightning_kmpTcpSocketTLS.safe)
 	}
 }
+
+struct MaxFees: Codable {
+	let feeBaseSat: Int64
+	let feeProportionalMillionths: Int64
+	
+	static func fromTrampolineFees(_ fees: Lightning_kmpTrampolineFees) -> MaxFees {
+		return MaxFees(
+			feeBaseSat: fees.feeBase.sat,
+			feeProportionalMillionths: fees.feeProportional
+		)
+	}
+	
+	func toKotlin() -> PhoenixShared.MaxFees {
+		return PhoenixShared.MaxFees(
+			feeBase: Bitcoin_kmpSatoshi(sat: self.feeBaseSat),
+			feeProportionalMillionths: self.feeProportionalMillionths
+		)
+	}
+}

--- a/phoenix-ios/phoenix-ios/utils/Prefs.swift
+++ b/phoenix-ios/phoenix-ios/utils/Prefs.swift
@@ -44,6 +44,7 @@ class Prefs {
 		case manualBackup_taskDone
 		case isNewWallet
 		case invoiceExpirationDays
+		case maxFees
 	}
 	
 	public static let shared = Prefs()
@@ -203,6 +204,25 @@ class Prefs {
 		}
 		set {
 			UserDefaults.standard.set(newValue, forKey: Keys.invoiceExpirationDays.rawValue)
+		}
+	}
+	
+	lazy private(set) var maxFeesPublisher: CurrentValueSubject<MaxFees?, Never> = {
+		let currentValue = self.maxFees
+		return CurrentValueSubject<MaxFees?, Never>(currentValue)
+	}()
+	
+	var maxFees: MaxFees? {
+		get {
+			let key = Keys.maxFees.rawValue
+			let result: MaxFees? = UserDefaults.standard.getCodable(forKey: key)
+			return result
+		}
+		set {
+			let key = Keys.maxFees.rawValue
+			UserDefaults.standard.setCodable(value: newValue, forKey: key)
+			log.debug("Prefs.maxFees: \(String(describing: newValue))")
+			maxFeesPublisher.send(newValue)
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/SendView.swift
+++ b/phoenix-ios/phoenix-ios/views/SendView.swift
@@ -1700,7 +1700,8 @@ struct ValidateView: View, ViewName {
 				saveTipPercentInPrefs()
 				mvi.intent(Scan.Intent_InvoiceFlow_SendInvoicePayment(
 					paymentRequest: model.paymentRequest,
-					amount: Lightning_kmpMilliSatoshi(msat: msat)
+					amount: Lightning_kmpMilliSatoshi(msat: msat),
+					maxFees: Prefs.shared.maxFees?.toKotlin()
 				))
 			}
 			
@@ -1732,6 +1733,7 @@ struct ValidateView: View, ViewName {
 				mvi.intent(Scan.Intent_LnurlPayFlow_SendLnurlPayment(
 					lnurlPay: model.lnurlPay,
 					amount: Lightning_kmpMilliSatoshi(msat: msat),
+					maxFees: Prefs.shared.maxFees?.toKotlin(),
 					comment: comment
 				))
 			}

--- a/phoenix-ios/phoenix-ios/views/configuration/general/PaymentOptionsView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/general/PaymentOptionsView.swift
@@ -18,12 +18,16 @@ struct PaymentOptionsView: View {
 	
 	@State var invoiceExpirationDays: Int = Prefs.shared.invoiceExpirationDays
 	let invoiceExpirationDaysOptions = [7, 30, 60]
+
+	@State var userDefinedMaxFees: MaxFees? = Prefs.shared.maxFees
 	
 	@State var payToOpen_feePercent: Double = 0.0
 	@State var payToOpen_minFeeSat: Int64 = 0
 	
 	@Environment(\.openURL) var openURL
+	@Environment(\.shortSheetState) var shortSheetState: ShortSheetState
 	
+	let maxFeesPublisher = Prefs.shared.maxFeesPublisher
 	let chainContextPublisher = AppDelegate.get().business.appConfigurationManager.chainContextPublisher()
 	
 	var body: some View {
@@ -86,6 +90,22 @@ struct PaymentOptionsView: View {
 				.padding([.top, .bottom], 8)
 				
 			} // </Section>
+
+			Section {
+				VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
+					Text("Maximum fee for outgoing Lightning payments")
+						.padding(.bottom, 8)
+					
+					Button {
+						showMaxFeeSheet()
+					} label: {
+						Text(maxFeesString())
+					}
+					
+				} // </VStack>
+				.padding([.top, .bottom], 8)
+				
+			} // </Section>
 			
 			Section {
 				VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
@@ -132,9 +152,22 @@ struct PaymentOptionsView: View {
 		} // </List>
 		.listStyle(.insetGrouped)
 		.navigationBarTitle(NSLocalizedString("Payment Options", comment: "Navigation Bar Title"))
+		.onReceive(maxFeesPublisher) {
+			maxFeesChanged($0)
+		}
 		.onReceive(chainContextPublisher) {
 			chainContextChanged($0)
 		}
+	}
+	
+	func maxFeesString() -> String {
+		
+		let currentFees = userDefinedMaxFees ?? defaultMaxFees()
+		
+		let base = Utils.formatBitcoin(sat: currentFees.feeBaseSat, bitcoinUnit: .sat)
+		let proportional = formatProportionalFee(currentFees.feeProportionalMillionths)
+		
+		return "\(base.string) + \(proportional)%"
 	}
 	
 	func formatFeePercent() -> String {
@@ -158,6 +191,14 @@ struct PaymentOptionsView: View {
 		Prefs.shared.invoiceExpirationDays = self.invoiceExpirationDays
 	}
 	
+	func showMaxFeeSheet() {
+		log.trace("showMaxFeeSheet()")
+		
+		shortSheetState.display(dismissable: false) {
+			MaxFeeConfiguration()
+		}
+	}
+	
 	func openFaqButtonTapped() -> Void {
 		log.trace("openFaqButtonTapped()")
 		
@@ -166,12 +207,291 @@ struct PaymentOptionsView: View {
 		}
 	}
 	
-	func chainContextChanged(_ context: WalletContext.V0ChainContext) -> Void {
+	func maxFeesChanged(_ newMaxFees: MaxFees?) {
+		log.trace("maxFeesChanged()")
+		
+		userDefinedMaxFees = newMaxFees
+	}
+	
+	func chainContextChanged(_ context: WalletContext.V0ChainContext) {
 		log.trace("chainContextChanged()")
 		
 		payToOpen_feePercent = context.payToOpen.v1.feePercent * 100 // 0.01 => 1%
 		payToOpen_minFeeSat = context.payToOpen.v1.minFeeSat
 	}
+}
+
+struct MaxFeeConfiguration: View, ViewName {
+	
+	@State var baseFee: String = ""
+	@State var parsedBaseFee: Result<Double, TextFieldCurrencyStylerError> = Result.failure(.emptyInput)
+	@State var isInvalidBaseFee: Bool = false
+	
+	@State var proportionalFee: String = ""
+	@State var parsedProportionalFee: Result<NSNumber, TextFieldNumberParserError> = Result.failure(.emptyInput)
+	@State var isInvalidProportionalFee: Bool = false
+	
+	@Environment(\.shortSheetState) var shortSheetState: ShortSheetState
+	
+	@ViewBuilder
+	var body: some View {
+		
+		VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
+			
+			Text("Base fee (satoshis)")
+				.padding(.leading, 8)
+				.padding(.bottom, 6)
+			
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				TextField(
+					defaultBaseFee(),
+					text: currencyStyler().amountProxy
+				)
+				.keyboardType(.decimalPad)
+				.disableAutocorrection(true)
+				.foregroundColor(isInvalidBaseFee ? Color.appNegative : Color.primaryForeground)
+				.padding([.top, .bottom], 8)
+				.padding([.leading, .trailing], 16)
+				
+				// Clear button (appears when TextField's text is non-empty)
+				Button {
+					clearBaseFee()
+				} label: {
+					Image(systemName: "multiply.circle.fill")
+						.foregroundColor(.secondary)
+				}
+				.isHidden(baseFee == "")
+				.padding(.trailing, 8)
+			}
+			.overlay(
+				RoundedRectangle(cornerRadius: 8)
+					.stroke(Color(UIColor.separator), lineWidth: 1)
+			)
+			.padding(.bottom)
+			
+			Text("Proportional fee (%)")
+				.padding(.leading, 8)
+				.padding(.bottom, 6)
+			
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				TextField(
+					defaultProportionalFee(),
+					text: percentParser().amountProxy
+				)
+				.keyboardType(.decimalPad)
+				.disableAutocorrection(true)
+				.foregroundColor(isInvalidProportionalFee ? Color.appNegative : Color.primaryForeground)
+				.padding([.top, .bottom], 8)
+				.padding([.leading, .trailing], 16)
+				
+				// Clear button (appears when TextField's text is non-empty)
+				Button {
+					clearProportionalFee()
+				} label: {
+					Image(systemName: "multiply.circle.fill")
+						.foregroundColor(.secondary)
+				}
+				.isHidden(proportionalFee == "")
+				.padding(.trailing, 8)
+			}
+			.overlay(
+				RoundedRectangle(cornerRadius: 8)
+					.stroke(Color(UIColor.separator), lineWidth: 1)
+			)
+			.padding(.bottom)
+			
+			HStack {
+				Spacer()
+				
+				Button("Cancel") {
+					didTapCancelButton()
+				}
+				.padding(.trailing)
+				
+				Button("Save") {
+					didTapSaveButton()
+				}
+				.disabled(isInvalidBaseFee || isInvalidProportionalFee)
+			}
+			.font(.title2)
+		}
+		.padding()
+		.onAppear {
+			onAppear()
+		}
+		.onChange(of: baseFee) { _ in
+			baseFeeDidChange()
+		}
+		.onChange(of: proportionalFee) { _ in
+			proportionalFeeDidChange()
+		}
+	}
+	
+	func defaultBaseFee() -> String {
+		
+		let fees = defaultMaxFees()
+		let formatted = Utils.formatBitcoin(sat: fees.feeBaseSat, bitcoinUnit: .sat)
+		return formatted.digits
+	}
+	
+	func defaultProportionalFee() -> String {
+		
+		let fees = defaultMaxFees()
+		return formatProportionalFee(fees.feeProportionalMillionths)
+	}
+	
+	func currencyStyler() -> TextFieldCurrencyStyler {
+		return TextFieldCurrencyStyler(
+			currency: Currency.bitcoin(.sat),
+			amount: $baseFee,
+			parsedAmount: $parsedBaseFee,
+			hideMsats: false
+		)
+	}
+	
+	func percentParser() -> TextFieldNumberParser {
+		return TextFieldNumberParser(
+			formatter: NumberFormatter(),
+			amount: $proportionalFee,
+			parsedAmount: $parsedProportionalFee
+		)
+	}
+	
+	func onAppear() {
+		log.trace("[\(viewName)] onAppear()")
+		
+		if let maxFees = Prefs.shared.maxFees {
+			
+			let feeBaseFormatted = Utils.formatBitcoin(sat: maxFees.feeBaseSat, bitcoinUnit: .sat)
+			parsedBaseFee = Result.success(Double(maxFees.feeBaseSat))
+			baseFee = feeBaseFormatted.digits
+			
+			let percent = Double(maxFees.feeProportionalMillionths) / Double(1_000_000)
+			parsedProportionalFee = Result.success(NSNumber(value: percent))
+			proportionalFee = formatProportionalFee(maxFees.feeProportionalMillionths)
+		}
+	}
+	
+	func baseFeeDidChange() {
+		log.trace("[\(viewName)] baseFeeDidChange()")
+		
+		switch parsedBaseFee {
+		case .failure:
+			if baseFee.isEmpty {
+				isInvalidBaseFee = false // user choosing default value
+			} else {
+				isInvalidBaseFee = true
+			}
+		case .success:
+			isInvalidBaseFee = false
+		}
+	}
+	
+	func proportionalFeeDidChange() {
+		log.trace("[\(viewName)] proportionalFeeDidChange()")
+		
+		switch parsedProportionalFee {
+		case .failure:
+			if proportionalFee.isEmpty {
+				isInvalidProportionalFee = false // user choosing default value
+			} else {
+				isInvalidProportionalFee = true
+			}
+		case .success:
+			isInvalidProportionalFee = false
+		}
+	}
+	
+	func clearBaseFee() {
+		log.trace("[\(viewName)] clearBaseFee()")
+		
+		parsedBaseFee = .failure(.emptyInput)
+		baseFee = ""
+	}
+	
+	func clearProportionalFee() {
+		log.trace("[\(viewName)] clearProportionalFee()")
+		
+		parsedProportionalFee = .failure(.emptyInput)
+		proportionalFee = ""
+	}
+	
+	func didTapCancelButton() {
+		log.trace("[\(viewName)] didTapCancelButton()")
+		
+		shortSheetState.close()
+	}
+	
+	func didTapSaveButton() {
+		log.trace("[\(viewName)] didTapSaveButton()")
+		
+		// Reminder: Our state variables:
+		//
+		// parsedBaseFee: Result<Double, TextFieldCurrencyStylerError>
+		// parsedProportionalFee: Result<NSNumber, TextFieldNumberParserError>
+		
+		var shouldSave = false
+		
+		var newBaseFee_sat: Int64? = nil
+		var newProportionalFee_millionths: Int64? = nil
+		
+		if let newBaseFee_double = try? parsedBaseFee.get(), newBaseFee_double > 0 {
+			
+			newBaseFee_sat = Int64(newBaseFee_double)
+			shouldSave = true
+		}
+		if let newProportionalFee_number = try? parsedProportionalFee.get() {
+			let newProportionalFee_double = newProportionalFee_number.doubleValue
+			if newProportionalFee_double > 0 {
+				
+				// Example:
+				// newProportionalFee_double: 0.5 <- is a a percent, i.e. 0.5%
+				// toNumber: 0.5 / 100 = 0.005
+				// toMillionths: 0.005 * 1,000,000 = 5,000
+				//
+				// Or, to simplify:
+				// toMillionths: 0.5 * 10,000 = 5,000
+				
+				newProportionalFee_millionths = Int64(newProportionalFee_double * Double(10_000))
+				shouldSave = true
+			}
+		}
+		
+		if shouldSave {
+			let defaults = defaultMaxFees()
+			Prefs.shared.maxFees = MaxFees(
+				feeBaseSat: newBaseFee_sat ?? defaults.feeBaseSat,
+				feeProportionalMillionths: newProportionalFee_millionths ?? defaults.feeProportionalMillionths
+			)
+		} else {
+			Prefs.shared.maxFees = nil
+		}
+		
+		shortSheetState.close()
+	}
+}
+
+fileprivate func defaultMaxFees() -> MaxFees {
+	
+	let peer = AppDelegate.get().business.getPeer()
+	if let defaultMaxFees = peer?.walletParams.trampolineFees.last {
+		return MaxFees.fromTrampolineFees(defaultMaxFees)
+	} else {
+		return MaxFees(feeBaseSat: 0, feeProportionalMillionths: 0)
+	}
+}
+
+fileprivate func formatProportionalFee(_ feeProportionalMillionths: Int64) -> String {
+	
+	let percent = Double(feeProportionalMillionths) / Double(1_000_000)
+	
+	let formatter = NumberFormatter()
+	formatter.numberStyle = .percent
+	formatter.percentSymbol = ""
+	formatter.paddingCharacter = ""
+	formatter.minimumFractionDigits = 2
+	
+	return formatter.string(from: NSNumber(value: percent))!
 }
 
 class PaymentOptionsView_Previews: PreviewProvider {

--- a/phoenix-ios/phoenix-ios/views/style/TextFieldCurrencyStyler.swift
+++ b/phoenix-ios/phoenix-ios/views/style/TextFieldCurrencyStyler.swift
@@ -41,8 +41,6 @@ enum TextFieldCurrencyStylerError: Error {
 /// }
 /// ```
 ///
-/// For changed, you can list
-///
 struct TextFieldCurrencyStyler {
 	
 	private let currency: Currency
@@ -84,6 +82,17 @@ struct TextFieldCurrencyStyler {
 		)
 	}
 	
+	/**
+	 * Attempts to format the given input, and returns a tuple containing the results.
+	 * On success, the tuple is:
+	 *   (formattedString, Result.success(parsedNumber))
+	 * On failure, the tuple is:
+	 *   (originalInput, Result.failure(reason))
+	 *
+	 * Note:
+	 * - The `Utils` class can be used to convert from number to formattedString.
+	 * - This class can be used to convert from string to (formattedString, parsedNumber)
+	 */
 	static func format(
 		input: String,
 		currency: Currency,

--- a/phoenix-ios/phoenix-ios/views/style/TextFieldNumberParser.swift
+++ b/phoenix-ios/phoenix-ios/views/style/TextFieldNumberParser.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import os.log
+
+#if DEBUG && false
+fileprivate var log = Logger(
+	subsystem: Bundle.main.bundleIdentifier!,
+	category: "TextFieldNumberParser"
+)
+#else
+fileprivate var log = Logger(OSLog.disabled)
+#endif
+
+enum TextFieldNumberParserError: Error {
+	case emptyInput
+	case invalidInput
+}
+
+/// This tool provides a binding for TextField's,
+/// allowing the value to be parsed **while typing**.
+///
+/// To use:
+/// - create an instance of TextFieldNumberParser within your ViewBuilder code
+/// - create TextField using the styler's `amountProxy`
+///
+/// ```
+/// let formatter: NumberFormatter
+/// @State var amount String
+/// @State var parsedAmount: Result<NSNumber, TextFieldPercentParserError>
+///
+/// var body: some View {
+///   let parser = TextFieldNumberParser(formatter: formatter, amount: $amount, parsedAmount: $parsedAmount)
+///   TextField("percent", text: parser.amountProxy)
+///       .onChange(of: amount) { _ in
+///           // new values for amount & parsedAmount available now
+///       }
+/// }
+/// ```
+///
+struct TextFieldNumberParser {
+	
+	let formatter: NumberFormatter
+	@Binding private var amount: String
+	@Binding private var parsedAmount: Result<NSNumber, TextFieldNumberParserError>
+	
+	init(
+		formatter: NumberFormatter,
+		amount: Binding<String>,
+		parsedAmount: Binding<Result<NSNumber, TextFieldNumberParserError>>
+	) {
+		self.formatter = formatter
+		self._amount = amount
+		self._parsedAmount = parsedAmount
+	}
+	
+	var amountProxy: Binding<String> {
+		
+		Binding<String>(
+			get: {
+				log.debug("<- get: \"\(self.amount)\"")
+				return self.amount
+			},
+			set: { (input: String) in
+				log.debug("-> set")
+				self.parsedAmount = TextFieldNumberParser.parse(input: input, formatter: formatter)
+				self.amount = input // contract: always change parsedAmount before amount
+			}
+		)
+	}
+	
+	static func parse(
+		input: String,
+		formatter: NumberFormatter
+	) -> Result<NSNumber, TextFieldNumberParserError>
+	{
+		let trimmedInput = input.trimmingCharacters(in: CharacterSet.whitespaces)
+		if trimmedInput.isEmpty {
+			return Result.failure(.emptyInput)
+		}
+		
+		if let number = formatter.number(from: input) {
+			return Result.success(number)
+		} else {
+			return Result.failure(.invalidInput)
+		}
+	}
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/Scan.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/Scan.kt
@@ -1,13 +1,18 @@
 package fr.acinq.phoenix.controllers.payments
 
+import fr.acinq.bitcoin.Satoshi
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.payment.PaymentRequest
 import fr.acinq.phoenix.data.Chain
 import fr.acinq.phoenix.controllers.MVI
 import fr.acinq.phoenix.data.LNUrl
 import io.ktor.http.*
-import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
+
+data class MaxFees(
+    val feeBase: Satoshi,
+    val feeProportionalMillionths: Long
+)
 
 @OptIn(ExperimentalTime::class)
 object Scan {
@@ -131,7 +136,8 @@ object Scan {
 
             data class SendInvoicePayment(
                 val paymentRequest: PaymentRequest,
-                val amount: MilliSatoshi
+                val amount: MilliSatoshi,
+                val maxFees: MaxFees?
             ) : InvoiceFlow()
         }
 
@@ -141,6 +147,7 @@ object Scan {
             data class SendLnurlPayment(
                 val lnurlPay: LNUrl.Pay,
                 val amount: MilliSatoshi,
+                val maxFees: MaxFees?,
                 val comment: String?
             ) : LnurlPayFlow()
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/TrampolineFees.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/TrampolineFees.kt
@@ -1,0 +1,67 @@
+package fr.acinq.phoenix.utils
+
+import fr.acinq.bitcoin.Satoshi
+import fr.acinq.lightning.TrampolineFees
+import fr.acinq.lightning.utils.sat
+import fr.acinq.phoenix.controllers.payments.MaxFees
+
+/**
+ * Creates a list of trampolineFees by taking into account both
+ * WalletParams.trampolineFees and the optional SendPayment.maxFees.
+ *
+ * The maxFees generally comes from user input,
+ * so it may either truncate the default list, or append to it.
+ * If the maxFees are "significantly" higher than the last item in the filtered trampolineFees,
+ * then the algorithm will inject additional steps to smoothly increment up to the maxFees.
+ */
+fun createTrampolineFees(
+    defaultFees: List<TrampolineFees>,
+    maxFees: MaxFees,
+    significantFeeBaseDiff: Satoshi = 300.sat,
+    significantFeeProportionalDiff: Long = 2000 // 0.2%
+): List<TrampolineFees> {
+    // Remove any items from default list that exceed the given maxFees
+    val trampolineFees = defaultFees.filter {
+        it.feeBase <= maxFees.feeBase &&
+        it.feeProportional <= maxFees.feeProportionalMillionths
+    }.toMutableList()
+    // If the maxFees already exist in the list then we're done
+    if (trampolineFees.any {
+            it.feeBase == maxFees.feeBase &&
+            it.feeProportional == maxFees.feeProportionalMillionths
+        }) {
+        return trampolineFees
+    }
+    // Check to see if there's a "significant jump" up to the user-defined maxFees
+    val cltvExpiryDelta = defaultFees.last().cltvExpiryDelta
+    val last = trampolineFees.lastOrNull() ?: TrampolineFees(0.sat, 0, cltvExpiryDelta)
+    val baseDiff = maxFees.feeBase.sat - last.feeBase.sat
+    val proportionalDiff = maxFees.feeProportionalMillionths - last.feeProportional
+    if (baseDiff >= significantFeeBaseDiff.sat ||
+        proportionalDiff >= significantFeeProportionalDiff
+    ) {
+        // It's a "significant jump" up to the user-provided max.
+        // So we insert a few steps to smooth out the potential fees.
+        val steps = 2
+        val baseIncrement = if (baseDiff > 0) {
+            baseDiff.toDouble() / (steps + 1).toDouble()
+        } else 0.0
+        val proportionalIncrement = if (proportionalDiff > 0) {
+            proportionalDiff.toDouble() / (steps + 1).toDouble()
+        } else 0.0
+        for (i in 1..steps) {
+            val base = last.feeBase.sat + (baseIncrement * i).toLong()
+            val proportional = last.feeProportional + (proportionalIncrement * i).toLong()
+            trampolineFees.add(TrampolineFees(
+                feeBase = Satoshi(sat = base),
+                feeProportional = proportional,
+                cltvExpiryDelta = last.cltvExpiryDelta
+            ))
+        }
+    }
+    return trampolineFees + TrampolineFees(
+        feeBase = maxFees.feeBase,
+        feeProportional = maxFees.feeProportionalMillionths,
+        cltvExpiryDelta = cltvExpiryDelta
+    )
+}

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/data/lnurl/LNUrlWithdrawTest.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/data/lnurl/LNUrlWithdrawTest.kt
@@ -22,8 +22,8 @@ class LNUrlWithdrawTest {
     private val defaultWithdraw = LNUrl.Withdraw(
         lnurl = defaultLnurl,
         callback = defaultCallback,
-        walletIdentifier = defaultK1,
-        description = defaultDesc,
+        k1 = defaultK1,
+        defaultDescription = defaultDesc,
         minWithdrawable = defaultMin,
         maxWithdrawable = defaultMax,
     )

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/utils/TrampolineFeesTests.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/utils/TrampolineFeesTests.kt
@@ -1,0 +1,102 @@
+package fr.acinq.phoenix.utils
+
+import fr.acinq.lightning.CltvExpiryDelta
+import fr.acinq.lightning.TrampolineFees
+import fr.acinq.lightning.utils.sat
+import fr.acinq.phoenix.controllers.payments.MaxFees
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TrampolineFeesTests {
+
+    @Test
+    fun createTrampolineFees() {
+        val defaultFees = listOf(
+            TrampolineFees(0.sat, 0, CltvExpiryDelta(576)),
+            TrampolineFees(1.sat, 100, CltvExpiryDelta(576)),
+            TrampolineFees(3.sat, 100, CltvExpiryDelta(576)),
+            TrampolineFees(5.sat, 500, CltvExpiryDelta(576)),
+            TrampolineFees(5.sat, 1000, CltvExpiryDelta(576)),
+            TrampolineFees(5.sat, 1200, CltvExpiryDelta(576))
+        )
+        run { // test: maxFee = item in default list
+            val trampolineFees = createTrampolineFees(
+                defaultFees = defaultFees,
+                maxFees = MaxFees(
+                    feeBase = 5.sat,
+                    feeProportionalMillionths = 1200
+                ),
+                significantFeeBaseDiff = 300.sat,
+                significantFeeProportionalDiff = 2000
+            )
+            assertEquals(trampolineFees, defaultFees)
+        }
+        run { // test: maxFee.feeBase truncates list
+            val trampolineFees = createTrampolineFees(
+                defaultFees = defaultFees,
+                maxFees = MaxFees(
+                    feeBase = 4.sat, // causes truncation
+                    feeProportionalMillionths = 1200
+                ),
+                significantFeeBaseDiff = 300.sat,
+                significantFeeProportionalDiff = 2000
+            )
+            assertEquals(trampolineFees, listOf(
+                TrampolineFees(0.sat, 0, CltvExpiryDelta(576)),
+                TrampolineFees(1.sat, 100, CltvExpiryDelta(576)),
+                TrampolineFees(3.sat, 100, CltvExpiryDelta(576)),
+                TrampolineFees(4.sat, 1200, CltvExpiryDelta(576)),
+            ))
+        }
+        run { // test: maxFee.feeProportionalMillionths truncates list
+            val trampolineFees = createTrampolineFees(
+                defaultFees = defaultFees,
+                maxFees = MaxFees(
+                    feeBase = 5.sat,
+                    feeProportionalMillionths = 750 // causes truncation
+                ),
+                significantFeeBaseDiff = 300.sat,
+                significantFeeProportionalDiff = 2000
+            )
+            assertEquals(trampolineFees, listOf(
+                TrampolineFees(0.sat, 0, CltvExpiryDelta(576)),
+                TrampolineFees(1.sat, 100, CltvExpiryDelta(576)),
+                TrampolineFees(3.sat, 100, CltvExpiryDelta(576)),
+                TrampolineFees(5.sat, 500, CltvExpiryDelta(576)),
+                TrampolineFees(5.sat, 750, CltvExpiryDelta(576)),
+            ))
+        }
+        run { // test: maxFee under significantDiff
+            val trampolineFees = createTrampolineFees(
+                defaultFees = defaultFees,
+                maxFees = MaxFees(
+                    feeBase = 100.sat, // 100 - 5 = 95
+                    feeProportionalMillionths = 2000 // 2000 - 1200 = 800
+                ),
+                significantFeeBaseDiff = 300.sat, // 300 > 95
+                significantFeeProportionalDiff = 2000 // 2000 > 800
+            )
+            assertEquals(trampolineFees, defaultFees +
+                TrampolineFees(100.sat, 2000, CltvExpiryDelta(576))
+            )
+        }
+        run { // test: maxFee over significantDiff
+            val trampolineFees = createTrampolineFees(
+                defaultFees = defaultFees,
+                maxFees = MaxFees(
+                    feeBase = 95.sat, // 95 - 5 = 90
+                    feeProportionalMillionths = 2100 // 2100 - 1200 = 900
+                ),
+                significantFeeBaseDiff = 90.sat, // 90 >= 90
+                significantFeeProportionalDiff = 1000 // 1000 !>= 900
+            )
+            assertEquals(trampolineFees, defaultFees + listOf(
+                TrampolineFees(35.sat, 1500, CltvExpiryDelta(576)),
+                TrampolineFees(65.sat, 1800, CltvExpiryDelta(576)),
+                TrampolineFees(95.sat, 2100, CltvExpiryDelta(576))
+            ))
+        }
+    }
+}


### PR DESCRIPTION
Fixes issue #191

This PR requires [13c7143](https://github.com/ACINQ/lightning-kmp/commit/13c71436daa1fc8f72166244c4aa143e958c3544) from https://github.com/ACINQ/lightning-kmp/pull/317

<img height="450" alt="Screen Shot 2022-01-24 at 11 49 50" src="https://user-images.githubusercontent.com/304604/150827762-3ffdcbed-3640-4511-b05e-dfb2c561f54c.png">

## Technical notes:

My theory is that users will think of this feature a bit like an Ebay auction. With Ebay, if I make a bid of X, I know that I'll only pay Y, where Y is the minimum necessary amount to win the bid. Similarly, if a user sets the max fee to X, they're expecting to pay Y, where Y is close to the minimum fee necessary to make the payment succeed.

So the lightning-kmp library needs a schedule of fees. And our default schedule is a slow ramp up to a conservative max fee. My fear is that, if we simply append the max fee of X at the end of the list, then the user will be paying the max fee everytime the required fee exceeds the conservative maximum.

So I'm thinking that, if our default schedule is something like `[Q, R, S, T, U]`, and the user sets the max to X, then the ideal schedule is more like `[Q, R, S, T, U, V, W, X]`, where `[V, W]` ramp up to X. So there's a bit of clever logic in `TrampolineFees.kt` to accomplish this, along with associated unit tests.

