### PR TITLE
Integrated currency converter

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -48,13 +48,14 @@
 		DC118C0627B4557D0080BBAC /* ValidateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC118C0527B4557D0080BBAC /* ValidateView.swift */; };
 		DC118C0827B457520080BBAC /* LnurlFetchNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC118C0727B457520080BBAC /* LnurlFetchNotice.swift */; };
 		DC118C0A27B457F70080BBAC /* LnurlFlowErrorNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC118C0927B457F70080BBAC /* LnurlFlowErrorNotice.swift */; };
+		DC118C0C27B561210080BBAC /* CurrencyAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC118C0B27B561210080BBAC /* CurrencyAmount.swift */; };
 		DC142135261E72320075857A /* AboutHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC142134261E72320075857A /* AboutHTML.swift */; };
 		DC142140261E72E40075857A /* AnyHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC14213F261E72E40075857A /* AnyHTML.swift */; };
 		DC142148261F5DCE0075857A /* AdvancedSecurityHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC142147261F5DCE0075857A /* AdvancedSecurityHTML.swift */; };
 		DC1706D926A71D8E00BAFCD0 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1706D826A71D8E00BAFCD0 /* ErrorView.swift */; };
 		DC18C418256FE22300A2D083 /* Prefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC18C417256FE22300A2D083 /* Prefs.swift */; };
 		DC18C41D256FF91100A2D083 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC18C41C256FF91100A2D083 /* Utils.swift */; };
-		DC1D2B4B2593EB860036AD38 /* CurrencyUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1D2B4A2593EB850036AD38 /* CurrencyUnit.swift */; };
+		DC1D2B4B2593EB860036AD38 /* Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1D2B4A2593EB850036AD38 /* Currency.swift */; };
 		DC1D2B502594CE900036AD38 /* FormattedAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1D2B4F2594CE900036AD38 /* FormattedAmount.swift */; };
 		DC27E4C22791C00F00C777CC /* PrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC27E4C12791C00F00C777CC /* PrivacyView.swift */; };
 		DC27E4C42791C58C00C777CC /* PaymentsBackupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC27E4C32791C58C00C777CC /* PaymentsBackupView.swift */; };
@@ -250,13 +251,14 @@
 		DC118C0527B4557D0080BBAC /* ValidateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateView.swift; sourceTree = "<group>"; };
 		DC118C0727B457520080BBAC /* LnurlFetchNotice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LnurlFetchNotice.swift; sourceTree = "<group>"; };
 		DC118C0927B457F70080BBAC /* LnurlFlowErrorNotice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LnurlFlowErrorNotice.swift; sourceTree = "<group>"; };
+		DC118C0B27B561210080BBAC /* CurrencyAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyAmount.swift; sourceTree = "<group>"; };
 		DC142134261E72320075857A /* AboutHTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutHTML.swift; sourceTree = "<group>"; };
 		DC14213F261E72E40075857A /* AnyHTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyHTML.swift; sourceTree = "<group>"; };
 		DC142147261F5DCE0075857A /* AdvancedSecurityHTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSecurityHTML.swift; sourceTree = "<group>"; };
 		DC1706D826A71D8E00BAFCD0 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		DC18C417256FE22300A2D083 /* Prefs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prefs.swift; sourceTree = "<group>"; };
 		DC18C41C256FF91100A2D083 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
-		DC1D2B4A2593EB850036AD38 /* CurrencyUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyUnit.swift; sourceTree = "<group>"; };
+		DC1D2B4A2593EB850036AD38 /* Currency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
 		DC1D2B4F2594CE900036AD38 /* FormattedAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattedAmount.swift; sourceTree = "<group>"; };
 		DC27E4C12791C00F00C777CC /* PrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyView.swift; sourceTree = "<group>"; };
 		DC27E4C32791C58C00C777CC /* PaymentsBackupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsBackupView.swift; sourceTree = "<group>"; };
@@ -439,7 +441,8 @@
 				DCB876312735AAB500657570 /* Prefs+Codable.swift */,
 				DCB8762F2735AA7300657570 /* Prefs+Serialization.swift */,
 				DC18C41C256FF91100A2D083 /* Utils.swift */,
-				DC1D2B4A2593EB850036AD38 /* CurrencyUnit.swift */,
+				DC1D2B4A2593EB850036AD38 /* Currency.swift */,
+				DC118C0B27B561210080BBAC /* CurrencyAmount.swift */,
 				DC1D2B4F2594CE900036AD38 /* FormattedAmount.swift */,
 				DC72C33325A51AAC008A927A /* CurrencyPrefs.swift */,
 				DCB04684260D162C007FDA37 /* ViewName.swift */,
@@ -1042,7 +1045,7 @@
 				DC0E31BB26EFDED4002071C6 /* VSlider.swift in Sources */,
 				DC27E4CB2791D17A00C777CC /* RecoveryPhraseView.swift in Sources */,
 				DCACF6FC2566D0BA0009B01E /* AppSecurity.swift in Sources */,
