### PR TITLE
Improving WalletPaymentInfo API

### DIFF
--- a/phoenix-ios/phoenix-ios/AppDelegate.swift
+++ b/phoenix-ios/phoenix-ios/AppDelegate.swift
@@ -386,7 +386,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MessagingDelegate {
 			let currencyPrefs = CurrencyPrefs()
 			let formattedAmt = Utils.format(currencyPrefs, msat: payment.amount)
 
-			let paymentInfo = WalletPaymentInfo(payment: payment, metadata: WalletPaymentMetadata.empty())
+			let paymentInfo = WalletPaymentInfo(
+				payment: payment,
+				metadata: WalletPaymentMetadata.empty(),
+				fetchOptions: WalletPaymentFetchOptions.companion.None
+			)
 			
 			var body: String
 			if let desc = paymentInfo.paymentDescription(), desc.count > 0 {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataQueries.kt
@@ -115,13 +115,16 @@ class MetadataQueries(val database: PaymentsDatabase) {
     companion object {
         fun mapDescriptions(
             lnurl_description: String?,
-            user_description: String?
+            user_description: String?,
+            modified_at: Long?
         ): WalletPaymentMetadata {
+            val lnurl = if (lnurl_description != null) {
+                LnurlPayMetadata.placeholder(lnurl_description)
+            } else null
             return WalletPaymentMetadata(
                 userDescription = user_description,
-                lnurl = if (lnurl_description != null) {
-                    LnurlPayMetadata.placeholder(lnurl_description)
-                } else null
+                lnurl = lnurl,
+                modifiedAt = modified_at
             )
         }
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsManager.kt
@@ -153,7 +153,8 @@ class PaymentsManager(
             paymentsDb().getIncomingPayment(id.paymentHash, options)?.let {
                 WalletPaymentInfo(
                     payment = it.first,
-                    metadata = it.second ?: WalletPaymentMetadata()
+                    metadata = it.second ?: WalletPaymentMetadata(),
+                    fetchOptions = options
                 )
             }
         }
@@ -161,7 +162,8 @@ class PaymentsManager(
             paymentsDb().getOutgoingPayment(id.id, options)?.let {
                 WalletPaymentInfo(
                     payment = it.first,
-                    metadata = it.second ?: WalletPaymentMetadata()
+                    metadata = it.second ?: WalletPaymentMetadata(),
+                    fetchOptions = options
                 )
             }
         }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/LightningExtensions.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/LightningExtensions.kt
@@ -14,6 +14,11 @@ import org.kodein.memory.util.freeze
 
 enum class WalletPaymentState { Success, Pending, Failure }
 
+val WalletPayment.createdAt: Long get() = when (this) {
+    is OutgoingPayment -> this.createdAt
+    is IncomingPayment -> this.createdAt
+}
+
 fun WalletPayment.id(): String = when (this) {
     is OutgoingPayment -> this.id.toString()
     is IncomingPayment -> this.paymentHash.toHex()

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/PaymentsMetadata.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/PaymentsMetadata.sq
@@ -50,7 +50,8 @@ WHERE  type = ? AND id = ?;
 
 fetchDescriptions:
 SELECT lnurl_description,
-       user_description
+       user_description,
+       modified_at
 FROM   payments_metadata
 WHERE  type = ? AND id = ?;
 

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/CloudKitDb.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/CloudKitDb.kt
@@ -138,6 +138,7 @@ class CloudKitDb(
                 // In order to optimize disk access, we fetch from 1 table at a time.
 
                 val metadataPlaceholder = WalletPaymentMetadata()
+                val emptyOptions = WalletPaymentFetchOptions.None
 
                 uniquePaymentIds.filterIsInstance<
                     WalletPaymentId.IncomingPaymentId
@@ -145,7 +146,11 @@ class CloudKitDb(
                     inQueries.getIncomingPayment(
                         paymentHash = paymentId.paymentHash
                     )?.let { payment ->
-                        rowMap[paymentId] = WalletPaymentInfo(payment, metadataPlaceholder)
+                        rowMap[paymentId] = WalletPaymentInfo(
+                            payment = payment,
+                            metadata = metadataPlaceholder,
+                            fetchOptions = emptyOptions
+                        )
                     }
                 } // </incoming_payments>
 
@@ -155,7 +160,11 @@ class CloudKitDb(
                     outQueries.getOutgoingPayment(
                         id = paymentId.id
                     )?.let { payment ->
-                        rowMap[paymentId] = WalletPaymentInfo(payment, metadataPlaceholder)
+                        rowMap[paymentId] = WalletPaymentInfo(
+                            payment = payment,
+                            metadata = metadataPlaceholder,
+                            fetchOptions = emptyOptions
+                        )
                     }
                 } // </outgoing_payments>
 
@@ -163,7 +172,10 @@ class CloudKitDb(
                 uniquePaymentIds.forEach { paymentId ->
                     metaQueries.getMetadata(paymentId, fetchOptions)?.let { metadata ->
                         rowMap[paymentId]?.let {
-                            rowMap[paymentId] = it.copy(metadata = metadata)
+                            rowMap[paymentId] = it.copy(
+                                metadata = metadata,
+                                fetchOptions = fetchOptions
+                            )
                         }
                     }
                 } // </payments_metadata>


### PR DESCRIPTION
This is a rather simple PR. Essentially it boils down to this:

```kotlin
// Before:
data class WalletPaymentInfo(
   val payment: WalletPayment,
   val metadata: WalletPaymentMetadata
 )
// After:
data class WalletPaymentInfo(
   val payment: WalletPayment,
   val metadata: WalletPaymentMetadata,
   val fetchOptions: WalletPaymentFetchOptions
 )
```

So when fetching a `WalletPaymentInfo` from the database, we have `WalletPaymentFetchOptions` which allows us to optimize the data we're fetching & deserializing. For example, on the Home screen, we only need the metadata descriptions.

However, this also means the `WalletPaymentMetadata` instance may have null values for columns that do exist in the database. So the addition of this field makes it easier to pass around instances of `WalletPaymentInfo`. Because you no longer need to know who's passing it to you, and what they fetched and didn't fetch. That information is now explicit, and easier to reason about within the UI code.