### PR TITLE
Auto read clipboard in send screen

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		DC5AF4572677BBF7003C911B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DC5AF4552677BBF7003C911B /* Localizable.strings */; };
 		DC5EE4C927679C6300A3035C /* RestoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5EE4C827679C6300A3035C /* RestoreView.swift */; };
 		DC67654E25655D93004D4263 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC67654D25655D93004D4263 /* Colors.xcassets */; };
+		DC67E40B27F3798600496C04 /* AnimatedMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC67E40A27F3798600496C04 /* AnimatedMenu.swift */; };
 		DC682FE8258175CE00CA1114 /* Popover.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC682FE7258175CE00CA1114 /* Popover.swift */; };
 		DC71E7302723240E0063613D /* KotlinObservables.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC71E72F2723240E0063613D /* KotlinObservables.swift */; };
 		DC71E7332728645B0063613D /* CurrencyConverterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC71E7322728645B0063613D /* CurrencyConverterView.swift */; };
@@ -299,6 +300,7 @@
 		DC5AF4562677BBF7003C911B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DC5EE4C827679C6300A3035C /* RestoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreView.swift; sourceTree = "<group>"; };
 		DC67654D25655D93004D4263 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		DC67E40A27F3798600496C04 /* AnimatedMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedMenu.swift; sourceTree = "<group>"; };
 		DC682FE7258175CE00CA1114 /* Popover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Popover.swift; sourceTree = "<group>"; };
 		DC71E72F2723240E0063613D /* KotlinObservables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinObservables.swift; sourceTree = "<group>"; };
 		DC71E7322728645B0063613D /* CurrencyConverterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyConverterView.swift; sourceTree = "<group>"; };
@@ -433,6 +435,7 @@
 				DC33369726BAF721000E3F49 /* ShortSheet.swift */,
 				DCFD079026D84A380020DD8E /* HorizontalActivity.swift */,
 				DCEC6A1727A82A98002C20BA /* ImagePicker.swift */,
+				DC67E40A27F3798600496C04 /* AnimatedMenu.swift */,
 			);
 			path = widgets;
 			sourceTree = "<group>";
@@ -1040,6 +1043,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DC09085825B5E43900A46136 /* String+VersionComparison.swift in Sources */,
+				DC67E40B27F3798600496C04 /* AnimatedMenu.swift in Sources */,
 				DC2F431627B6983B0006FCC4 /* CopyOptionsSheet.swift in Sources */,
 				DCACF6FE2566D0BA0009B01E /* GenericPasswordConvertible.swift in Sources */,
 				DC33369826BAF721000E3F49 /* ShortSheet.swift in Sources */,

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		C8D7ABC95B979B59AF5A7CA7 /* InitializationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D7A209301A31C14A982ECD /* InitializationView.swift */; };
 		C8D7AFF5BC5754DBBEEB2688 /* ElectrumConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D7A1F8A123C59199C182C2 /* ElectrumConfigurationView.swift */; };
 		DC0732EC263CA6C3004CB88D /* PaymentOptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0732EB263CA6C3004CB88D /* PaymentOptionsView.swift */; };
+		DC08A51827FB39530041603B /* AnimatedChevron.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC08A51727FB39530041603B /* AnimatedChevron.swift */; };
+		DC08A51A27FB6C5F0041603B /* TopTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC08A51927FB6C5F0041603B /* TopTab.swift */; };
 		DC09085825B5E43900A46136 /* String+VersionComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC09085725B5E43900A46136 /* String+VersionComparison.swift */; };
 		DC09086325B626B300A46136 /* AppStatusPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC09086225B626B300A46136 /* AppStatusPopover.swift */; };
 		DC0994B0263A074C003031CA /* InfoGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0994AF263A074C003031CA /* InfoGrid.swift */; };
