### PR TITLE
Store original fiat exchange rate associated with payment

### DIFF
--- a/phoenix-ios/phoenix-ios/AppDelegate.swift
+++ b/phoenix-ios/phoenix-ios/AppDelegate.swift
@@ -86,8 +86,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MessagingDelegate {
 		let electrumConfig = Prefs.shared.electrumConfig
 		business.appConfigurationManager.updateElectrumConfig(server: electrumConfig?.serverAddress)
 		
-		let fiatCurrencies = Prefs.shared.preferredFiatCurrencies
-		business.appConfigurationManager.updatePreferredFiatCurrencies(list: fiatCurrencies)
+		let preferredFiatCurrencies = AppConfigurationManager.PreferredFiatCurrencies(
+			primary: Prefs.shared.fiatCurrency,
+			others: Prefs.shared.preferredFiatCurrencies
+		)
+		business.appConfigurationManager.updatePreferredFiatCurrencies(current: preferredFiatCurrencies)
 		
 		business.start()
 	}
@@ -154,8 +157,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MessagingDelegate {
 			Prefs.shared.fiatCurrencyPublisher,
 			Prefs.shared.currencyConverterListPublisher
 		).sink { _ in
-			let list = Prefs.shared.preferredFiatCurrencies
-			self.business.appConfigurationManager.updatePreferredFiatCurrencies(list: list)
+			let current = AppConfigurationManager.PreferredFiatCurrencies(
+				primary: Prefs.shared.fiatCurrency,
+				others: Prefs.shared.preferredFiatCurrencies
+			)
+			self.business.appConfigurationManager.updatePreferredFiatCurrencies(current: current)
 		}.store(in: &cancellables)
 		
 		return true

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions.swift
@@ -66,6 +66,7 @@ extension WalletPaymentMetadata {
 	static func empty() -> WalletPaymentMetadata {
 		return WalletPaymentMetadata(
 			lnurl: nil,
+			originalFiat: nil,
 			userDescription: nil,
 			userNotes: nil,
 			modifiedAt: nil

--- a/phoenix-ios/phoenix-ios/sync/SyncTxManager.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncTxManager.swift
@@ -325,7 +325,7 @@ class SyncTxManager {
 			databaseManager.getDatabases().sink { databases in
 				
 				if let paymentsDb = databases.payments as? SqlitePaymentsDb,
-					let cloudKitDb = paymentsDb.cloudKitDb as? CloudKitDb
+					let cloudKitDb = paymentsDb.getCloudKitDb() as? CloudKitDb
 				{
 					self._paymentsDb = paymentsDb
 					self._cloudKitDb = cloudKitDb

--- a/phoenix-ios/phoenix-ios/utils/Utils.swift
+++ b/phoenix-ios/phoenix-ios/utils/Utils.swift
@@ -71,6 +71,18 @@ class Utils {
 		return fiat
 	}
 	
+	static func convertToFiat(msat: Int64, originalFiat: OriginalFiat) -> Double {
+		
+		// OriginalFiat.rate: Double { get }
+		//
+		// originalFiat.rate => value of 1.0 BTC in fiat
+		
+		let btc = Double(msat) / Millisatoshis_Per_Bitcoin
+		let fiat = btc * originalFiat.rate
+		
+		return fiat
+	}
+	
 	/// Formats the given amount of satoshis into a FormattedAmount struct,
 	/// which contains the various string values needed for display.
 	///
@@ -420,6 +432,60 @@ class Utils {
 		
 		let fiatAmount = convertToFiat(msat: msat, exchangeRate: exchangeRate)
 		return formatFiat(amount: fiatAmount, fiatCurrency: exchangeRate.fiatCurrency)
+	}
+	
+	/// Converts from satoshi to a fiat amount, using the original exchange rate.
+	///
+	/// - Returns: A FormattedAmount struct, which contains the various string values needed for display.
+	///
+	static func formatFiat(
+		sat: Bitcoin_kmpSatoshi,
+		originalFiat: OriginalFiat
+	) -> FormattedAmount? {
+		
+		return formatFiat(sat: sat.toLong(), originalFiat: originalFiat)
+	}
+	
+	/// Converts from satoshi to a fiat amount, using the original exchange rate.
+	///
+	/// - Returns: A FormattedAmount struct, which contains the various string values needed for display.
+	///
+	static func formatFiat(
+		sat: Int64,
+		originalFiat: OriginalFiat
+	) -> FormattedAmount? {
+		
+		let msat = sat * Int64(Millisatoshis_Per_Satoshi)
+		return formatFiat(msat: msat, originalFiat: originalFiat)
+	}
+	
+	/// Converts from millisatoshi to a fiat amount, using the original exchange rate.
+	///
+	/// - Returns: A FormattedAmount struct, which contains the various string values needed for display.
+	///
+	static func formatFiat(
+		msat: Lightning_kmpMilliSatoshi,
+		originalFiat: OriginalFiat
+	) -> FormattedAmount? {
+		
+		return formatFiat(msat: msat.toLong(), originalFiat: originalFiat)
+	}
+	
+	/// Converts from millisatoshi to a fiat amount, using the original exchange rate.
+	///
+	/// - Returns: A FormattedAmount struct, which contains the various string values needed for display.
+	///
+	static func formatFiat(
+		msat: Int64,
+		originalFiat: OriginalFiat
+	) -> FormattedAmount? {
+		
+		guard let fiatCurrency = FiatCurrency.companion.valueOfOrNull(code: originalFiat.type) else {
+			return nil
+		}
+		
+		let fiatAmount = convertToFiat(msat: msat, originalFiat: originalFiat)
+		return formatFiat(amount: fiatAmount, fiatCurrency: fiatCurrency)
 	}
 	
 	static func formatFiat(

--- a/phoenix-ios/phoenix-ios/utils/Utils.swift
+++ b/phoenix-ios/phoenix-ios/utils/Utils.swift
@@ -71,18 +71,6 @@ class Utils {
 		return fiat
 	}
 	
-	static func convertToFiat(msat: Int64, originalFiat: OriginalFiat) -> Double {
-		
-		// OriginalFiat.rate: Double { get }
-		//
-		// originalFiat.rate => value of 1.0 BTC in fiat
-		
-		let btc = Double(msat) / Millisatoshis_Per_Bitcoin
-		let fiat = btc * originalFiat.rate
-		
-		return fiat
-	}
-	
 	/// Formats the given amount of satoshis into a FormattedAmount struct,
 	/// which contains the various string values needed for display.
 	///
@@ -432,60 +420,6 @@ class Utils {
 		
 		let fiatAmount = convertToFiat(msat: msat, exchangeRate: exchangeRate)
 		return formatFiat(amount: fiatAmount, fiatCurrency: exchangeRate.fiatCurrency)
-	}
-	
-	/// Converts from satoshi to a fiat amount, using the original exchange rate.
-	///
-	/// - Returns: A FormattedAmount struct, which contains the various string values needed for display.
-	///
-	static func formatFiat(
-		sat: Bitcoin_kmpSatoshi,
-		originalFiat: OriginalFiat
-	) -> FormattedAmount? {
-		
-		return formatFiat(sat: sat.toLong(), originalFiat: originalFiat)
-	}
-	
-	/// Converts from satoshi to a fiat amount, using the original exchange rate.
-	///
-	/// - Returns: A FormattedAmount struct, which contains the various string values needed for display.
-	///
-	static func formatFiat(
-		sat: Int64,
-		originalFiat: OriginalFiat
-	) -> FormattedAmount? {
-		
-		let msat = sat * Int64(Millisatoshis_Per_Satoshi)
-		return formatFiat(msat: msat, originalFiat: originalFiat)
-	}
-	
-	/// Converts from millisatoshi to a fiat amount, using the original exchange rate.
-	///
-	/// - Returns: A FormattedAmount struct, which contains the various string values needed for display.
-	///
-	static func formatFiat(
-		msat: Lightning_kmpMilliSatoshi,
-		originalFiat: OriginalFiat
-	) -> FormattedAmount? {
-		
-		return formatFiat(msat: msat.toLong(), originalFiat: originalFiat)
-	}
-	
-	/// Converts from millisatoshi to a fiat amount, using the original exchange rate.
-	///
-	/// - Returns: A FormattedAmount struct, which contains the various string values needed for display.
-	///
-	static func formatFiat(
-		msat: Int64,
-		originalFiat: OriginalFiat
-	) -> FormattedAmount? {
-		
-		guard let fiatCurrency = FiatCurrency.companion.valueOfOrNull(code: originalFiat.type) else {
-			return nil
-		}
-		
-		let fiatAmount = convertToFiat(msat: msat, originalFiat: originalFiat)
-		return formatFiat(amount: fiatAmount, fiatCurrency: fiatCurrency)
 	}
 	
 	static func formatFiat(

--- a/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
@@ -1028,7 +1028,10 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 		return (minutesStr, secondsStr)
 	}
 	
-	func displayAmounts(msat: Lightning_kmpMilliSatoshi, originalFiat: OriginalFiat?) -> DisplayAmounts {
+	func displayAmounts(
+		msat: Lightning_kmpMilliSatoshi,
+		originalFiat: ExchangeRate.BitcoinPriceRate?
+	) -> DisplayAmounts {
 		
 		let bitcoin = Utils.formatBitcoin(msat: msat, bitcoinUnit: .sat, policy: .showMsats)
 		var fiatCurrent: FormattedAmount? = nil
@@ -1038,13 +1041,16 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 			fiatCurrent = Utils.formatFiat(msat: msat, exchangeRate: fiatExchangeRate)
 		}
 		if let originalFiat = originalFiat {
-			fiatOriginal = Utils.formatFiat(msat: msat, originalFiat: originalFiat)
+			fiatOriginal = Utils.formatFiat(msat: msat, exchangeRate: originalFiat)
 		}
 		
 		return DisplayAmounts(bitcoin: bitcoin, fiatCurrent: fiatCurrent, fiatOriginal: fiatOriginal)
 	}
 	
-	func displayAmounts(sat: Bitcoin_kmpSatoshi, originalFiat: OriginalFiat?) -> DisplayAmounts {
+	func displayAmounts(
+		sat: Bitcoin_kmpSatoshi,
+		originalFiat: ExchangeRate.BitcoinPriceRate?
+	) -> DisplayAmounts {
 		
 		let bitcoin = Utils.formatBitcoin(sat: sat, bitcoinUnit: .sat)
 		var fiatCurrent: FormattedAmount? = nil
@@ -1054,7 +1060,7 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 			fiatCurrent = Utils.formatFiat(sat: sat, exchangeRate: fiatExchangeRate)
 		}
 		if let originalFiat = originalFiat {
-			fiatOriginal = Utils.formatFiat(sat: sat, originalFiat: originalFiat)
+			fiatOriginal = Utils.formatFiat(sat: sat, exchangeRate: originalFiat)
 		}
 		
 		return DisplayAmounts(bitcoin: bitcoin, fiatCurrent: fiatCurrent, fiatOriginal: fiatOriginal)

--- a/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
@@ -160,9 +160,9 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 			
 			offChain_completedAt(offChain)
 			offChain_elapsed(outgoingPayment)
-			offChain_amountReceived(outgoingPayment)
+			offChain_amountSent(outgoingPayment)
 			offChain_fees(outgoingPayment)
-			offChain_totalAmount(outgoingPayment)
+			offChain_amountReceived(outgoingPayment)
 			offChain_recipientPubkey(outgoingPayment)
 		
 		} else if let onChain = outgoingPayment.status.asOnChain() {
@@ -656,6 +656,8 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 					Text(verbatim: display_msat.string)
 				}
 				
+				Text(verbatim: display_percent)
+				
 				if let display_fiatCurrent = display_amounts.fiatCurrent {
 					Text(verbatim: "≈ \(display_fiatCurrent.string)") +
 					Text(" (now)")
@@ -666,14 +668,12 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 					Text(" (original)")
 						.foregroundColor(.secondary)
 				}
-				
-				Text(verbatim: display_percent)
 			}
 		}
 	}
 	
 	@ViewBuilder
-	func offChain_totalAmount(_ outgoingPayment: Lightning_kmpOutgoingPayment) -> some View {
+	func offChain_amountSent(_ outgoingPayment: Lightning_kmpOutgoingPayment) -> some View {
 		let identifier: String = #function
 		
 		InfoGridRowWrapper(
@@ -682,7 +682,7 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 			keyColumnWidth: keyColumnWidth(identifier: identifier)
 		) {
 			
-			keyColumn(NSLocalizedString("total amount", comment: "Label in DetailsView_IncomingPayment"))
+			keyColumn(NSLocalizedString("amount sent", comment: "Label in DetailsView_IncomingPayment"))
 			
 		} valueColumn: {
 			

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/WalletPayment.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/WalletPayment.kt
@@ -100,7 +100,7 @@ data class WalletPaymentInfo(
  */
 data class WalletPaymentMetadata(
     val lnurl: LnurlPayMetadata? = null,
-    val originalFiat: OriginalFiat? = null,
+    val originalFiat: ExchangeRate.BitcoinPriceRate? = null,
     val userDescription: String? = null,
     val userNotes: String? = null,
     val modifiedAt: Long? = null
@@ -113,11 +113,6 @@ data class LnurlPayMetadata(
 ) {
     companion object {/* allow companion extensions */}
 }
-
-data class OriginalFiat(
-    val type: String,
-    val rate: Double // BitcoinPriceRate.price
-)
 
 /**
  * Represents options when fetching data from the `payments_metadata` table.

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/WalletPayment.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/WalletPayment.kt
@@ -100,6 +100,7 @@ data class WalletPaymentInfo(
  */
 data class WalletPaymentMetadata(
     val lnurl: LnurlPayMetadata? = null,
+    val originalFiat: OriginalFiat? = null,
     val userDescription: String? = null,
     val userNotes: String? = null,
     val modifiedAt: Long? = null
@@ -112,6 +113,11 @@ data class LnurlPayMetadata(
 ) {
     companion object {/* allow companion extensions */}
 }
+
+data class OriginalFiat(
+    val type: String,
+    val rate: Double // BitcoinPriceRate.price
+)
 
 /**
  * Represents options when fetching data from the `payments_metadata` table.
@@ -138,7 +144,8 @@ data class WalletPaymentFetchOptions(val flags: Int) { // <- bitmask
         val Descriptions = WalletPaymentFetchOptions(1 shl 0)
         val Lnurl = WalletPaymentFetchOptions(1 shl 1)
         val UserNotes = WalletPaymentFetchOptions(1 shl 2)
+        val OriginalFiat = WalletPaymentFetchOptions(1 shl 3)
 
-        val All = Descriptions + Lnurl + UserNotes
+        val All = Descriptions + Lnurl + UserNotes + OriginalFiat
     }
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
@@ -466,7 +466,9 @@ class SqlitePaymentsDb(
         return if (row.original_fiat != null) {
             row
         } else {
-            row.copy(original_fiat = currencyManager?.calculateOriginalFiat())
+            row.copy(original_fiat = currencyManager?.calculateOriginalFiat()?.let {
+                Pair(it.fiatCurrency.name, it.price)
+            })
         }
     }
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
@@ -27,6 +27,7 @@ import fr.acinq.lightning.channel.ChannelException
 import fr.acinq.lightning.db.*
 import fr.acinq.lightning.utils.Either
 import fr.acinq.lightning.utils.UUID
+import fr.acinq.lightning.utils.ensureNeverFrozen
 import fr.acinq.lightning.utils.toByteVector32
 import fr.acinq.lightning.wire.FailureMessage
 import fr.acinq.phoenix.data.WalletPaymentId
@@ -43,50 +44,103 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
 
 class SqlitePaymentsDb(
     driver: SqlDriver,
     private val currencyManager: CurrencyManager? = null
 ) : PaymentsDb {
 
-    private val database = PaymentsDatabase(
-        driver = driver,
-        outgoing_payment_partsAdapter = Outgoing_payment_parts.Adapter(
-            part_routeAdapter = OutgoingQueries.hopDescAdapter,
-            part_status_typeAdapter = EnumColumnAdapter()
-        ),
-        outgoing_paymentsAdapter = Outgoing_payments.Adapter(
-            status_typeAdapter = EnumColumnAdapter(),
-            details_typeAdapter = EnumColumnAdapter()
-        ),
-        incoming_paymentsAdapter = Incoming_payments.Adapter(
-            origin_typeAdapter = EnumColumnAdapter(),
-            received_with_typeAdapter = EnumColumnAdapter()
-        ),
-        payments_metadataAdapter = Payments_metadata.Adapter(
-            lnurl_base_typeAdapter = EnumColumnAdapter(),
-            lnurl_metadata_typeAdapter = EnumColumnAdapter(),
-            lnurl_successAction_typeAdapter = EnumColumnAdapter()
-        )
-    )
-    private val inQueries = IncomingQueries(database)
-    internal val outQueries = OutgoingQueries(database)
-    private val aggrQueries = database.aggregatedQueriesQueries
-    private val metaQueries = MetadataQueries(database)
+    init {
+        ensureNeverFrozen() // Crashes when attempting to freeze CurrencyManager sub-graph
+    }
 
-    val cloudKitDb = makeCloudKitDb(database)
+    /**
+     * Within `SqlitePaymentsDb`, we are using background threads.
+     * ```
+     * withContext(Dispatchers.Default) {
+     *     // code running in background thread here...
+     * }
+     * ```
+     * Recall that kotlin-native has that horrible unworkable memory management "feature",
+     * where it attempts to freeze the object sub-graph of any object moved between threads.
+     * This means that:
+     * ```
+     * withContext(Dispatchers.Default) {
+     *     // Any object we access within this lambda will be frozen.
+     *     localVariable.function() // implicitly accesses this...
+     *     // Thus kotlin-native will freeze `this`, and ALL local variables too.
+     *     // Which results in a crash.
+     * }
+     * ```
+     * There are various workarounds for this problem. In the long-term, the preferred solution
+     * is to disable kotlin's unworkable ridiculous policy. Which is possible in v1.6.0.
+     * But for the time being, the simplest solution is:
+     * ```
+     * val variable = localVariable
+     * withContext(Dispatchers.Default) {
+     *     variable.function() // only freeze variable, and not `this`
+     * }
+     * ```
+     */
+    private class Properties(driver: SqlDriver) {
+        val database = PaymentsDatabase(
+            driver = driver,
+            outgoing_payment_partsAdapter = Outgoing_payment_parts.Adapter(
+                part_routeAdapter = OutgoingQueries.hopDescAdapter,
+                part_status_typeAdapter = EnumColumnAdapter()
+            ),
+            outgoing_paymentsAdapter = Outgoing_payments.Adapter(
+                status_typeAdapter = EnumColumnAdapter(),
+                details_typeAdapter = EnumColumnAdapter()
+            ),
+            incoming_paymentsAdapter = Incoming_payments.Adapter(
+                origin_typeAdapter = EnumColumnAdapter(),
+                received_with_typeAdapter = EnumColumnAdapter()
+            ),
+            payments_metadataAdapter = Payments_metadata.Adapter(
+                lnurl_base_typeAdapter = EnumColumnAdapter(),
+                lnurl_metadata_typeAdapter = EnumColumnAdapter(),
+                lnurl_successAction_typeAdapter = EnumColumnAdapter()
+            )
+        )
+        val inQueries = IncomingQueries(database)
+        val outQueries = OutgoingQueries(database)
+        val aggrQueries = database.aggregatedQueriesQueries
+        val metaQueries = MetadataQueries(database)
+
+        val cloudKitDb = makeCloudKitDb(database)
+    }
+    private val _doNotFreezeMe = Properties(driver)
+
+    fun getCloudKitDb(): CloudKitInterface? {
+        return _doNotFreezeMe.cloudKitDb
+    }
 
     private var metadataQueue = MutableStateFlow(mapOf<WalletPaymentId, WalletPaymentMetadataRow>())
 
-    override suspend fun addOutgoingParts(parentId: UUID, parts: List<OutgoingPayment.Part>) {
+    override suspend fun addOutgoingParts(
+        parentId: UUID,
+        parts: List<OutgoingPayment.Part>
+    ) {
+        val outQueries = _doNotFreezeMe.outQueries
+
         withContext(Dispatchers.Default) {
             outQueries.addOutgoingParts(parentId, parts)
         }
     }
 
-    override suspend fun addOutgoingPayment(outgoingPayment: OutgoingPayment) {
+    override suspend fun addOutgoingPayment(
+        outgoingPayment: OutgoingPayment
+    ) {
+        val database = _doNotFreezeMe.database
+        val outQueries = _doNotFreezeMe.outQueries
+        val metaQueries = _doNotFreezeMe.metaQueries
+
         val paymentId = outgoingPayment.walletPaymentId()
         val metadataRow = dequeueMetadata(paymentId)
+
         withContext(Dispatchers.Default) {
             database.transaction {
                 outQueries.addOutgoingPayment(outgoingPayment)
@@ -99,31 +153,56 @@ class SqlitePaymentsDb(
         }
     }
 
-    override suspend fun completeOutgoingPayment(id: UUID, completed: OutgoingPayment.Status.Completed) {
+    override suspend fun completeOutgoingPayment(
+        id: UUID,
+        completed: OutgoingPayment.Status.Completed
+    ) {
+        val outQueries = _doNotFreezeMe.outQueries
+
         withContext(Dispatchers.Default) {
             outQueries.completeOutgoingPayment(id, completed)
         }
     }
 
-    override suspend fun updateOutgoingPart(partId: UUID, preimage: ByteVector32, completedAt: Long) {
+    override suspend fun updateOutgoingPart(
+        partId: UUID,
+        preimage: ByteVector32,
+        completedAt: Long
+    ) {
+        val outQueries = _doNotFreezeMe.outQueries
+
         withContext(Dispatchers.Default) {
             outQueries.updateOutgoingPart(partId, preimage, completedAt)
         }
     }
 
-    override suspend fun updateOutgoingPart(partId: UUID, failure: Either<ChannelException, FailureMessage>, completedAt: Long) {
+    override suspend fun updateOutgoingPart(
+        partId: UUID,
+        failure: Either<ChannelException, FailureMessage>,
+        completedAt: Long
+    ) {
+        val outQueries = _doNotFreezeMe.outQueries
+
         withContext(Dispatchers.Default) {
             outQueries.updateOutgoingPart(partId, failure, completedAt)
         }
     }
 
-    override suspend fun getOutgoingPart(partId: UUID): OutgoingPayment? {
+    override suspend fun getOutgoingPart(
+        partId: UUID
+    ): OutgoingPayment? {
+        val outQueries = _doNotFreezeMe.outQueries
+
         return withContext(Dispatchers.Default) {
             outQueries.getOutgoingPart(partId)
         }
     }
 
-    override suspend fun getOutgoingPayment(id: UUID): OutgoingPayment? {
+    override suspend fun getOutgoingPayment(
+        id: UUID
+    ): OutgoingPayment? {
+        val outQueries = _doNotFreezeMe.outQueries
+
         return withContext(Dispatchers.Default) {
             outQueries.getOutgoingPayment(id)
         }
@@ -133,6 +212,10 @@ class SqlitePaymentsDb(
         id: UUID,
         options: WalletPaymentFetchOptions
     ): Pair<OutgoingPayment, WalletPaymentMetadata?>? {
+        val database = _doNotFreezeMe.database
+        val outQueries = _doNotFreezeMe.outQueries
+        val metaQueries = _doNotFreezeMe.metaQueries
+
         return withContext(Dispatchers.Default) {
             database.transactionWithResult {
                 outQueries.getOutgoingPayment(id)?.let { payment ->
@@ -148,14 +231,24 @@ class SqlitePaymentsDb(
 
     // ---- list outgoing
 
-    override suspend fun listOutgoingPayments(paymentHash: ByteVector32): List<OutgoingPayment> {
+    override suspend fun listOutgoingPayments(
+        paymentHash: ByteVector32
+    ): List<OutgoingPayment> {
+        val outQueries = _doNotFreezeMe.outQueries
+
         return withContext(Dispatchers.Default) {
             outQueries.listOutgoingPayments(paymentHash)
         }
     }
 
     @Deprecated("This method uses offset and has bad performances, use seek method instead when possible")
-    override suspend fun listOutgoingPayments(count: Int, skip: Int, filters: Set<PaymentTypeFilter>): List<OutgoingPayment> {
+    override suspend fun listOutgoingPayments(
+        count: Int,
+        skip: Int,
+        filters: Set<PaymentTypeFilter>
+    ): List<OutgoingPayment> {
+        val outQueries = _doNotFreezeMe.outQueries
+
         return withContext(Dispatchers.Default) {
             outQueries.listOutgoingPayments(count, skip)
         }
@@ -168,9 +261,14 @@ class SqlitePaymentsDb(
         origin: IncomingPayment.Origin,
         createdAt: Long
     ) {
+        val database = _doNotFreezeMe.database
+        val inQueries = _doNotFreezeMe.inQueries
+        val metaQueries = _doNotFreezeMe.metaQueries
+
         val paymentHash = Crypto.sha256(preimage).toByteVector32()
         val paymentId = WalletPaymentId.IncomingPaymentId(paymentHash)
         val metadataRow = dequeueMetadata(paymentId)
+
         withContext(Dispatchers.Default) {
             database.transaction {
                 inQueries.addIncomingPayment(
@@ -192,6 +290,9 @@ class SqlitePaymentsDb(
         receivedWith: Set<IncomingPayment.ReceivedWith>,
         receivedAt: Long
     ) {
+        val database = _doNotFreezeMe.database
+        val inQueries = _doNotFreezeMe.inQueries
+
         withContext(Dispatchers.Default) {
             database.transaction {
                 inQueries.receivePayment(paymentHash, receivedWith, receivedAt)
@@ -206,9 +307,14 @@ class SqlitePaymentsDb(
         createdAt: Long,
         receivedAt: Long
     ) {
+        val database = _doNotFreezeMe.database
+        val inQueries = _doNotFreezeMe.inQueries
+        val metaQueries = _doNotFreezeMe.metaQueries
+
         val paymentHash = Crypto.sha256(preimage).toByteVector32()
         val paymentId = WalletPaymentId.IncomingPaymentId(paymentHash)
         val metadataRow = dequeueMetadata(paymentId)
+
         withContext(Dispatchers.Default) {
             database.transaction {
                 inQueries.addAndReceivePayment(
@@ -226,13 +332,22 @@ class SqlitePaymentsDb(
         }
     }
 
-    override suspend fun updateNewChannelReceivedWithChannelId(paymentHash: ByteVector32, channelId: ByteVector32) {
+    override suspend fun updateNewChannelReceivedWithChannelId(
+        paymentHash: ByteVector32,
+        channelId: ByteVector32
+    ) {
+        val inQueries = _doNotFreezeMe.inQueries
+
         withContext(Dispatchers.Default) {
             inQueries.updateNewChannelReceivedWithChannelId(paymentHash, channelId)
         }
     }
 
-    override suspend fun getIncomingPayment(paymentHash: ByteVector32): IncomingPayment? {
+    override suspend fun getIncomingPayment(
+        paymentHash: ByteVector32
+    ): IncomingPayment? {
+        val inQueries = _doNotFreezeMe.inQueries
+
         return withContext(Dispatchers.Default) {
             inQueries.getIncomingPayment(paymentHash)
         }
@@ -242,6 +357,10 @@ class SqlitePaymentsDb(
         paymentHash: ByteVector32,
         options: WalletPaymentFetchOptions
     ): Pair<IncomingPayment, WalletPaymentMetadata?>? {
+        val database = _doNotFreezeMe.database
+        val inQueries = _doNotFreezeMe.inQueries
+        val metaQueries = _doNotFreezeMe.metaQueries
+
         return withContext(Dispatchers.Default) {
             database.transactionWithResult {
                 inQueries.getIncomingPayment(paymentHash)?.let { payment ->
@@ -255,7 +374,13 @@ class SqlitePaymentsDb(
         }
     }
 
-    override suspend fun listReceivedPayments(count: Int, skip: Int, filters: Set<PaymentTypeFilter>): List<IncomingPayment> {
+    override suspend fun listReceivedPayments(
+        count: Int,
+        skip: Int,
+        filters: Set<PaymentTypeFilter>
+    ): List<IncomingPayment> {
+        val inQueries = _doNotFreezeMe.inQueries
+
         return withContext(Dispatchers.Default) {
             inQueries.listReceivedPayments(count, skip)
         }
@@ -264,18 +389,27 @@ class SqlitePaymentsDb(
     // ---- list ALL payments
 
     suspend fun listPaymentsCount(): Long {
+        val aggrQueries = _doNotFreezeMe.aggrQueries
+
         return withContext(Dispatchers.Default) {
             aggrQueries.listAllPaymentsCount(::allPaymentsCountMapper).executeAsList().first()
         }
     }
 
     suspend fun listPaymentsCountFlow(): Flow<Long> {
+        val aggrQueries = _doNotFreezeMe.aggrQueries
+
         return withContext(Dispatchers.Default) {
             aggrQueries.listAllPaymentsCount(::allPaymentsCountMapper).asFlow().mapToOne()
         }
     }
 
-    suspend fun listPaymentsOrder(count: Int, skip: Int): List<WalletPaymentOrderRow> {
+    suspend fun listPaymentsOrder(
+        count: Int,
+        skip: Int
+    ): List<WalletPaymentOrderRow> {
+        val aggrQueries = _doNotFreezeMe.aggrQueries
+
         return withContext(Dispatchers.Default) {
             aggrQueries.listAllPaymentsOrder(
                 limit = count.toLong(),
@@ -285,7 +419,12 @@ class SqlitePaymentsDb(
         }
     }
 
-    suspend fun listPaymentsOrderFlow(count: Int, skip: Int): Flow<List<WalletPaymentOrderRow>> {
+    suspend fun listPaymentsOrderFlow(
+        count: Int,
+        skip: Int
+    ): Flow<List<WalletPaymentOrderRow>> {
+        val aggrQueries = _doNotFreezeMe.aggrQueries
+
         return withContext(Dispatchers.Default) {
             aggrQueries.listAllPaymentsOrder(
                 limit = count.toLong(),
@@ -336,6 +475,8 @@ class SqlitePaymentsDb(
         userDescription: String?,
         userNotes: String?
     ) {
+        val metaQueries = _doNotFreezeMe.metaQueries
+
         withContext(Dispatchers.Default) {
             metaQueries.updateUserInfo(
                 id = id,
@@ -348,6 +489,8 @@ class SqlitePaymentsDb(
     suspend fun deletePayment(
         paymentId: WalletPaymentId
     ) {
+        val database = _doNotFreezeMe.database
+
         withContext(Dispatchers.Default) {
             database.transaction {
                 when (paymentId) {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudAsset.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudAsset.kt
@@ -1,7 +1,8 @@
 package fr.acinq.phoenix.db.cloud
 
 import fr.acinq.lightning.utils.currentTimestampMillis
-import fr.acinq.phoenix.data.OriginalFiat
+import fr.acinq.phoenix.data.ExchangeRate
+import fr.acinq.phoenix.data.FiatCurrency
 import fr.acinq.phoenix.db.payments.LNUrlBase
 import fr.acinq.phoenix.db.payments.LNUrlMetadata
 import fr.acinq.phoenix.db.payments.LNUrlSuccessAction
@@ -101,7 +102,7 @@ fun WalletPaymentMetadataRow.cloudSerialize(): ByteArray {
         user_description = user_description,
         user_notes = user_notes,
         original_fiat = original_fiat?.let {
-            CloudAsset.OriginalFiatWrapper(it.type, it.rate)
+            CloudAsset.OriginalFiatWrapper(it.first, it.second)
         }
     )
     return Cbor.encodeToByteArray(wrapper)
@@ -131,7 +132,7 @@ fun CloudAsset.Companion.cloudDeserialize(blob: ByteArray): WalletPaymentMetadat
         user_description = wrapper.user_description,
         user_notes = wrapper.user_notes,
         original_fiat = wrapper.original_fiat?.let {
-          OriginalFiat(it.type, it.rate)
+            Pair(it.type, it.rate)
         },
         modified_at = currentTimestampMillis()
     )

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudAsset.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/CloudAsset.kt
@@ -1,6 +1,7 @@
 package fr.acinq.phoenix.db.cloud
 
 import fr.acinq.lightning.utils.currentTimestampMillis
+import fr.acinq.phoenix.data.OriginalFiat
 import fr.acinq.phoenix.db.payments.LNUrlBase
 import fr.acinq.phoenix.db.payments.LNUrlMetadata
 import fr.acinq.phoenix.db.payments.LNUrlSuccessAction
@@ -11,9 +12,27 @@ import kotlinx.serialization.cbor.Cbor
 
 enum class CloudAssetVersion(val value: Int) {
     // Initial version
-    V0(0)
+    V0(0),
+    // V1:
+    // - added `original_fiat`
+    V1(1)
     // Future versions go here
 }
+
+// Upgrade notes:
+// If needed in the future, you can use code like this to extract only the version:
+//
+// data class CloudAssetVersion(
+//    @SerialName("v")
+//    val version: Int
+// )
+// val version: CloudAssetVersion = try {
+//    Cbor {
+//       ignoreUnknownKeys = true
+//    }.decodeFromByteArray(blob)
+// } catch (e: Throwable) {
+//    return null
+// }
 
 @Serializable
 @OptIn(ExperimentalSerializationApi::class)
@@ -26,6 +45,7 @@ data class CloudAsset(
     val lnurl_description: String?,
     val user_description: String?,
     val user_notes: String?,
+    val original_fiat: OriginalFiatWrapper? = null // added in V1
 ) {
     @Serializable
     @OptIn(ExperimentalSerializationApi::class)
@@ -56,11 +76,18 @@ data class CloudAsset(
     ) {
         var typeVersion = LNUrlSuccessAction.TypeVersion.valueOf(type)
     }
+
+    @Serializable
+    @OptIn(ExperimentalSerializationApi::class)
+    data class OriginalFiatWrapper(
+        val type: String,
+        val rate: Double
+    )
 }
 
 fun WalletPaymentMetadataRow.cloudSerialize(): ByteArray {
     val wrapper = CloudAsset(
-        version = CloudAssetVersion.V0.value,
+        version = CloudAssetVersion.V1.value,
         lnurl_base = lnurl_base?.let {
             CloudAsset.LNUrlBaseWrapper(it.first.name, it.second)
         },
@@ -72,7 +99,10 @@ fun WalletPaymentMetadataRow.cloudSerialize(): ByteArray {
         },
         lnurl_description = lnurl_description,
         user_description = user_description,
-        user_notes = user_notes
+        user_notes = user_notes,
+        original_fiat = original_fiat?.let {
+            CloudAsset.OriginalFiatWrapper(it.type, it.rate)
+        }
     )
     return Cbor.encodeToByteArray(wrapper)
 }
@@ -100,6 +130,9 @@ fun CloudAsset.Companion.cloudDeserialize(blob: ByteArray): WalletPaymentMetadat
         lnurl_description = wrapper.lnurl_description,
         user_description = wrapper.user_description,
         user_notes = wrapper.user_notes,
+        original_fiat = wrapper.original_fiat?.let {
+          OriginalFiat(it.type, it.rate)
+        },
         modified_at = currentTimestampMillis()
     )
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataQueries.kt
@@ -27,7 +27,9 @@ class MetadataQueries(val database: PaymentsDatabase) {
             lnurl_successAction_blob = data.lnurl_successAction?.second,
             user_description = data.user_description,
             user_notes = data.user_notes,
-            modified_at = data.modified_at
+            modified_at = data.modified_at,
+            original_fiat_type = data.original_fiat?.type,
+            original_fiat_rate = data.original_fiat?.rate
         )
     }
 
@@ -101,7 +103,9 @@ class MetadataQueries(val database: PaymentsDatabase) {
                     lnurl_successAction_blob = null,
                     user_description = userDescription,
                     user_notes = userNotes,
-                    modified_at = modifiedAt
+                    modified_at = modifiedAt,
+                    original_fiat_type = null,
+                    original_fiat_rate = null
                 )
             }
             didUpdateWalletPaymentMetadata(id, database)
@@ -134,7 +138,9 @@ class MetadataQueries(val database: PaymentsDatabase) {
             lnurl_successAction_blob: ByteArray?,
             user_description: String?,
             user_notes: String?,
-            modified_at: Long?
+            modified_at: Long?,
+            original_fiat_type: String?,
+            original_fiat_rate: Double?
         ): WalletPaymentMetadata {
             val lnurlBase =
                 if (lnurl_base_type != null && lnurl_base_blob != null) {
@@ -151,11 +157,17 @@ class MetadataQueries(val database: PaymentsDatabase) {
                     Pair(lnurl_successAction_type, lnurl_successAction_blob)
                 } else null
 
+            val originalFiat =
+                if (original_fiat_type != null && original_fiat_rate != null) {
+                    OriginalFiat(original_fiat_type, original_fiat_rate)
+                } else null
+
             return WalletPaymentMetadataRow(
                 lnurl_base = lnurlBase,
                 lnurl_metadata = lnurlMetadata,
                 lnurl_successAction = lnurlSuccesssAction,
                 lnurl_description = lnurl_description,
+                original_fiat = originalFiat,
                 user_description = user_description,
                 user_notes = user_notes,
                 modified_at = modified_at

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataQueries.kt
@@ -28,8 +28,8 @@ class MetadataQueries(val database: PaymentsDatabase) {
             user_description = data.user_description,
             user_notes = data.user_notes,
             modified_at = data.modified_at,
-            original_fiat_type = data.original_fiat?.type,
-            original_fiat_rate = data.original_fiat?.rate
+            original_fiat_type = data.original_fiat?.first,
+            original_fiat_rate = data.original_fiat?.second
         )
     }
 
@@ -159,7 +159,7 @@ class MetadataQueries(val database: PaymentsDatabase) {
 
             val originalFiat =
                 if (original_fiat_type != null && original_fiat_rate != null) {
-                    OriginalFiat(original_fiat_type, original_fiat_rate)
+                    Pair(original_fiat_type, original_fiat_rate)
                 } else null
 
             return WalletPaymentMetadataRow(

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataTypes.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataTypes.kt
@@ -5,6 +5,7 @@ import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.db.WalletPayment
 import fr.acinq.phoenix.data.LNUrl
 import fr.acinq.phoenix.data.LnurlPayMetadata
+import fr.acinq.phoenix.data.OriginalFiat
 import fr.acinq.phoenix.data.WalletPaymentMetadata
 import io.ktor.http.*
 import kotlinx.serialization.*
@@ -222,17 +223,18 @@ data class WalletPaymentMetadataRow(
     val lnurl_metadata: Pair<LNUrlMetadata.TypeVersion, ByteArray>? = null,
     val lnurl_successAction: Pair<LNUrlSuccessAction.TypeVersion, ByteArray>? = null,
     val lnurl_description: String? = null,
+    val original_fiat: OriginalFiat? = null,
     val user_description: String? = null,
     val user_notes: String? = null,
     val modified_at: Long? = null
 ) {
 
     fun deserialize(): WalletPaymentMetadata {
-        val base = lnurl_base?.let {
-            when (val base = LNUrlBase.deserialize(it.first, it.second)) {
+        val base = lnurl_base?.let { (baseType, baseBlob) ->
+            when (val base = LNUrlBase.deserialize(baseType, baseBlob)) {
                 is LNUrlBase.Pay -> {
-                    lnurl_metadata?.let { (type, blob) ->
-                        when (val metadata = LNUrlMetadata.deserialize(type, blob)) {
+                    lnurl_metadata?.let { (metaType, metaBlob) ->
+                        when (val metadata = LNUrlMetadata.deserialize(metaType, metaBlob)) {
                             is LNUrlMetadata.PayMetadata -> {
                                 metadata.unwrap()
                             }
@@ -258,10 +260,24 @@ data class WalletPaymentMetadataRow(
 
         return WalletPaymentMetadata(
             lnurl = lnurl,
+            originalFiat = original_fiat,
             userDescription = user_description,
             userNotes = user_notes,
             modifiedAt = modified_at
         )
+    }
+
+    /**
+     * Returns true if all columns are null (excluding modified_at).
+     */
+    fun isEmpty(): Boolean {
+        return lnurl_base == null
+            && lnurl_metadata == null
+            && lnurl_successAction == null
+            && lnurl_description == null
+            && original_fiat == null
+            && user_description == null
+            && user_notes == null
     }
 
     /**
@@ -291,24 +307,18 @@ data class WalletPaymentMetadataRow(
                 lnurlDescription = it.pay.metadata.plainText
             }
 
-            if (lnurlBase == null
-             && lnurlMetadata == null
-             && lnurlSuccessAction == null
-             && lnurlDescription == null
-             && metadata.userDescription == null
-             && metadata.userNotes == null) {
-                return null
-            }
-
-            return WalletPaymentMetadataRow(
+            val row = WalletPaymentMetadataRow(
                 lnurl_base = lnurlBase,
                 lnurl_metadata = lnurlMetadata,
                 lnurl_successAction = lnurlSuccessAction,
                 lnurl_description = lnurlDescription,
+                original_fiat = metadata.originalFiat,
                 user_description = metadata.userDescription,
                 user_notes = metadata.userNotes,
                 modified_at = metadata.modifiedAt
             )
+
+            return if (row.isEmpty()) null else row
         }
     }
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConfigurationManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConfigurationManager.kt
@@ -210,10 +210,26 @@ class AppConfigurationManager(
     }
 
     // Fiat preferences
-    private val _preferredFiatCurrencies by lazy { MutableStateFlow<List<FiatCurrency>>(listOf()) }
-    fun preferredFiatCurrencies(): StateFlow<List<FiatCurrency>> = _preferredFiatCurrencies
+    data class PreferredFiatCurrencies(
+        val primary: FiatCurrency,
+        val others: Set<FiatCurrency>
+    ) {
+        constructor(primary: FiatCurrency, others: List<FiatCurrency>):
+            this(primary = primary, others = others.toSet())
 
-    fun updatePreferredFiatCurrencies(list: List<FiatCurrency>) {
-        _preferredFiatCurrencies.value = list
+        val all: Set<FiatCurrency> get() {
+            return if (others.contains(primary)) {
+                others
+            } else {
+                others.toMutableSet().apply { add(primary) }
+            }
+        }
+    }
+
+    private val _preferredFiatCurrencies by lazy { MutableStateFlow<PreferredFiatCurrencies?>(null) }
+    fun preferredFiatCurrencies(): StateFlow<PreferredFiatCurrencies?> = _preferredFiatCurrencies
+
+    fun updatePreferredFiatCurrencies(current: PreferredFiatCurrencies) {
+        _preferredFiatCurrencies.value = current
     }
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/DatabaseManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/DatabaseManager.kt
@@ -46,8 +46,14 @@ class DatabaseManager(
                 log.info { "nodeParams available: building databases..." }
 
                 val nodeIdHash = nodeParams.nodeId.hash160().toHexString()
-                val channelsDb = SqliteChannelsDb(createChannelsDbDriver(ctx, chain, nodeIdHash), nodeParams.copy())
-                val paymentsDb = SqlitePaymentsDb(createPaymentsDbDriver(ctx, chain, nodeIdHash), currencyManager)
+                val channelsDb = SqliteChannelsDb(
+                    driver = createChannelsDbDriver(ctx, chain, nodeIdHash),
+                    nodeParams = nodeParams.copy()
+                )
+                val paymentsDb = SqlitePaymentsDb(
+                    driver = createPaymentsDbDriver(ctx, chain, nodeIdHash),
+                    currencyManager = currencyManager
+                )
                 log.debug { "databases object created" }
                 _databases.value = object : Databases {
                     override val channels: ChannelsDb get() = channelsDb

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/DatabaseManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/DatabaseManager.kt
@@ -22,14 +22,16 @@ class DatabaseManager(
     loggerFactory: LoggerFactory,
     private val ctx: PlatformContext,
     private val chain: Chain,
-    private val nodeParamsManager: NodeParamsManager
+    private val nodeParamsManager: NodeParamsManager,
+    private val currencyManager: CurrencyManager
 ) : CoroutineScope by MainScope() {
 
     constructor(business: PhoenixBusiness): this(
         loggerFactory = business.loggerFactory,
         ctx = business.ctx,
         chain = business.chain,
-        nodeParamsManager = business.nodeParamsManager
+        nodeParamsManager = business.nodeParamsManager,
+        currencyManager = business.currencyManager
     )
 
     private val log = newLogger(loggerFactory)
@@ -45,7 +47,7 @@ class DatabaseManager(
 
                 val nodeIdHash = nodeParams.nodeId.hash160().toHexString()
                 val channelsDb = SqliteChannelsDb(createChannelsDbDriver(ctx, chain, nodeIdHash), nodeParams.copy())
-                val paymentsDb = SqlitePaymentsDb(createPaymentsDbDriver(ctx, chain, nodeIdHash))
+                val paymentsDb = SqlitePaymentsDb(createPaymentsDbDriver(ctx, chain, nodeIdHash), currencyManager)
                 log.debug { "databases object created" }
                 _databases.value = object : Databases {
                     override val channels: ChannelsDb get() = channelsDb

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/PaymentsMetadata.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/PaymentsMetadata.sq
@@ -19,6 +19,8 @@ CREATE TABLE IF NOT EXISTS payments_metadata (
     user_description TEXT,
     user_notes TEXT DEFAULT NULL,
     modified_at INTEGER DEFAULT NULL,
+    original_fiat_type TEXT DEFAULT NULL,
+    original_fiat_rate REAL DEFAULT NULL,
     PRIMARY KEY (type, id)
 );
 
@@ -35,8 +37,9 @@ INSERT INTO payments_metadata (
             lnurl_metadata_type, lnurl_metadata_blob,
             lnurl_successAction_type, lnurl_successAction_blob,
             user_description, user_notes,
-            modified_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            modified_at,
+            original_fiat_type, original_fiat_rate)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 updateUserInfo:
 UPDATE payments_metadata

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/4.sqm
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/4.sqm
@@ -1,0 +1,8 @@
+-- Migration: v4 -> v5
+--
+-- Changes:
+-- * Added column: payments_metadata.original_fiat_type
+-- * Added column: payments_metadata.original_fiat_rate
+
+ALTER TABLE payments_metadata ADD COLUMN original_fiat_type TEXT DEFAULT NULL;
+ALTER TABLE payments_metadata ADD COLUMN original_fiat_rate REAL DEFAULT NULL;

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/CloudKitDb.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/CloudKitDb.kt
@@ -448,7 +448,9 @@ class CloudKitDb(
                             lnurl_description = row.lnurl_description,
                             user_description = row.user_description,
                             user_notes = row.user_notes,
-                            modified_at = row.modified_at
+                            modified_at = row.modified_at,
+                            original_fiat_type = row.original_fiat?.type,
+                            original_fiat_rate = row.original_fiat?.rate
                         )
                     }
                 } // </payments_metadata table>

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/CloudKitDb.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/CloudKitDb.kt
@@ -449,8 +449,8 @@ class CloudKitDb(
                             user_description = row.user_description,
                             user_notes = row.user_notes,
                             modified_at = row.modified_at,
-                            original_fiat_type = row.original_fiat?.type,
-                            original_fiat_rate = row.original_fiat?.rate
+                            original_fiat_type = row.original_fiat?.first,
+                            original_fiat_rate = row.original_fiat?.second
                         )
                     }
                 } // </payments_metadata table>


### PR DESCRIPTION
This PR is split into 3 commits, 1 per theme.

### Commit 1

Adds the original fiat exchange rate to the database.

There are 2 new columns for the `payments_metadata` table:

- original_fiat_type: TEXT
- original_fiat_rate: REAL

E.g.:

* original_fiat_type = USD
* original_fiat_rate = 47,912.90

With these values, we can convert things such as:

- total amount sent
- fees paid

And in order to facilitate storing this information, the AppConfigurationManager has been improved:

```kotlin
// Before:
fun updatePreferredFiatCurrencies(list: List<FiatCurrency>) {/**/}

// After:
fun updatePreferredFiatCurrencies(current: PreferredFiatCurrencies) {/**/}

data class PreferredFiatCurrencies(
  val primary: FiatCurrency,
  val others: Set<FiatCurrency>
) {/**/}
```

### Commit 2

Workaround for kotlin-native `freeze()` silliness

Within `SqlitePaymentsDb`, we are using background threads:

```kotlin
withContext(Dispatchers.Default) {
  // code running in background thread here...
}
```

Recall that kotlin-native has that horrible unworkable memory management "feature", where it attempts to freeze the object sub-graph of any object moved between threads. This means that:

```kotlin
withContext(Dispatchers.Default) {
  // Any object we access within this lambda will be frozen.
  localVariable.function() // implicitly accesses this...
  // Thus kotlin-native will freeze `this`, and ALL local variables too.
  // Which results in a crash.
}
```

There are various workarounds for this problem. In the long-term, the preferred solution is to disable kotlin's unworkable ridiculous policy. Which is possible in v1.6.0.

But for the time being, the simplest solution is:

```kotlin
val variable = localVariable
withContext(Dispatchers.Default) {
  variable.function() // only freeze variable, and not `this`
}
```

### Commit 3

Adds the original fiat amounts to the UI. For now we're just displaying this information within the "Payment Details" screen:

<img height="450" alt="Screen Shot 2022-03-29 at 09 39 12" src="https://user-images.githubusercontent.com/304604/160614658-92905024-0ba5-4486-ae09-9aa8b10d4949.png">

There are more ways in which we can integrate this new information into the UI. But the first step is to start storing the necessary information in the database.