### PR TITLE
Fixed Czech translation

### DIFF
--- a/phoenix-ios/phoenix-ios/cs.lproj/Localizable.strings
+++ b/phoenix-ios/phoenix-ios/cs.lproj/Localizable.strings
@@ -750,8 +750,8 @@
 /* No comment provided by engineer. */
 "Sending Payment..." = "Odesílání platby...";
 
-/* No comment provided by engineer. */
-"SENT" = "ODESLAT";
+/* Confirm dialog that payment has been sent. */
+"SENT" = "ODESLÁNO";
 
 /* Label in DetailsView_IncomingPayment */
 "sent at" = "odeslat na";


### PR DESCRIPTION
"odeslat" is imperative mood, but there should be past - "odesláno"