@@ -238,6 +240,8 @@
 		C8D7A986A61CCD64FA661B88 /* DisplayConfigurationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayConfigurationView.swift; sourceTree = "<group>"; };
 		C8D7AFF1A7C09789C6CF2D06 /* ConfigurationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationView.swift; sourceTree = "<group>"; };
 		DC0732EB263CA6C3004CB88D /* PaymentOptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentOptionsView.swift; sourceTree = "<group>"; };
+		DC08A51727FB39530041603B /* AnimatedChevron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedChevron.swift; sourceTree = "<group>"; };
+		DC08A51927FB6C5F0041603B /* TopTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTab.swift; sourceTree = "<group>"; };
 		DC09085725B5E43900A46136 /* String+VersionComparison.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+VersionComparison.swift"; sourceTree = "<group>"; };
 		DC09086225B626B300A46136 /* AppStatusPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatusPopover.swift; sourceTree = "<group>"; };
 		DC0994AF263A074C003031CA /* InfoGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoGrid.swift; sourceTree = "<group>"; };
@@ -436,6 +440,8 @@
 				DCFD079026D84A380020DD8E /* HorizontalActivity.swift */,
 				DCEC6A1727A82A98002C20BA /* ImagePicker.swift */,
 				DC67E40A27F3798600496C04 /* AnimatedMenu.swift */,
+				DC08A51727FB39530041603B /* AnimatedChevron.swift */,
+				DC08A51927FB6C5F0041603B /* TopTab.swift */,
 			);
 			path = widgets;
 			sourceTree = "<group>";
@@ -1112,6 +1118,7 @@
 				DC118BFE27B451890080BBAC /* MetadataSheet.swift in Sources */,
 				DCF360D02591018300E92031 /* CloseChannelsView.swift in Sources */,
 				DCFD079126D84A380020DD8E /* HorizontalActivity.swift in Sources */,
+				DC08A51827FB39530041603B /* AnimatedChevron.swift in Sources */,
 				C8D7ABC95B979B59AF5A7CA7 /* InitializationView.swift in Sources */,
 				DC89857F25914747007B253F /* UIApplicationState+Phoenix.swift in Sources */,
 				DCCD046127EE045C007D57A5 /* DetailsView.swift in Sources */,
@@ -1166,6 +1173,7 @@
 				DC2F431A27B699800006FCC4 /* ModifyInvoiceSheet.swift in Sources */,
 				DCD5FF4326A0D34B009CC666 /* EqualSizes.swift in Sources */,
 				F4AED298257A50CD009485C1 /* LogsConfigurationView.swift in Sources */,
