### PR TITLE
Option to hide amounts on home screen

### DIFF
--- a/phoenix-ios/phoenix-ios/utils/Prefs.swift
+++ b/phoenix-ios/phoenix-ios/utils/Prefs.swift
@@ -45,6 +45,7 @@ class Prefs {
 		case isNewWallet
 		case invoiceExpirationDays
 		case maxFees
+		case hideAmountsOnHomeScreen
 	}
 	
 	public static let shared = Prefs()
@@ -56,11 +57,6 @@ class Prefs {
 		])
 	}
 	
-	lazy private(set) var currencyTypePublisher: CurrentValueSubject<CurrencyType, Never> = {
-		var value = self.currencyType
-		return CurrentValueSubject<CurrencyType, Never>(value)
-	}()
-	
 	var currencyType: CurrencyType {
 		get {
 			let key = Keys.currencyType.rawValue
@@ -70,7 +66,6 @@ class Prefs {
 		set {
 			let key = Keys.currencyType.rawValue
 			UserDefaults.standard.setCodable(value: newValue, forKey: key)
-			currencyTypePublisher.send(newValue)
 	  }
 	}
 	
@@ -223,6 +218,15 @@ class Prefs {
 			UserDefaults.standard.setCodable(value: newValue, forKey: key)
 			log.debug("Prefs.maxFees: \(String(describing: newValue))")
 			maxFeesPublisher.send(newValue)
+		}
+	}
+	
+	var hideAmountsOnHomeScreen: Bool {
+		get {
+			 UserDefaults.standard.bool(forKey: Keys.hideAmountsOnHomeScreen.rawValue)
+		}
+		set {
+			UserDefaults.standard.set(newValue, forKey: Keys.hideAmountsOnHomeScreen.rawValue)
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/utils/Utils.swift
+++ b/phoenix-ios/phoenix-ios/utils/Utils.swift
@@ -438,7 +438,7 @@ class Utils {
 	// MARK: Alt Formatting
 	// --------------------------------------------------
 	
-	static let hiddenCharacter = "\u{066D}"
+	static let hiddenCharacter = "\u{2217}" // asterisk operator
 	
 	static func hiddenAmount(_ currencyPrefs: CurrencyPrefs) -> FormattedAmount {
 		

--- a/phoenix-ios/phoenix-ios/views/send/PriceSliderSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/send/PriceSliderSheet.swift
@@ -39,7 +39,7 @@ struct PriceSliderSheet: View {
 	init(flowType: FlowType, msat: Int64, valueChanged: @escaping (Int64) -> Void) {
 		self.flowType = flowType
 		self.valueChanged = valueChanged
-		_amountSats = State(initialValue: Utils.convertBitcoin(msat: msat, bitcoinUnit: .sat))
+		_amountSats = State(initialValue: Utils.convertBitcoin(msat: msat, to: .sat))
 	}
 	
 	// The Slider family works with BinaryFloatingPoint.
@@ -469,7 +469,7 @@ struct PriceSliderSheet: View {
 		}
 		
 		let newMsat = percentToMsat(floorPercent / 100.0)
-		amountSats = Utils.convertBitcoin(msat: newMsat, bitcoinUnit: .sat)
+		amountSats = Utils.convertBitcoin(msat: newMsat, to: .sat)
 	}
 	
 	func plusButtonTapped() {
@@ -496,7 +496,7 @@ struct PriceSliderSheet: View {
 		}
 		
 		let newMsat = percentToMsat(ceilingPercent / 100.0)
-		amountSats = Utils.convertBitcoin(msat: newMsat, bitcoinUnit: .sat)
+		amountSats = Utils.convertBitcoin(msat: newMsat, to: .sat)
 	}
 	
 	func recentPercents() -> [Int] {
@@ -565,7 +565,7 @@ struct PriceSliderSheet: View {
 			// - anything above min is treated like a tip
 			
 			let newMsat = percentToMsat(Double(percent) / 100.0)
-			amountSats = Utils.convertBitcoin(msat: newMsat, bitcoinUnit: .sat)
+			amountSats = Utils.convertBitcoin(msat: newMsat, to: .sat)
 		}
 	}
 	


### PR DESCRIPTION
Fixes issue #208 

- easy toggle on/off option from home screen
- option only affects the home screen, in order to protect the user from prying eyes when opening the app
- option is persistent across app launches

![issue_208](https://user-images.githubusercontent.com/304604/162226741-be522087-2a48-4fea-a75f-8e88ae1947f9.gif)