-				DC1D2B4B2593EB860036AD38 /* CurrencyUnit.swift in Sources */,
+				DC1D2B4B2593EB860036AD38 /* Currency.swift in Sources */,
 				DC118C0627B4557D0080BBAC /* ValidateView.swift in Sources */,
 				DC118C0827B457520080BBAC /* LnurlFetchNotice.swift in Sources */,
 				DCE7233027B167240017CF56 /* SyncSeedManager_Actor.swift in Sources */,
@@ -1059,6 +1062,7 @@
 				53BEFF4EDB40975C2123C63D /* ui.swift in Sources */,
 				DCACF6FD2566D0BA0009B01E /* SecurityFile.swift in Sources */,
 				DCB6235A25B0A42D005AD4B7 /* ComingSoonView.swift in Sources */,
+				DC118C0C27B561210080BBAC /* CurrencyAmount.swift in Sources */,
 				DC46BAF726CACCF700E760A6 /* KotlinBasics.swift in Sources */,
 				DC142140261E72E40075857A /* AnyHTML.swift in Sources */,
 				DCB493CB269F3B06001B0F09 /* Result+Deugly.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/utils/Currency.swift
+++ b/phoenix-ios/phoenix-ios/utils/Currency.swift
@@ -4,7 +4,7 @@ import PhoenixShared
 /// Represents a displayable currency,
 /// which can be either a BitcoinUnit or a FiatCurrency.
 ///
-enum Currency: Hashable, CustomStringConvertible {
+enum Currency: Hashable, Identifiable, CustomStringConvertible {
 	
 	case bitcoin(BitcoinUnit)
 	case fiat(FiatCurrency)
@@ -18,12 +18,12 @@ enum Currency: Hashable, CustomStringConvertible {
 		}
 	}
 	
-	var identifiable: String {
+	var id: String {
 		switch self {
 		case .bitcoin(let unit):
-			return unit.shortName.lowercased()
+			return unit.name.lowercased()
 		case .fiat(let currency):
-			return currency.shortName.uppercased()
+			return currency.name.uppercased()
 		}
 	}
 	
@@ -35,9 +35,6 @@ enum Currency: Hashable, CustomStringConvertible {
 			return "fiat(\(currency.shortName))"
 		}
 	}
-}
-
-extension Currency {
 	
 	/// A list of all BitcoinUnit's and the currently selected FiatCurrency (IFF we know the exchangeRate).
 	///
@@ -58,5 +55,41 @@ extension Currency {
 		}
 		
 		return all
+	}
+	
+	static func displayable2(currencyPrefs: CurrencyPrefs, plus: Currency? = nil) -> [Currency] {
+		
+		var all = [Currency](Prefs.shared.currencyConverterList)
+		
+		let preferredFiatCurrency = Currency.fiat(currencyPrefs.fiatCurrency)
+		if !all.contains(preferredFiatCurrency) {
+			all.insert(preferredFiatCurrency, at: 0)
+		}
+		
+		let preferredBitcoinUnit = Currency.bitcoin(currencyPrefs.bitcoinUnit)
+		if !all.contains(preferredBitcoinUnit) {
+			all.insert(preferredBitcoinUnit, at: 0)
+		}
+		
+		if let plus = plus {
+			if !all.contains(plus) {
+				all.append(plus)
+			}
+		}
+		
+		return all.filter { currency in
+			switch currency {
+			case .bitcoin(_):
+				return true
+			case .fiat(let fiatCurrency):
+				if let _ = currencyPrefs.fiatExchangeRate(fiatCurrency: fiatCurrency) {
+					return true
+				} else {
+					// We don't have the exchange rate for this fiat currency.
+					// So we won't be able to perform conversion to millisatoshi.
+					return false
+				}
+			}
+		}
 	}
 }

--- a/phoenix-ios/phoenix-ios/utils/CurrencyAmount.swift
+++ b/phoenix-ios/phoenix-ios/utils/CurrencyAmount.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct CurrencyAmount {
+struct CurrencyAmount: Equatable {
 	let currency: Currency
 	let amount: Double
 }

--- a/phoenix-ios/phoenix-ios/utils/CurrencyAmount.swift
+++ b/phoenix-ios/phoenix-ios/utils/CurrencyAmount.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct CurrencyAmount {
+	let currency: Currency
+	let amount: Double
+}

--- a/phoenix-ios/phoenix-ios/utils/Prefs.swift
+++ b/phoenix-ios/phoenix-ios/utils/Prefs.swift
@@ -3,7 +3,7 @@ import PhoenixShared
 import Combine
 import os.log
 
-#if DEBUG && true
+#if DEBUG && false
 fileprivate var log = Logger(
 	subsystem: Bundle.main.bundleIdentifier!,
 	category: "Prefs"
@@ -259,13 +259,19 @@ class Prefs {
 	
 	var preferredFiatCurrencies: [FiatCurrency] {
 		get {
-			var result = Set<FiatCurrency>(arrayLiteral: self.fiatCurrency)
+			var resultArray = [self.fiatCurrency]
+			var resultSet = Set<FiatCurrency>(resultArray)
+			
 			for currency in self.currencyConverterList {
 				if case .fiat(let fiat) = currency {
-					result.insert(fiat)
+					let (inserted, _) = resultSet.insert(fiat)
+					if inserted {
+						resultArray.append(fiat)
+					}
 				}
 			}
-			return Array(result)
+			
+			return resultArray
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/receive/ReceiveLightningView.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/ReceiveLightningView.swift
@@ -79,7 +79,8 @@ struct ReceiveLightningView: View {
 		ZStack {
 			NavigationLink(
 				destination: CurrencyConverterView(
-					currencyAmount: $modificationAmount,
+					initialAmount: modificationAmount,
+					didChange: currencyConverterDidChange,
 					didClose: currencyConvertDidClose
 				),
 				isActive: $currencyConverterOpen
@@ -912,6 +913,12 @@ struct ReceiveLightningView: View {
 				SwapInDisabledPopover()
 			}
 		}
+	}
+	
+	func currencyConverterDidChange(_ amount: CurrencyAmount?) {
+		log.trace("currencyConverterDidChange()")
+		
+		modificationAmount = amount
 	}
 	
 	func currencyConvertDidClose() {

--- a/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
@@ -54,7 +54,12 @@ struct ValidateView: View {
 	
 	@ObservedObject var mvi: MVIState<Scan.Model, Scan.Intent>
 	
-	@State var unit = Currency.bitcoin(.sat)
+	@State var currency = Currency.bitcoin(.sat)
+	@State var currencyList: [Currency] = [Currency.bitcoin(.sat)]
+	
+	@State var currencyPickerChoice: String = Currency.bitcoin(.sat).abbrev
+	@State var currencyConverterOpen = false
+	
 	@State var amount: String = ""
 	@State var parsedAmount: Result<Double, TextFieldCurrencyStylerError> = Result.failure(.emptyInput)
 	
@@ -64,6 +69,8 @@ struct ValidateView: View {
 	
 	@State var comment: String = ""
 	@State var hasPromptedForComment = false
+	
+	@State var didAppear = false
 	
 	@StateObject var connectionsManager = ObservableConnectionsManager()
 	
@@ -96,10 +103,25 @@ struct ValidateView: View {
 	)
 	@State var maxFiatWidth: CGFloat? = nil
 	
+	// --------------------------------------------------
+	// MARK: ViewBuilders
+	// --------------------------------------------------
+	
+	@ViewBuilder
 	var body: some View {
 		
 		ZStack {
 		
+			NavigationLink(
+				destination: CurrencyConverterView(
+					initialAmount: currentAmount(),
+					amountDidChange: currencyConverterAmountChanged
+				),
+				isActive: $currencyConverterOpen
+			) {
+				EmptyView()
+			}
+			
 			Color.primaryBackground
 				.ignoresSafeArea(.all, edges: .all)
 			
@@ -155,8 +177,8 @@ struct ValidateView: View {
 		.onChange(of: amount) { _ in
 			amountDidChange()
 		}
-		.onChange(of: unit) { _  in
-			unitDidChange()
+		.onChange(of: currencyPickerChoice) { _ in
+			currencyPickerDidChange()
 		}
 	}
 	
@@ -195,11 +217,9 @@ struct ValidateView: View {
 					.multilineTextAlignment(.trailing)
 					.foregroundColor(isInvalidAmount ? Color.appNegative : Color.primaryForeground)
 			
-				Picker(selection: $unit, label: Text(unit.abbrev).frame(minWidth: 40)) {
-					let options = Currency.displayable(currencyPrefs: currencyPrefs)
-					ForEach(0 ..< options.count) {
-						let option = options[$0]
-						Text(option.abbrev).tag(option)
+				Picker(selection: $currencyPickerChoice, label: Text(currencyPickerChoice).frame(minWidth: 40)) {
+					ForEach(currencyPickerOptions(), id: \.self) { option in
+						Text(option).tag(option)
 					}
 				}
 				.pickerStyle(MenuPickerStyle())
@@ -352,15 +372,6 @@ struct ValidateView: View {
 		.foregroundColor(tipInfo.isEmpty ? Color.clear : Color.secondary)
 	}
 	
-	func currencyStyler() -> TextFieldCurrencyStyler {
-		return TextFieldCurrencyStyler(
-			currency: unit,
-			amount: $amount,
-			parsedAmount: $parsedAmount,
-			hideMsats: false
-		)
-	}
-	
 	@ViewBuilder
 	func actionButton(
 		text: String,
@@ -427,15 +438,6 @@ struct ValidateView: View {
 		}
 	}
 	
-	func priceTargetButtonText() -> String {
-		
-		if let _ = lnurlWithdraw() {
-			return NSLocalizedString("range", comment: "button label - try to make it short")
-		} else {
-			return NSLocalizedString("tip", comment: "button label - try to make it short")
-		}
-	}
-	
 	@ViewBuilder
 	func commentButton() -> some View {
 		
@@ -449,34 +451,25 @@ struct ValidateView: View {
 		}
 	}
 	
-	func paymentRequest() -> Lightning_kmpPaymentRequest? {
-		
-		if let model = mvi.model as? Scan.Model_InvoiceFlow_InvoiceRequest {
-			return model.paymentRequest
-		} else {
-			return nil
-		}
+	// --------------------------------------------------
+	// MARK: UI Content Helpers
+	// --------------------------------------------------
+
+	func currencyStyler() -> TextFieldCurrencyStyler {
+		return TextFieldCurrencyStyler(
+			currency: currency,
+			amount: $amount,
+			parsedAmount: $parsedAmount,
+			hideMsats: false
+		)
 	}
 	
-	func lnurlPay() -> LNUrl.Pay? {
+	func priceTargetButtonText() -> String {
 		
-		if let model = mvi.model as? Scan.Model_LnurlPayFlow_LnurlPayRequest {
-			return model.lnurlPay
-		} else if let model = mvi.model as? Scan.Model_LnurlPayFlow_LnurlPayFetch {
-			return model.lnurlPay
+		if let _ = lnurlWithdraw() {
+			return NSLocalizedString("range", comment: "button label - try to make it short")
 		} else {
-			return nil
-		}
-	}
-	
-	func lnurlWithdraw() -> LNUrl.Withdraw? {
-		
-		if let model = mvi.model as? Scan.Model_LnurlWithdrawFlow_LnurlWithdrawRequest {
-			return model.lnurlWithdraw
-		} else if let model = mvi.model as? Scan.Model_LnurlWithdrawFlow_LnurlWithdrawFetch {
-			return model.lnurlWithdraw
-		} else {
-			return nil
+			return NSLocalizedString("tip", comment: "button label - try to make it short")
 		}
 	}
 	
@@ -507,31 +500,6 @@ struct ValidateView: View {
 		} else {
 			return nil
 		}
-	}
-	
-	func priceRange() -> MsatRange? {
-		
-		if let paymentRequest = paymentRequest() {
-			if let min = paymentRequest.amount {
-				return MsatRange(
-					min: min,
-					max: min.times(m: 2.0)
-				)
-			}
-		}
-		else if let lnurlPay = lnurlPay() {
-			return MsatRange(
-				min: lnurlPay.minSendable,
-				max: lnurlPay.maxSendable
-			)
-		} else if let lnurlWithdraw = lnurlWithdraw() {
-			return MsatRange(
-				min: lnurlWithdraw.minWithdrawable,
-				max: lnurlWithdraw.maxWithdrawable
-			)
-		}
-		
-		return nil
 	}
 	
 	func hasExtendedMetadata() -> Bool {
@@ -572,40 +540,25 @@ struct ValidateView: View {
 		return maxCommentLength > 0
 	}
 	
-	func tipNumbers() -> TipNumbers? {
+	func disconnectedText() -> String {
 		
-		guard let totalAmt = try? parsedAmount.get(), totalAmt > 0 else {
-			return nil
+		if connectionsManager.connections.internet != Lightning_kmpConnection.established {
+			return NSLocalizedString("waiting for internet", comment: "button text")
 		}
-		
-		var totalMsat: Int64? = nil
-		switch unit {
-		case .bitcoin(let bitcoinUnit):
-			totalMsat = Utils.toMsat(from: totalAmt, bitcoinUnit: bitcoinUnit)
-		case .fiat(let fiatCurrency):
-			if let exchangeRate = currencyPrefs.fiatExchangeRate(fiatCurrency: fiatCurrency) {
-				totalMsat = Utils.toMsat(fromFiat: totalAmt, exchangeRate: exchangeRate)
-			}
+		if connectionsManager.connections.peer != Lightning_kmpConnection.established {
+			return NSLocalizedString("connecting to peer", comment: "button text")
 		}
-		
-		var baseMsat: Int64? = nil
-		if let paymentRequest = paymentRequest() {
-			baseMsat = paymentRequest.amount?.msat
-		} else if let lnurlPay = lnurlPay() {
-			baseMsat = lnurlPay.minSendable.msat
+		if connectionsManager.connections.electrum != Lightning_kmpConnection.established {
+			return NSLocalizedString("connecting to electrum", comment: "button text")
 		}
-		
-		guard let totalMsat = totalMsat, let baseMsat = baseMsat, totalMsat > baseMsat else {
-			return nil
-		}
-		
-		let tipMsat = totalMsat - baseMsat
-		let percent = Double(tipMsat) / Double(baseMsat)
-		
-		return TipNumbers(baseMsat: baseMsat, tipMsat: tipMsat, totalMsat: totalMsat, percent: percent)
+		return ""
 	}
 	
 	func tipStrings() -> TipStrings {
+		
+		if isInvalidAmount { // e.g. exceeds balance
+			return TipStrings.empty(currencyPrefs)
+		}
 		
 		guard let nums = tipNumbers() else {
 			return TipStrings.empty(currencyPrefs)
@@ -646,6 +599,66 @@ struct ValidateView: View {
 		)
 	}
 	
+	// --------------------------------------------------
+	// MARK: Utilities
+	// --------------------------------------------------
+	
+	func paymentRequest() -> Lightning_kmpPaymentRequest? {
+		
+		if let model = mvi.model as? Scan.Model_InvoiceFlow_InvoiceRequest {
+			return model.paymentRequest
+		} else {
+			return nil
+		}
+	}
+	
+	func lnurlPay() -> LNUrl.Pay? {
+		
+		if let model = mvi.model as? Scan.Model_LnurlPayFlow_LnurlPayRequest {
+			return model.lnurlPay
+		} else if let model = mvi.model as? Scan.Model_LnurlPayFlow_LnurlPayFetch {
+			return model.lnurlPay
+		} else {
+			return nil
+		}
+	}
+	
+	func lnurlWithdraw() -> LNUrl.Withdraw? {
+		
+		if let model = mvi.model as? Scan.Model_LnurlWithdrawFlow_LnurlWithdrawRequest {
+			return model.lnurlWithdraw
+		} else if let model = mvi.model as? Scan.Model_LnurlWithdrawFlow_LnurlWithdrawFetch {
+			return model.lnurlWithdraw
+		} else {
+			return nil
+		}
+	}
+	
+	func priceRange() -> MsatRange? {
+		
+		if let paymentRequest = paymentRequest() {
+			if let min = paymentRequest.amount {
+				return MsatRange(
+					min: min,
+					max: min.times(m: 2.0)
+				)
+			}
+		}
+		else if let lnurlPay = lnurlPay() {
+			return MsatRange(
+				min: lnurlPay.minSendable,
+				max: lnurlPay.maxSendable
+			)
+		} else if let lnurlWithdraw = lnurlWithdraw() {
+			return MsatRange(
+				min: lnurlWithdraw.minWithdrawable,
+				max: lnurlWithdraw.maxWithdrawable
+			)
+		}
+		
+		return nil
+	}
+	
 	func balanceMsat() -> Int64? {
 		
 		if let model = mvi.model as? Scan.Model_InvoiceFlow_InvoiceRequest {
@@ -663,25 +676,90 @@ struct ValidateView: View {
 		}
 	}
 	
-	func disconnectedText() -> String {
+	func tipNumbers() -> TipNumbers? {
 		
-		if connectionsManager.connections.internet != Lightning_kmpConnection.established {
-			return NSLocalizedString("waiting for internet", comment: "button text")
+		guard let totalAmt = try? parsedAmount.get(), totalAmt > 0 else {
+			return nil
 		}
-		if connectionsManager.connections.peer != Lightning_kmpConnection.established {
-			return NSLocalizedString("connecting to peer", comment: "button text")
+		
+		var totalMsat: Int64? = nil
+		switch currency {
+		case .bitcoin(let bitcoinUnit):
+			totalMsat = Utils.toMsat(from: totalAmt, bitcoinUnit: bitcoinUnit)
+		case .fiat(let fiatCurrency):
+			if let exchangeRate = currencyPrefs.fiatExchangeRate(fiatCurrency: fiatCurrency) {
+				totalMsat = Utils.toMsat(fromFiat: totalAmt, exchangeRate: exchangeRate)
+			}
 		}
-		if connectionsManager.connections.electrum != Lightning_kmpConnection.established {
-			return NSLocalizedString("connecting to electrum", comment: "button text")
+		
+		var baseMsat: Int64? = nil
+		if let paymentRequest = paymentRequest() {
+			baseMsat = paymentRequest.amount?.msat
+		} else if let lnurlPay = lnurlPay() {
+			baseMsat = lnurlPay.minSendable.msat
 		}
-		return ""
+		
+		guard let totalMsat = totalMsat, let baseMsat = baseMsat, totalMsat > baseMsat else {
+			return nil
+		}
+		
+		let tipMsat = totalMsat - baseMsat
+		let percent = Double(tipMsat) / Double(baseMsat)
+		
+		return TipNumbers(baseMsat: baseMsat, tipMsat: tipMsat, totalMsat: totalMsat, percent: percent)
 	}
+	
+	func currencyPickerOptions() -> [String] {
+		
+		var options = [String]()
+		for currency in currencyList {
+			options.append(currency.abbrev)
+		}
+		
+		options.append(NSLocalizedString("other",
+			comment: "Option in currency picker list. Sends user to Currency Converter")
+		)
+		
+		return options
+	}
+	
+	func currencyFromChoice() -> Currency? {
+		
+		for currency in currencyList {
+			if currency.abbrev == currencyPickerChoice {
+				return currency
+			}
+		}
+		
+		return nil
+	}
+	
+	func currentAmount() -> CurrencyAmount? {
+		
+		guard let amt = try? parsedAmount.get(), amt > 0 else {
+			return nil
+		}
+		
+		return CurrencyAmount(currency: currency, amount: amt)
+	}
+	
+	// --------------------------------------------------
+	// MARK: Actions
+	// --------------------------------------------------
 	
 	func onAppear() -> Void {
 		log.trace("onAppear()")
 		
+		if didAppear {
+			return
+		}
+		didAppear = true
+			
+		currencyList = Currency.displayable2(currencyPrefs: currencyPrefs)
+		
 		let bitcoinUnit = currencyPrefs.bitcoinUnit
-		unit = Currency.bitcoin(bitcoinUnit)
+		currency = Currency.bitcoin(bitcoinUnit)
+		currencyPickerChoice = currency.abbrev
 		
 		var amount_msat: Lightning_kmpMilliSatoshi? = nil
 		if let paymentRequest = paymentRequest() {
@@ -743,15 +821,25 @@ struct ValidateView: View {
 		refreshAltAmount()
 	}
 	
-	func unitDidChange() -> Void {
-		log.trace("unitDidChange()")
+	func currencyPickerDidChange() -> Void {
+		log.trace("currencyPickerDidChange()")
 		
-		// We might want to apply a different formatter
-		let result = TextFieldCurrencyStyler.format(input: amount, currency: unit, hideMsats: false)
-		parsedAmount = result.1
-		amount = result.0
-		
-		refreshAltAmount()
+		if let newCurrency = currencyFromChoice() {
+			if currency != newCurrency {
+				currency = newCurrency
+				
+				// We might want to apply a different formatter
+				let result = TextFieldCurrencyStyler.format(input: amount, currency: currency, hideMsats: false)
+				parsedAmount = result.1
+				amount = result.0
+				
+				// This seems to be needed, because `amountDidChange` isn't automatically called
+				refreshAltAmount()
+			}
+		} else {
+			currencyConverterOpen = true
+			currencyPickerChoice = currency.abbrev
+		}
 	}
 	
 	func refreshAltAmount() -> Void {
@@ -772,35 +860,13 @@ struct ValidateView: View {
 			isInvalidAmount = false
 			
 			var msat: Int64? = nil
-			var alt: FormattedAmount? = nil
-			
-			switch unit {
+			switch currency {
 			case .bitcoin(let bitcoinUnit):
-				// amt    => bitcoinUnit
-				// altAmt => fiatCurrency
-				
 				msat = Utils.toMsat(from: amt, bitcoinUnit: bitcoinUnit)
 				
-				if let exchangeRate = currencyPrefs.fiatExchangeRate() {
-					alt = Utils.formatFiat(msat: msat!, exchangeRate: exchangeRate)
-					
-				} else {
-					// We don't know the exchange rate, so we can't display fiat value.
-					altAmount = ""
-				}
 			case .fiat(let fiatCurrency):
-				// amt    => fiatCurrency
-				// altAmt => bitcoinUnit
-				
 				if let exchangeRate = currencyPrefs.fiatExchangeRate(fiatCurrency: fiatCurrency) {
-					
 					msat = Utils.toMsat(fromFiat: amt, exchangeRate: exchangeRate)
-					alt = Utils.formatBitcoin(msat: msat!, bitcoinUnit: currencyPrefs.bitcoinUnit)
-					
-				} else {
-					// We don't know the exchange rate !
-					// We shouldn't get into this state since Currency.displayable() already filters for this.
-					altAmount = ""
 				}
 			}
 			
@@ -810,9 +876,6 @@ struct ValidateView: View {
 				if msat > balanceMsat && !(mvi.model is Scan.Model_LnurlWithdrawFlow) {
 					isInvalidAmount = true
 					altAmount = NSLocalizedString("Amount exceeds your balance", comment: "error message")
-					
-				} else if let alt = alt {
-					altAmount = "≈ \(alt.string)"
 				}
 			}
 			
@@ -837,7 +900,7 @@ struct ValidateView: View {
 				let isRange = maxMsat > minMsat
 				
 				var bitcoinUnit: BitcoinUnit
-				if case .bitcoin(let unit) = unit {
+				if case .bitcoin(let unit) = currency {
 					bitcoinUnit = unit
 				} else {
 					bitcoinUnit = currencyPrefs.bitcoinUnit
@@ -858,7 +921,7 @@ struct ValidateView: View {
 					
 					let exactBitcoin = Utils.formatBitcoin(msat: minMsat, bitcoinUnit: bitcoinUnit)
 					
-					if case .fiat(let fiatCurrency) = unit,
+					if case .fiat(let fiatCurrency) = currency,
 						let exchangeRate = currencyPrefs.fiatExchangeRate(fiatCurrency: fiatCurrency)
 					{
 						let approxFiat = Utils.formatFiat(msat: minMsat, exchangeRate: exchangeRate)
@@ -878,7 +941,7 @@ struct ValidateView: View {
 					
 					let minBitcoin = Utils.formatBitcoin(msat: minMsat, bitcoinUnit: bitcoinUnit)
 					
-					if case .fiat(let fiatCurrency) = unit,
+					if case .fiat(let fiatCurrency) = currency,
 						let exchangeRate = currencyPrefs.fiatExchangeRate(fiatCurrency: fiatCurrency)
 					{
 						let approxFiat = Utils.formatFiat(msat: minMsat, exchangeRate: exchangeRate)
@@ -898,7 +961,7 @@ struct ValidateView: View {
 					
 					let maxBitcoin = Utils.formatBitcoin(msat: maxMsat, bitcoinUnit: bitcoinUnit)
 					
-					if case .fiat(let fiatCurrency) = unit,
+					if case .fiat(let fiatCurrency) = currency,
 						let exchangeRate = currencyPrefs.fiatExchangeRate(fiatCurrency: fiatCurrency)
 					{
 						let approxFiat = Utils.formatFiat(msat: maxMsat, exchangeRate: exchangeRate)
@@ -912,6 +975,45 @@ struct ValidateView: View {
 							comment: "error message"
 						)
 					}
+				}
+			}
+			
+			if !isInvalidAmount && !isExpiredInvoice {
+				
+				if let msat = msat {
+					
+					var altBitcoinUnit: FormattedAmount? = nil
+					var altFiatCurrency: FormattedAmount? = nil
+					
+					let preferredBitcoinUnit = currencyPrefs.bitcoinUnit
+					if currency != Currency.bitcoin(preferredBitcoinUnit) {
+						altBitcoinUnit = Utils.formatBitcoin(msat: msat, bitcoinUnit: preferredBitcoinUnit)
+					}
+					
+					let preferredFiatCurrency = currencyPrefs.fiatCurrency
+					if currency != Currency.fiat(preferredFiatCurrency) {
+						if let exchangeRate = currencyPrefs.fiatExchangeRate(fiatCurrency: preferredFiatCurrency) {
+							altFiatCurrency = Utils.formatFiat(msat: msat, exchangeRate: exchangeRate)
+						}
+					}
+					
+					if let altBitcoinUnit = altBitcoinUnit, let altFiatCurrency = altFiatCurrency {
+						altAmount = "≈ \(altBitcoinUnit.string)  /  ≈ \(altFiatCurrency.string)"
+						
+					} else if let altBitcoinUnit = altBitcoinUnit {
+						altAmount = "≈ \(altBitcoinUnit.string)"
+						
+					} else if let altFiatCurrency = altFiatCurrency {
+						altAmount = "≈ \(altFiatCurrency.string)"
+						
+					} else {
+						// We don't know the exchange rate
+						altAmount = ""
+					}
+					
+				} else {
+					// We don't know the exchange rate
+					altAmount = ""
 				}
 			}
 			
@@ -945,7 +1047,7 @@ struct ValidateView: View {
 		var msat = minMsat
 		if let amt = try? parsedAmount.get(), amt > 0 {
 			
-			switch unit {
+			switch currency {
 			case .bitcoin(let bitcoinUnit):
 				msat = Utils.toMsat(from: amt, bitcoinUnit: bitcoinUnit)
 				
@@ -1003,13 +1105,14 @@ struct ValidateView: View {
 		log.trace("priceSliderChanged()")
 		
 		let preferredBitcoinUnit = currencyPrefs.bitcoinUnit
-		unit = Currency.bitcoin(preferredBitcoinUnit)
+		currency = Currency.bitcoin(preferredBitcoinUnit)
+		currencyPickerChoice = currency.abbrev
 		
 		// The TextFieldCurrencyStyler doesn't seem to fire when we manually set the text value.
 		// So we need to do it manually here, to ensure the `parsedAmount` is properly updated.
 		
 		let amt = Utils.formatBitcoin(msat: msat, bitcoinUnit: preferredBitcoinUnit)
-		let result = TextFieldCurrencyStyler.format(input: amt.digits, currency: unit, hideMsats: false)
+		let result = TextFieldCurrencyStyler.format(input: amt.digits, currency: currency, hideMsats: false)
 		
 		parsedAmount = result.1
 		amount = result.0
@@ -1046,7 +1149,7 @@ struct ValidateView: View {
 		}
 		
 		var msat: Int64? = nil
-		switch unit {
+		switch currency {
 		case .bitcoin(let bitcoinUnit):
 			msat = Utils.toMsat(from: amt, bitcoinUnit: bitcoinUnit)
 		case .fiat(let fiatCurrency):
@@ -1142,6 +1245,38 @@ struct ValidateView: View {
 		mvi.intent(Scan.Intent_LnurlWithdrawFlow_CancelLnurlWithdraw(
 			lnurlWithdraw: lnurlWithdraw
 		))
+	}
+	
+	func currencyConverterAmountChanged(_ newAmt: CurrencyAmount?) {
+		log.trace("currencyConverterAmountChanged()")
+		
+		if let newAmt = newAmt {
+			
+			let newCurrencyList = Currency.displayable2(currencyPrefs: currencyPrefs, plus: newAmt.currency)
+			
+			if currencyList != newCurrencyList {
+				currencyList = newCurrencyList
+			}
+			
+			currency = newAmt.currency
+			currencyPickerChoice = newAmt.currency.abbrev
+			
+			let formattedAmt: FormattedAmount
+			switch newAmt.currency {
+			case .bitcoin(let bitcoinUnit):
+				formattedAmt = Utils.formatBitcoin(amount: newAmt.amount, bitcoinUnit: bitcoinUnit, hideMsats: false)
+			case .fiat(let fiatCurrency):
+				formattedAmt = Utils.formatFiat(amount: newAmt.amount, fiatCurrency: fiatCurrency)
+			}
+		
+			parsedAmount = Result.success(newAmt.amount)
+			amount = formattedAmt.digits
+			
+		} else {
+			
+			parsedAmount = Result.failure(.emptyInput)
+			amount = ""
+		}
 	}
 	
 	func showAppStatusPopover() {

--- a/phoenix-ios/phoenix-ios/views/tools/CurrencyConverterView.swift
+++ b/phoenix-ios/phoenix-ios/views/tools/CurrencyConverterView.swift
@@ -384,7 +384,7 @@ struct CurrencyConverterView: View {
 			}
 		}
 		
-		if let didClose = didClose {
+		if !currencySelectorOpen, let didClose = didClose {
 			didClose()
 		}
 	}

--- a/phoenix-ios/phoenix-ios/views/tools/CurrencyConverterView.swift
+++ b/phoenix-ios/phoenix-ios/views/tools/CurrencyConverterView.swift
@@ -365,19 +365,29 @@ struct CurrencyConverterView: View {
 				currencies = defaultCurrencies()
 			}
 			
-			if let initialAmount = initialAmount {
-				lastChange = initialAmount
+			if didChange == nil {
+				// Created via init() - use default initial value
 				parsedRow = ParsedRow(
-					currency: initialAmount.currency,
-					parsedAmount: Result.success(initialAmount.amount)
+					currency: Currency.bitcoin(.btc),
+					parsedAmount: Result.success(1.0)
 				)
 			} else {
-				let defaultInitialAmount = CurrencyAmount(currency: Currency.bitcoin(.btc), amount: 1.0)
-				lastChange = defaultInitialAmount // don't fire didChange for defaultInitialValue
-				parsedRow = ParsedRow(
-					currency: defaultInitialAmount.currency,
-					parsedAmount: Result.success(defaultInitialAmount.amount)
-				)
+				// Created via init(initialAmount:didChange:didClose:).
+				// If an initialAmount was passed then use it.
+				// Otherwise all rows should remain empty.
+				if let initialAmount = initialAmount {
+					lastChange = initialAmount
+					parsedRow = ParsedRow(
+						currency: initialAmount.currency,
+						parsedAmount: Result.success(initialAmount.amount)
+					)
+				} else {
+					lastChange = nil
+					parsedRow = ParsedRow(
+						currency: Currency.bitcoin(.btc),
+						parsedAmount: Result.failure(.emptyInput)
+					)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Imagine the user has selected their preferred currencies:
- bitcoin unit: satoshis
- fiat currency: USD

And then we offer them this selection of currencies:

<img height="450" src="https://user-images.githubusercontent.com/304604/153661485-1514f9b3-d869-4874-b77a-44aeb9c27bfc.png">

That doesn't really make sense. And it's probably confusing to the user: "What is mbtc ???"

We already know their preferred currencies. And the currency converter gives us a hint as to the other currencies they're probably dealing with. For example, here's mine:

<img height="450" src="https://user-images.githubusercontent.com/304604/153661889-e9e4cbda-a0fe-4d7b-8931-af344560b839.png">

So this PR updates the list:

<img height="450" src="https://user-images.githubusercontent.com/304604/153663581-3e4f2645-a509-4244-9cd8-ffbfb973757b.png">

And if they select "other", we pop them over to the currency converter. When they're done, they return to the original screen, and we use the value they typed in.

<img height="450" src="https://user-images.githubusercontent.com/304604/153664275-08067c46-ad19-4666-8824-efbd77318072.png">