+				DC08A51A27FB6C5F0041603B /* TopTab.swift in Sources */,
 				DC27E4CF2792079600C777CC /* CenterTopLineAlignment.swift in Sources */,
 				DC118BF827B44E6E0080BBAC /* LoginView.swift in Sources */,
 				DC74174D270F455D00F7E3E3 /* AES256.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions.swift
@@ -287,6 +287,43 @@ extension ExchangeRate {
 	}
 }
 
+extension LNUrl.Auth {
+	
+	static var defaultActionPromptTitle: String {
+		return NSLocalizedString("Authenticate", comment: "lnurl-auth: login button title")
+	}
+	
+	var actionPromptTitle: String {
+		if let action = self.action() {
+			switch action {
+				case .register_ : return NSLocalizedString("Register",     comment: "lnurl-auth: login button title")
+				case .login     : return NSLocalizedString("Login",        comment: "lnurl-auth: login button title")
+				case .link      : return NSLocalizedString("Link",         comment: "lnurl-auth: login button title")
+				case .auth      : return NSLocalizedString("Authenticate", comment: "lnurl-auth: login button title")
+				default         : break
+			}
+		}
+		return LNUrl.Auth.defaultActionPromptTitle
+	}
+	
+	static var defaultActionSuccessTitle: String {
+		return NSLocalizedString("Authenticated", comment: "lnurl-auth: success text")
+	}
+	
+	var actionSuccessTitle: String {
+		if let action = self.action() {
+			switch action {
+				case .register_ : return NSLocalizedString("Registered",    comment: "lnurl-auth: success text")
+				case .login     : return NSLocalizedString("Logged In",     comment: "lnurl-auth: success text")
+				case .link      : return NSLocalizedString("Linked",        comment: "lnurl-auth: success text")
+				case .auth      : return NSLocalizedString("Authenticated", comment: "lnurl-auth: success text")
+				default         : break
+			}
+		}
+		return LNUrl.Auth.defaultActionSuccessTitle
+	}
+}
+
 extension FiatCurrency {
 	
 	var shortName: String {

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinTypes.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinTypes.swift
@@ -70,6 +70,10 @@ extension Scan {
 	typealias BadRequestReason_ServiceError = BadRequestReasonServiceError
 	typealias BadRequestReason_UnknownFormat = BadRequestReasonUnknownFormat
 	typealias BadRequestReason_UnsupportedLnUrl = BadRequestReasonUnsupportedLnUrl
+	
+	typealias ClipboardContent_InvoiceRequest = ClipboardContentInvoiceRequest
+	typealias ClipboardContent_LoginRequest = ClipboardContentLoginRequest
+	typealias ClipboardContent_LnurlRequest = ClipboardContentLnurlRequest
 }
 
 extension LNUrl {

--- a/phoenix-ios/phoenix-ios/views/send/LoginView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/LoginView.swift
@@ -170,30 +170,12 @@ struct LoginView: View {
 	
 	func buttonTitle() -> String {
 		
-		if let action = auth?.action() {
-			switch action {
-				case .register_ : return NSLocalizedString("Register", comment: "lnurl-auth: login button title")
-				case .login     : return NSLocalizedString("Login",    comment: "lnurl-auth: login button title")
-				case .link      : return NSLocalizedString("Link",     comment: "lnurl-auth: login button title")
-				case .auth      : fallthrough
-				default         : break
-			}
-		}
-		return NSLocalizedString("Authenticate", comment: "lnurl-auth: login button title")
+		return auth?.actionPromptTitle ?? LNUrl.Auth.defaultActionPromptTitle
 	}
 	
 	func successTitle() -> String {
 		
-		if let action = auth?.action() {
-			switch action {
-				case .register_ : return NSLocalizedString("Registered", comment: "lnurl-auth: success text")
-				case .login     : return NSLocalizedString("Logged In",  comment: "lnurl-auth: success text")
-				case .link      : return NSLocalizedString("Linked",     comment: "lnurl-auth: success text")
-				case .auth      : fallthrough
-				default         : break
-			}
-		}
-		return NSLocalizedString("Authenticated", comment: "lnurl-auth: success text")
+		return auth?.actionSuccessTitle ?? LNUrl.Auth.defaultActionSuccessTitle
 	}
 	
 	func errorText() -> String? {

--- a/phoenix-ios/phoenix-ios/views/send/ScanView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/ScanView.swift
@@ -20,7 +20,7 @@ struct ScanView: View {
 	@Binding var paymentRequest: String?
 	
 	@State var showingFullMenu = false
-	@State var menuIcon: AnimatedMenu.Icon = .menuIcon
+	@State var chevronPosition: AnimatedChevron.Position = .pointingUp
 	@State var clipboardHasString = UIPasteboard.general.hasStrings
 	@State var clipboardContent: Scan.ClipboardContent? = nil
 	
@@ -123,37 +123,35 @@ struct ScanView: View {
 
 		VStack(alignment: HorizontalAlignment.center, spacing: 0) {
 
-			ZStack(alignment: Alignment.center) {
+			ZStack(alignment: Alignment.top) {
 				
-				Color.buttonFill
-					.frame(width: 42, height: 42)
-					.cornerRadius(100)
-					.overlay(
-						RoundedRectangle(cornerRadius: 100)
-							.stroke(Color(UIColor.separator), lineWidth: 1)
-					)
-					.onTapGesture {
-						withAnimation {
-							if showingFullMenu {
-								showingFullMenu = false
-								menuIcon = .menuIcon
-							} else {
-								showingFullMenu = true
-								menuIcon = .closeIcon
-							}
+				TopTab(
+					color: Color.primaryBackground,
+					size: CGSize(width: 72, height: 21)
+				)
+				.offset(y: 1)
+				.onTapGesture {
+					withAnimation {
+						if showingFullMenu {
+							showingFullMenu = false
+							chevronPosition = .pointingUp
+						} else {
+							showingFullMenu = true
+							chevronPosition = .pointingDown
 						}
 					}
+				}
 				
-				AnimatedMenu(
-					icon: $menuIcon,
+				AnimatedChevron(
+					position: $chevronPosition,
 					color: Color.appAccent,
-					lineWidth: 24,
-					lineHeight: 3,
-					lineSpacing: 6)
+					lineWidth: 22,
+					lineThickness: 3,
+					verticalOffset: 6
+				)
+				.offset(y: 7)
 				
 			} // </ZStack>
-			.padding(.horizontal, 10)
-			.offset(y: 10)
 			.zIndex(1)
 			
 			menuOptions()

--- a/phoenix-ios/phoenix-ios/views/widgets/AnimatedChevron.swift
+++ b/phoenix-ios/phoenix-ios/views/widgets/AnimatedChevron.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct ChevronShape: Shape {
+	let width: CGFloat
+	let height: CGFloat
+	var offset: CGFloat
+	
+	init(width: CGFloat, height: CGFloat, isPointingUp: Bool) {
+		self.width = width
+		self.height = height
+		self.offset = isPointingUp ? 0 : height
+	}
+	
+	var animatableData: CGFloat {
+		get { offset }
+		set { offset = newValue }
+	}
+	
+	func path(in rect: CGRect) -> Path {
+		Path { path in
+			path.move(to: CGPoint(x: 0, y: height/2))
+			path.addLine(to: CGPoint(x: width/2, y: offset))
+			path.move(to: CGPoint(x: width/2, y: offset))
+			path.addLine(to: CGPoint(x: width, y: height/2))
+		}
+	}
+}
+
+struct AnimatedChevron: View {
+	
+	enum Position {
+		case pointingUp
+		case pointingDown
+		
+		mutating func toggle() {
+			switch self {
+				case .pointingUp   : self = .pointingDown
+				case .pointingDown : self = .pointingUp
+			}
+		}
+	}
+	
+	@Binding var position: Position
+	
+	let color: Color
+	let lineWidth: CGFloat
+	let lineThickness: CGFloat
+	let verticalOffset: CGFloat
+	
+	var isPointingUp: Bool {
+		return position == .pointingUp
+	}
+	
+	var isPointingDown: Bool {
+		return position == .pointingDown
+	}
+	
+	var shapeSize: CGSize {
+		return CGSize(
+			width: lineWidth,
+			height: verticalOffset * 2
+		)
+	}
+	
+	var viewSize: CGSize {
+		return CGSize(
+			width: lineWidth + lineThickness,
+			height: (verticalOffset * 2) + lineThickness
+		)
+	}
+	
+	var body: some View {
+		
+		ChevronShape(
+			width: shapeSize.width,
+			height: shapeSize.height,
+			isPointingUp: isPointingUp
+		)
+		.stroke(style: StrokeStyle(lineWidth: lineThickness, lineCap: .round))
+		.foregroundColor(color)
+		.frame(width: shapeSize.width, height: shapeSize.height, alignment: Alignment.center)
+		.frame(width: viewSize.width, height: viewSize.height, alignment: Alignment.center)
+	}
+}

--- a/phoenix-ios/phoenix-ios/views/widgets/AnimatedMenu.swift
+++ b/phoenix-ios/phoenix-ios/views/widgets/AnimatedMenu.swift
@@ -1,0 +1,193 @@
+/**
+ * Class inspired by: Amos Gyamfi
+ * https://github.com/amosgyamfi
+ */
+
+import SwiftUI
+
+struct AnimatedMenu: View {
+	
+	enum Icon {
+		case menuIcon
+		case closeIcon
+	}
+	
+	@Binding var icon: Icon
+	
+	private let color: Color
+	private let lineWidth: CGFloat
+	private let lineHeight: CGFloat
+	private let lineSpacing: CGFloat
+	
+	init(icon: Binding<Icon>, color: Color, lineWidth: CGFloat, lineHeight: CGFloat, lineSpacing: CGFloat) {
+		self._icon = icon
+		self.color = color
+		self.lineWidth = lineWidth
+		self.lineHeight = lineHeight
+		self.lineSpacing = lineSpacing
+	}
+	
+	var isMenuIcon: Bool {
+		return icon == .menuIcon
+	}
+	
+	var isCloseIcon: Bool {
+		return icon == .closeIcon
+	}
+	
+	var body: some View {
+		VStack(alignment: .center, spacing: lineSpacing){
+				
+			Rectangle() // top
+				.fill(color)
+				.frame(width: isCloseIcon ? diagonalLength : lineWidth, height: lineHeight)
+				.cornerRadius(4)
+				.rotationEffect(isCloseIcon ? diagonalAngle : .zero, anchor: .topLeading)
+				.offset(x: isCloseIcon ? closeIconRect.origin.x : 0)
+				.offset(x: isCloseIcon ? xOffset : 0, y: isCloseIcon ? -yOffset : 0)
+				
+			Rectangle() // middle
+				.fill(color)
+				.frame(width: lineWidth, height: lineHeight)
+				.cornerRadius(4)
+				.scaleEffect(isCloseIcon ? 0 : 1)
+				.opacity(isCloseIcon ? 0 : 1)
+			
+			Rectangle() // bottom
+				.fill(color)
+				.frame(width: isCloseIcon ? diagonalLength : lineWidth, height: lineHeight)
+				.cornerRadius(4)
+				.rotationEffect(isCloseIcon ? diagonalAngle.negative : .zero, anchor: .bottomLeading)
+				.offset(x: isCloseIcon ? closeIconRect.origin.x : 0)
+				.offset(x: isCloseIcon ? xOffset : 0, y: isCloseIcon ? yOffset : 0)
+		}
+		.frame(width: lineWidth, height: menuIconSize.height, alignment: Alignment.leading)
+	}
+	
+	var menuIconSize: CGSize {
+		
+		return CGSize(
+			width: lineWidth,
+			height: (lineHeight * 3) + (lineSpacing * 2)
+		)
+	}
+	
+	var closeIconRect: CGRect {
+		
+		let menuIconSize = menuIconSize
+		if menuIconSize.width > menuIconSize.height {
+			
+			// If the menuIcon has longer width than height,
+			// then we create a square within it for the closeIcon.
+			
+			let squareSize = menuIconSize.height
+			let excessWidth = menuIconSize.width - squareSize
+			
+			return CGRect(x: (excessWidth / 2), y: 0, width: squareSize, height: squareSize)
+			
+		} else {
+			
+			return CGRect(origin: CGPoint(x: 0, y: 0), size: menuIconSize)
+		}
+	}
+	
+	var diagonalLength: CGFloat {
+		
+		//  |\
+		//  | \
+		// a|  \c <- this length
+		//  |___\
+		//    b
+		//
+		// a^2 + b^2 = c^2
+		
+		let closeIconRect = closeIconRect
+		let width = closeIconRect.size.width
+		let height = closeIconRect.size.height
+		return sqrt(pow(width, 2) + pow(height, 2))
+	}
+	
+	var diagonalAngle: Angle {
+		
+		//  |\ <-- this angle = ß
+		//  | \
+		// a|  \c
+		//  |___\
+		//    b
+		//
+		// ß = asin(a/c)
+		
+		let radians = asin(closeIconRect.size.height / diagonalLength)
+		return Angle.radians(radians)
+	}
+	
+	var yOffset: CGFloat {
+		
+		// Consider the bottom line.
+		// It's not actually a line - it's a rectangle (with height = lineHeight).
+		// And when we rotate it, we are using AnchorPoint.bottomLeading.
+		//
+		// ----------------
+		// |              |
+		// ----------------
+		// ^
+		// So it rotates from this bottom left point,
+		// and then the left edge of the rectangle looks like this:
+		//
+		//
+		// \  | <view frame
+		//  \ |    is here>
+		//   \|__________
+		// ^^
+		// Left edge is here, outside the view.
+		//
+		// So if we want it to be perfectly centered,
+		// then we need to use an offset.
+		//
+		// So we have a bit more trigonometry to do:
+		//
+		//  |\
+		// a| \c <- the left edge
+		//  |__\ <- this angle = α
+		//    b
+		//
+		// We know:
+		// c = lineHeight
+		// α = 180 - 90 - diagonalAngle
+		//
+		// Thus:
+		// a = c × sin(α)
+		
+		let c = lineHeight
+		let α = Angle(degrees: 90 - diagonalAngle.degrees)
+		
+		let a = c * sin(α.radians)
+		return (a / 2)
+	}
+
+	var xOffset: CGFloat {
+		
+		//  |\
+		// a| \c
+		//  |__\
+		//    b
+		//
+		// We already know a & c:
+		//
+		// b^2 = c^2 - a^2
+		//
+		
+		let c = lineHeight
+		let a = yOffset * 2
+		
+		let b = sqrt(pow(c, 2) - pow(a, 2))
+		return (b / 2)
+	}
+}
+
+extension Angle {
+	
+	var negative: Angle {
+		return Angle.radians(self.radians * -1.0)
+	}
+}

--- a/phoenix-ios/phoenix-ios/views/widgets/TopTab.swift
+++ b/phoenix-ios/phoenix-ios/views/widgets/TopTab.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct TopTab: View {
+	
+	let color: Color
+	let size: CGSize
+	
+	var body: some View {
+		
+		let radius = size.height
+		Path { p in
+			
+			// Left arc
+			p.move(to: CGPoint(x: radius, y: radius))
+			p.addLine(to: CGPoint(x: 0, y: radius))
+			p.addArc(
+				center: CGPoint(x: radius, y: radius),
+				radius: radius,
+				startAngle: Angle.degrees(-180),
+				endAngle: Angle.degrees(-90),
+				clockwise: false
+			)
+			p.addLine(to: CGPoint(x: radius, y: radius))
+
+			// Center square
+			p.move(to: CGPoint(x: radius, y: 0))
+			p.addRect(CGRect(
+				x: radius,
+				y: 0,
+				width: size.width - (radius * 2),
+				height: size.height
+			))
+			
+			// Right arc
+			p.move(to: CGPoint(x: size.width - radius, y: radius))
+			p.addLine(to: CGPoint(x: size.width - radius, y: 0))
+			p.addArc(
+				center: CGPoint(x: size.width - radius, y: radius),
+				radius: radius,
+				startAngle: Angle.degrees(-90),
+				endAngle: Angle.degrees(0),
+				clockwise: false
+			)
+			p.addLine(to: CGPoint(x: size.width - radius, y: radius))
+		}
+		.fill(color)
+		.frame(width: size.width, height: size.height, alignment: Alignment.center)
+	}
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/Scan.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/Scan.kt
@@ -175,4 +175,18 @@ object Scan {
             ) : LnurlAuthFlow()
         }
     }
+
+    sealed class ClipboardContent {
+        data class InvoiceRequest(
+            val paymentRequest: PaymentRequest
+        ): ClipboardContent()
+
+        data class LnurlRequest(
+            val url: Url
+        ) : ClipboardContent()
+
+        data class LoginRequest(
+            val auth: LNUrl.Auth
+        ) : ClipboardContent()
+    }
 }


### PR DESCRIPTION
Fixes issue #200 

We automatically read and parse the clipboard. Without fetching the LNURL, we can detect:

- Bolt 11 invoice
- LNUrl.Auth
- LNUrl (generic URL)

So we append this information to the "Paste from clipboard" button.

I also took this opportunity to improve the UI, based on the mock-ups from issue #200 

![clipboard_inspect](https://user-images.githubusercontent.com/304604/161127370-656ff1f7-7038-4b08-b292-40a9d8d9a9ce.gif)

And here's how we surface the other types:

<img width="289" alt="inspect_auth" src="https://user-images.githubusercontent.com/304604/161127456-12c328d8-6191-4418-ad3e-22ecfd08530d.png">

<img width="290" alt="inspect_lnurl" src="https://user-images.githubusercontent.com/304604/161127510-a3936181-b6f4-4812-849e-c576f94af385.png">

