### PR TITLE
Allow self-signed certificates for custom Electrum server

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -156,6 +156,8 @@
 		DCE1E5FA26418183005465B8 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE1E5F926418183005465B8 /* Toast.swift */; };
 		DCE7232E27AD68CD0017CF56 /* SyncTxManager_Actor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE7232D27AD68CD0017CF56 /* SyncTxManager_Actor.swift */; };
 		DCE7233027B167240017CF56 /* SyncSeedManager_Actor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE7232F27B167240017CF56 /* SyncSeedManager_Actor.swift */; };
+		DCE77A5627C5240500F0FA24 /* TLSConnectionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE77A5527C5240500F0FA24 /* TLSConnectionCheck.swift */; };
+		DCE77A5827C671D600F0FA24 /* ElectrumAddressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE77A5727C671D600F0FA24 /* ElectrumAddressSheet.swift */; };
 		DCEC6A1827A82A98002C20BA /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEC6A1727A82A98002C20BA /* ImagePicker.swift */; };
 		DCED09D42625DBC4005D5EE2 /* AnimationCompletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCED09D32625DBC4005D5EE2 /* AnimationCompletion.swift */; };
 		DCEFD922276A796800001767 /* SyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEFD921276A796800001767 /* SyncManager.swift */; };
@@ -368,6 +370,8 @@
 		DCE1E5F926418183005465B8 /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
 		DCE7232D27AD68CD0017CF56 /* SyncTxManager_Actor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTxManager_Actor.swift; sourceTree = "<group>"; };
 		DCE7232F27B167240017CF56 /* SyncSeedManager_Actor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncSeedManager_Actor.swift; sourceTree = "<group>"; };
+		DCE77A5527C5240500F0FA24 /* TLSConnectionCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLSConnectionCheck.swift; sourceTree = "<group>"; };
+		DCE77A5727C671D600F0FA24 /* ElectrumAddressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElectrumAddressSheet.swift; sourceTree = "<group>"; };
 		DCEC6A1727A82A98002C20BA /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		DCED09D32625DBC4005D5EE2 /* AnimationCompletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationCompletion.swift; sourceTree = "<group>"; };
 		DCEFD921276A796800001767 /* SyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManager.swift; sourceTree = "<group>"; };
@@ -619,6 +623,7 @@
 			children = (
 				DC27E4C12791C00F00C777CC /* PrivacyView.swift */,
 				C8D7A1F8A123C59199C182C2 /* ElectrumConfigurationView.swift */,
+				DCE77A5727C671D600F0FA24 /* ElectrumAddressSheet.swift */,
 				C8D7A2BD01ADA0DE6034AE0F /* TorConfigurationView.swift */,
 				DC27E4C32791C58C00C777CC /* PaymentsBackupView.swift */,
 			);
@@ -768,6 +773,7 @@
 				DCACF6F62566D0BA0009B01E /* GenericPasswordStore.swift */,
 				DCACF6F92566D0BA0009B01E /* GenericPasswordConvertible.swift */,
 				DCACF6F52566D0BA0009B01E /* KeyStoreError.swift */,
+				DCE77A5527C5240500F0FA24 /* TLSConnectionCheck.swift */,
 			);
 			path = security;
 			sourceTree = "<group>";
@@ -1159,6 +1165,7 @@
 				C8D7ABB189B14D3104ABB50D /* AboutView.swift in Sources */,
 				DCCD045F27EE0301007D57A5 /* SummaryView.swift in Sources */,
 				C8D7AA4B09B32AD99C88BB5E /* DisplayConfigurationView.swift in Sources */,
+				DCE77A5827C671D600F0FA24 /* ElectrumAddressSheet.swift in Sources */,
 				DC384D81265C12B700131772 /* Cache.swift in Sources */,
 				DCAC5B7027726FC80077BB98 /* DeepLink.swift in Sources */,
 				DC9473FA261270B4008D7242 /* MVI+Mock.swift in Sources */,
@@ -1167,6 +1174,7 @@
 				DC99E94025BA141000FB20F7 /* LocalWebView.swift in Sources */,
 				53BEFA633D95514CA5C0422A /* ChannelsConfigurationView.swift in Sources */,
 				DCED09D42625DBC4005D5EE2 /* AnimationCompletion.swift in Sources */,
+				DCE77A5627C5240500F0FA24 /* TLSConnectionCheck.swift in Sources */,
 				DC2F432027B69F320006FCC4 /* BgAppRefreshDisabledPopover.swift in Sources */,
 				DCCC7FD526B0A006008ACD9B /* SquareSize.swift in Sources */,
 				DCB493D1269F890D001B0F09 /* SyncTxManager_PendingSettings.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/AppDelegate.swift
+++ b/phoenix-ios/phoenix-ios/AppDelegate.swift
@@ -772,8 +772,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MessagingDelegate {
 		let prvPeerConnectionState = peerConnectionState
 		peerConnectionState = connections.peer
 		
-		if prvPeerConnectionState != Lightning_kmpConnection.established &&
-		   peerConnectionState == Lightning_kmpConnection.established
+		if !(prvPeerConnectionState is Lightning_kmpConnection.ESTABLISHED) &&
+		   (peerConnectionState is Lightning_kmpConnection.ESTABLISHED)
 		{
 			maybeRegisterFcmToken()
 		}
@@ -791,7 +791,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MessagingDelegate {
 			log.debug("maybeRegisterFcmToken: no: !fcmToken")
 			return
 		}
-		if peerConnectionState != Lightning_kmpConnection.established {
+		if !(peerConnectionState is Lightning_kmpConnection.ESTABLISHED) {
 			log.debug("maybeRegisterFcmToken: no: !peerConnection")
 			return
 		}

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions.swift
@@ -208,10 +208,10 @@ extension Lightning_kmpConnection {
 	
 	func localizedText() -> String {
 		switch self {
-		case .closed       : return NSLocalizedString("Offline", comment: "Connection state")
-		case .establishing : return NSLocalizedString("Connecting...", comment: "Connection state")
-		case .established  : return NSLocalizedString("Connected", comment: "Connection state")
-		default            : return NSLocalizedString("Unknown", comment: "Connection state")
+		case is CLOSED       : return NSLocalizedString("Offline", comment: "Connection state")
+		case is ESTABLISHING : return NSLocalizedString("Connecting...", comment: "Connection state")
+		case is ESTABLISHED  : return NSLocalizedString("Connected", comment: "Connection state")
+		default              : return NSLocalizedString("Unknown", comment: "Connection state")
 		}
 	}
 }

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinObservables.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinObservables.swift
@@ -1,18 +1,29 @@
 import Foundation
+import Combine
 import PhoenixShared
+import os.log
+
+#if DEBUG && true
+fileprivate var log = Logger(
+	subsystem: Bundle.main.bundleIdentifier!,
+	category: "KotlinObservables"
+)
+#else
+fileprivate var log = Logger(OSLog.disabled)
+#endif
 
 
 class ObservableConnectionsManager: ObservableObject {
 	
 	@Published var connections: Connections
 	
-	private var watcher: Ktor_ioCloseable? = nil
+	private var watcher: Ktor_ioCloseable?
 	
 	init() {
-		let manager = AppDelegate.get().business.connectionsManager
-		connections = manager.currentValue
+		let connectionsManager = AppDelegate.get().business.connectionsManager
+		connections = connectionsManager.currentValue
 		
-		let swiftFlow = SwiftFlow<Connections>(origin: manager.connections)
+		let swiftFlow = SwiftFlow<Connections>(origin: connectionsManager.connections)
 		
 		watcher = swiftFlow.watch {[weak self](newConnections: Connections?) in
 			self?.connections = newConnections!
@@ -21,9 +32,120 @@ class ObservableConnectionsManager: ObservableObject {
 	
 	#if DEBUG // For debugging UI: Force connection state
 	init(fakeConnections: Connections) {
-		self.connections = fakeConnections
+		connections = fakeConnections
+		watcher = nil
 	}
 	#endif
+	
+	deinit {
+		let _watcher = watcher
+		DispatchQueue.main.async {
+			_watcher?.close()
+		}
+	}
+}
+
+// MARK: -
+
+class CustomElectrumServerObserver: ObservableObject {
+	
+	enum Problem {
+		case badCertificate
+		//
+		// reserved for other problems such as:
+		// - cannot connect to server
+		// - cannot resolve DNS address
+	}
+	
+	@Published var problem: Problem? = nil
+	
+	private var cancellables = Set<AnyCancellable>()
+	private var watcher: Ktor_ioCloseable?
+	
+	private var lastElectrumClose: Lightning_kmpConnection.CLOSED? = nil
+	private var electrumConfig: ElectrumConfigPrefs?
+	
+	init() {
+		let connectionsManager = AppDelegate.get().business.connectionsManager
+		
+		let swiftFlow = SwiftFlow<Connections>(origin: connectionsManager.connections)
+		
+		watcher = swiftFlow.watch {[weak self](newConnections: Connections?) in
+			if let newConnections = newConnections {
+				self?.connectionsChanged(newConnections)
+			}
+		}
+		
+		electrumConfig = Prefs.shared.electrumConfig
+		Prefs.shared.electrumConfigPublisher.sink {[weak self](config: ElectrumConfigPrefs?) in
+			self?.configChanged(config)
+			
+		}.store(in: &cancellables)
+		
+		connectionsChanged(connectionsManager.currentValue)
+	}
+	
+	private func connectionsChanged(_ connections: Connections) {
+		let electrumConnection = connections.electrum
+		
+		if let close = electrumConnection as? Lightning_kmpConnection.CLOSED {
+			lastElectrumClose = close
+			checkForProblems()
+			
+		} else if electrumConnection is Lightning_kmpConnection.ESTABLISHED {
+			lastElectrumClose = nil
+			checkForProblems()
+			
+		} else if electrumConnection is Lightning_kmpConnection.ESTABLISHING {
+			// waiting for either success or failure...
+		}
+	}
+	
+	private func configChanged(_ config: ElectrumConfigPrefs?) {
+		
+		electrumConfig = config
+		checkForProblems()
+	}
+	
+	private func checkForProblems() {
+		
+		// Lots of wrapping & unwrapping here:
+		//
+		// The original error comes from PhoenixCrypto (written in Swift).
+		// The original error is of type `NWError` - a Swift enum, which cannot be sent to Kotlin.
+		// So `NWError` is converted into type `NativeSocketError` (NSObject).
+		// Kotlin wants to convert this into the cross-platform generic type `TcpSocket.IOException`.
+		// So the `NativeSocketError` is converted into `NativeSocketException`,
+		// which can be put inside `TcpSocket.IOException`.
+		
+		guard
+			let _ = electrumConfig,
+			let closed = lastElectrumClose,
+			let closedReason: Lightning_kmpTcpSocketIOException = closed.reason,
+			let nativeSocketException = closedReason.cause as? Lightning_kmpNativeSocketException
+		else {
+			// - Not using a custom electrum server
+			// - Electrum connection isn't closed
+			// - Electrum connection isn't closed abnormally
+			// - Cannot extract exception info
+			problem = nil
+			return
+		}
+		
+		log.debug("electrumConnection.closed.reason = \(closedReason)")
+		
+		if let tlsError = nativeSocketException.asTLS() {
+			
+			if tlsError.status == errSSLBadCert {
+				problem = .badCertificate
+			} else {
+				problem = nil
+			}
+			
+		} else {
+			problem = nil
+		}
+	}
 	
 	deinit {
 		let _watcher = watcher

--- a/phoenix-ios/phoenix-ios/security/TLSConnectionCheck.swift
+++ b/phoenix-ios/phoenix-ios/security/TLSConnectionCheck.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Combine
+import Network
+import os.log
+
+#if DEBUG && true
+fileprivate var log = Logger(
+	subsystem: Bundle.main.bundleIdentifier!,
+	category: "TLSConnectionCheck"
+)
+#else
+fileprivate var log = Logger(OSLog.disabled)
+#endif
+
+
+enum TLSConnectionStatus {
+	case trusted
+	case untrusted(cert: SecCertificate)
+}
+
+enum TLSConnectionError: Error {
+	case invalidPort
+	case cancelled
+	case network(error: NWError)
+}
+
+class TLSConnectionCheck {
+	
+	static func check(
+		host: String,
+		port: UInt16,
+		completion: @escaping (Result<TLSConnectionStatus, TLSConnectionError>) -> Void
+	) -> AnyCancellable {
+		
+		let cancelledPublisher = PassthroughSubject<Void, Never>()
+		let cancellable = AnyCancellable.init({
+			cancelledPublisher.send()
+		})
+		
+		let promise = {(result: Result<TLSConnectionStatus, TLSConnectionError>) in
+			DispatchQueue.main.async {
+				completion(result)
+			}
+		}
+		
+		let ep_host = NWEndpoint.Host(host)
+		guard let ep_port = NWEndpoint.Port(rawValue: port) else {
+			promise(.failure(.invalidPort))
+			return cancellable
+		}
+			
+		let tlsOptions = NWProtocolTLS.Options()
+		let tcpOptions = NWProtocolTCP.Options()
+			
+		var isTrusted: Bool = false
+		var untrustedCert: SecCertificate? = nil
+		
+		let verify_queue = DispatchQueue.global()
+		let verify_block: sec_protocol_verify_t = {(
+			metadata   : sec_protocol_metadata_t,
+			trust      : sec_trust_t,
+			completion : @escaping sec_protocol_verify_complete_t
+		) in
+			
+			let sec_trust = sec_trust_copy_ref(trust).takeRetainedValue()
+			var error: CFError?
+			let result = SecTrustEvaluateWithError(sec_trust, &error)
+			
+			if result {
+				isTrusted = true
+			} else {
+				log.debug("SecTrustEvaluate: \(String(describing: error))")
+				
+				// The certificate is not fully trusted.
+				// This could be for any number of reasons:
+				// - cert is expired
+				// - cert is self-signed
+				// - a parent cert in the chain is self-signed
+				// - [... very long list of possible reasons ...]
+				
+				let certs: [SecCertificate]
+				if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
+					certs = SecTrustCopyCertificateChain(sec_trust) as? [SecCertificate] ?? []
+					
+				} else {
+					certs = (0 ..< SecTrustGetCertificateCount(sec_trust)).compactMap { index in
+						SecTrustGetCertificateAtIndex(sec_trust, index)
+					}
+				}
+				untrustedCert = certs.first
+			}
+			
+			completion(true)
+		}
+		
+		sec_protocol_options_set_verify_block(tlsOptions.securityProtocolOptions, verify_block, verify_queue)
+		
+		let options = NWParameters(tls: tlsOptions, tcp: tcpOptions)
+		let connection = NWConnection(host: ep_host, port: ep_port, using: options)
+		
+		var cancellables = Set<AnyCancellable>()
+		connection.stateUpdateHandler = {(state: NWConnection.State) in
+			
+			switch state {
+				case .failed(let error):
+					promise(.failure(.network(error: error)))
+					cancellables.removeAll()
+				case .ready:
+					if isTrusted {
+						promise(.success(.trusted))
+					} else if let untrustedCert = untrustedCert {
+						promise(.success(.untrusted(cert: untrustedCert)))
+					} else {
+						promise(.failure(.network(error: NWError.tls(OSStatus.zero))))
+					}
+					cancellables.removeAll()
+				case .cancelled:
+					log.debug("NWConnection cancelled")
+				default:
+					break
+			}
+			
+		} // </stateUpdateHandler>
+		
+		connection.start(queue: DispatchQueue.global(qos: .userInitiated))
+		
+		cancelledPublisher.sink { _ in
+			connection.cancel()
+		}.store(in: &cancellables)
+			
+		return cancellable
+	}
+	
+	// MARK: Debug
+	
+	#if DEBUG
+	static func debug(
+		result: Result<TLSConnectionStatus, TLSConnectionError>,
+		delay: TimeInterval,
+		completion: @escaping (Result<TLSConnectionStatus, TLSConnectionError>) -> Void
+	) -> AnyCancellable {
+		
+		DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+			completion(result)
+		}
+		return AnyCancellable.init({
+			// do nothing
+		})
+	}
+	
+	static func debugCert() -> SecCertificate {
+		
+		let base64 =
+		"""
+		MIIDnzCCAocCFGw8AU6bWkI4JTKj/TvtS6nuHdiiMA0GCSqGSIb3DQEBCwUAMIGL
+		MQswCQYDVQQGEwJERTEVMBMGA1UECAwMTmllZGVyc2FjaGVuMRkwFwYDVQQKDBBl
+		bGVjdHJ1bS5lbXp5LmRlMRIwEAYDVQQLDAllbGVjdHJ1bXgxGTAXBgNVBAMMEGVs
+		ZWN0cnVtLmVtenkuZGUxGzAZBgkqhkiG9w0BCQEWDGVtenlAZW16eS5kZTAeFw0y
+		MTEwMTIyMTA2MjdaFw0yNjEwMTEyMTA2MjdaMIGLMQswCQYDVQQGEwJERTEVMBMG
+		A1UECAwMTmllZGVyc2FjaGVuMRkwFwYDVQQKDBBlbGVjdHJ1bS5lbXp5LmRlMRIw
+		EAYDVQQLDAllbGVjdHJ1bXgxGTAXBgNVBAMMEGVsZWN0cnVtLmVtenkuZGUxGzAZ
+		BgkqhkiG9w0BCQEWDGVtenlAZW16eS5kZTCCASIwDQYJKoZIhvcNAQEBBQADggEP
+		ADCCAQoCggEBALn6g79JySAiT6D/OsDj2DP1yHxbOr5laxhHgWZsvTJjDbm7pYZ8
+		hPrFrhYZyF/tLrhZSdfCyWBTiINHwGhXTecYeL2oATVz/XQnMX1XzBn7/cQUGX1o
+		Sqw4wuAwifNp9yvkOEaqSv8kvRiGSHKqxt68RCwWfDR1TyF73ltD52oBnkN9TQ3T
+		gKvTASoikXJnynpuXWlBKP8TOJ07frTk8ZebB4nHUEgnjx13sDF85pDP1cNazCWS
+		nk8Jy1+OE7KaRIuO311BXHbgdvgNcR0CIBPcGuAanNmaFLSigWsnnlNNgtkgRYFc
+		bQFk+mBEnXDz/LvqUe5QAwO0GTVFTSjLzDcCAwEAATANBgkqhkiG9w0BAQsFAAOC
+		AQEAlraiQDHY/knqRlij+O268yos3rOC+ARKzEDKbONc9EP5fOp+ld4+sd4gQVfW
+		/SsB+FKx0zCLNG1uCC9NJ0F5Ukbt+dJ8u0B1pKPWs6dId6zAQKk0+yl+DfZvoJ6R
+		tebT8iI1RVrvxyV488CqbTHOSKZGlJS8SiPkXzu0+Onyr/uNpayAKvwE/NhFbU3h
+		z8b3TQ9WNGli5Sslx1nMjO0at/gtbUk5DsXvUZnmy3wXmsylnVi7R6+troyuVmP8
+		CfsTNyoJPvgKQsSNoCRBIPjIx1eTPKQAaFwIu2Ckxo2cykBnTJLsZFKq7yhjjVZO
+		qiVb2Ts1gAR16RIdK1Ni0T5d5Q==
+		"""
+		
+		let data: Data = Data(base64Encoded: base64, options: .ignoreUnknownCharacters)!
+		let cert: SecCertificate = SecCertificateCreateWithData(nil, data as CFData)!
+		
+		return cert
+	}
+	#endif
+}

--- a/phoenix-ios/phoenix-ios/sync/SyncSeedManager.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncSeedManager.swift
@@ -302,7 +302,7 @@ class SyncSeedManager: SyncManagerProtcol {
 	/// Called from SyncManager; part of SyncManagerProtocol
 	///
 	func networkStatusChanged(hasInternet: Bool) {
-		log.trace("networkStatusChanged(hasInternet: \(hasInternet)")
+		log.trace("networkStatusChanged(hasInternet: \(hasInternet))")
 		
 		Task {
 			if let newState = await self.actor.networkStatusChanged(hasInternet: hasInternet) {

--- a/phoenix-ios/phoenix-ios/sync/SyncSeedManager_Actor.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncSeedManager_Actor.swift
@@ -131,7 +131,7 @@ actor SyncSeedManager_Actor {
 	}
 	
 	func networkStatusChanged(hasInternet: Bool) -> SyncSeedManager_State? {
-		log.trace("networkStatusChanged(hasInternet: \(hasInternet)")
+		log.trace("networkStatusChanged(hasInternet: \(hasInternet))")
 		
 		if hasInternet {
 			waitingForInternet = false

--- a/phoenix-ios/phoenix-ios/sync/SyncTxManager.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncTxManager.swift
@@ -343,7 +343,7 @@ class SyncTxManager {
 	/// Called from SyncManager; part of SyncManagerProtocol
 	///
 	func networkStatusChanged(hasInternet: Bool) {
-		log.trace("networkStatusChanged(hasInternet: \(hasInternet)")
+		log.trace("networkStatusChanged(hasInternet: \(hasInternet))")
 		
 		Task {
 			if let newState = await self.actor.networkStatusChanged(hasInternet: hasInternet) {

--- a/phoenix-ios/phoenix-ios/sync/SyncTxManager_Actor.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncTxManager_Actor.swift
@@ -61,7 +61,7 @@ actor SyncTxManager_Actor {
 	}
 	
 	func networkStatusChanged(hasInternet: Bool) -> SyncTxManager_State? {
-		log.trace("networkStatusChanged(hasInternet: \(hasInternet)")
+		log.trace("networkStatusChanged(hasInternet: \(hasInternet))")
 		
 		if hasInternet {
 			waitingForInternet = false

--- a/phoenix-ios/phoenix-ios/utils/Prefs+Codable.swift
+++ b/phoenix-ios/phoenix-ios/utils/Prefs+Codable.swift
@@ -51,18 +51,33 @@ struct FcmTokenInfo: Equatable, Codable {
 struct ElectrumConfigPrefs: Codable {
 	let host: String
 	let port: UInt16
+	let pinnedPubKey: String?
 	
 	private let version: Int // for potential future upgrades
 	
-	init(host: String, port: UInt16) {
+	init(host: String, port: UInt16, pinnedPubKey: String?) {
 		self.host = host
 		self.port = port
-		self.version = 1
-	}
+		self.pinnedPubKey = pinnedPubKey
+		self.version = 2
+	} 
 	
 	var serverAddress: Lightning_kmpServerAddress {
-		return Lightning_kmpServerAddress(host: host, port: Int32(port), tls: Lightning_kmpTcpSocketTLS.safe)
+		if let pinnedPubKey = pinnedPubKey {
+			return Lightning_kmpServerAddress(
+				host : host,
+				port : Int32(port),
+				tls  : Lightning_kmpTcpSocketTLS.PINNED_PUBLIC_KEY(pubKey: pinnedPubKey)
+			)
+		} else {
+			return Lightning_kmpServerAddress(
+				host : host,
+				port : Int32(port),
+				tls  : Lightning_kmpTcpSocketTLS.TRUSTED_CERTIFICATES()
+			)
+		}
 	}
+
 }
 
 struct MaxFees: Codable {

--- a/phoenix-ios/phoenix-ios/utils/Prefs.swift
+++ b/phoenix-ios/phoenix-ios/utils/Prefs.swift
@@ -70,8 +70,7 @@ class Prefs {
 	}
 	
 	lazy private(set) var fiatCurrencyPublisher: CurrentValueSubject<FiatCurrency, Never> = {
-		var value = self.fiatCurrency
-		return CurrentValueSubject<FiatCurrency, Never>(value)
+		return CurrentValueSubject<FiatCurrency, Never>(self.fiatCurrency)
 	}()
 	
 	var fiatCurrency: FiatCurrency {
@@ -92,8 +91,7 @@ class Prefs {
 	}
 	
 	lazy private(set) var bitcoinUnitPublisher: CurrentValueSubject<BitcoinUnit, Never> = {
-		var value = self.bitcoinUnit
-		return CurrentValueSubject<BitcoinUnit, Never>(value)
+		return CurrentValueSubject<BitcoinUnit, Never>(self.bitcoinUnit)
 	}()
 	
 	var bitcoinUnit: BitcoinUnit {
@@ -114,8 +112,7 @@ class Prefs {
 	}
 	
 	lazy private(set) var themePublisher: CurrentValueSubject<Theme, Never> = {
-		var value = self.theme
-		return CurrentValueSubject<Theme, Never>(value)
+		return CurrentValueSubject<Theme, Never>(self.theme)
 	}()
 	
 	var theme: Theme {
@@ -132,8 +129,7 @@ class Prefs {
 	}
 
 	lazy private(set) var isTorEnabledPublisher: CurrentValueSubject<Bool, Never> = {
-		var value = self.isTorEnabled
-		return CurrentValueSubject<Bool, Never>(value)
+		return CurrentValueSubject<Bool, Never>(self.isTorEnabled)
 	}()
 
 	var isTorEnabled: Bool {
@@ -146,6 +142,10 @@ class Prefs {
 		}
 	}
 	
+	lazy private(set) var electrumConfigPublisher: CurrentValueSubject<ElectrumConfigPrefs?, Never> = {
+		return CurrentValueSubject<ElectrumConfigPrefs?, Never>(self.electrumConfig)
+	}()
+	
 	var electrumConfig: ElectrumConfigPrefs? {
 		get {
 			let key = Keys.electrumConfig.rawValue
@@ -155,6 +155,7 @@ class Prefs {
 		set {
 			let key = Keys.electrumConfig.rawValue
 			UserDefaults.standard.setCodable(value: newValue, forKey: key)
+			electrumConfigPublisher.send(newValue)
 		}
 	}
 	
@@ -203,8 +204,7 @@ class Prefs {
 	}
 	
 	lazy private(set) var maxFeesPublisher: CurrentValueSubject<MaxFees?, Never> = {
-		let currentValue = self.maxFees
-		return CurrentValueSubject<MaxFees?, Never>(currentValue)
+		return CurrentValueSubject<MaxFees?, Never>(self.maxFees)
 	}()
 	
 	var maxFees: MaxFees? {
@@ -235,8 +235,7 @@ class Prefs {
 	// --------------------------------------------------
 	
 	lazy private(set) var currencyConverterListPublisher: CurrentValueSubject<[Currency], Never> = {
-		var list = self.currencyConverterList
-		return CurrentValueSubject<[Currency], Never>(list)
+		return CurrentValueSubject<[Currency], Never>(self.currencyConverterList)
 	}()
 	
 	var currencyConverterList: [Currency] {
@@ -383,8 +382,7 @@ class Prefs {
 	}
 	
 	lazy private(set) var backupTransactions_isEnabledPublisher: CurrentValueSubject<Bool, Never> = {
-		var value = self.backupTransactions_isEnabled
-		return CurrentValueSubject<Bool, Never>(value)
+		return CurrentValueSubject<Bool, Never>(self.backupTransactions_isEnabled)
 	}()
 	
 	var backupTransactions_isEnabled: Bool {
@@ -438,8 +436,7 @@ class Prefs {
 	// --------------------------------------------------
 	
 	lazy private(set) var backupSeed_isEnabled_publisher: CurrentValueSubject<Bool, Never> = {
-		var value = self.backupSeed_isEnabled
-		return CurrentValueSubject<Bool, Never>(value)
+		return CurrentValueSubject<Bool, Never>(self.backupSeed_isEnabled)
 	}()
 	
 	var backupSeed_isEnabled: Bool {

--- a/phoenix-ios/phoenix-ios/views/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/HomeView.swift
@@ -40,6 +40,8 @@ struct HomeView : MVIView {
 	@State var selectedItem: WalletPaymentInfo? = nil
 	@State var isMempoolFull = false
 	
+	@StateObject var customElectrumServerObserver = CustomElectrumServerObserver()
+	
 	@EnvironmentObject var currencyPrefs: CurrencyPrefs
 	@EnvironmentObject var deepLinkManager: DeepLinkManager
 	
@@ -276,28 +278,8 @@ struct HomeView : MVIView {
 			)
 			.padding(.bottom, 25)
 
-			// === Beta Version Disclaimer ===
-			generalNotice
-			
-			// === Mempool Full Warning ====
-			if isMempoolFull {
-				NoticeBox {
-					HStack(alignment: VerticalAlignment.top, spacing: 0) {
-						Image(systemName: "exclamationmark.triangle")
-							.imageScale(.large)
-							.padding(.trailing, 10)
-						VStack(alignment: HorizontalAlignment.leading, spacing: 5) {
-							Text("Bitcoin mempool is full and fees are high.")
-							Button {
-								mempoolFullInfo()
-							} label: {
-								Text("See how Phoenix is affected".uppercased())
-							}
-						}
-					}
-					.font(.caption)
-				}
-			}
+			// === Notices & Warnings ===
+			notices
 			
 			// === Payments List ====
 			ScrollView {
@@ -346,8 +328,9 @@ struct HomeView : MVIView {
 	}
 	
 	@ViewBuilder
-	var generalNotice: some View {
+	var notices: some View {
 		
+		// === Welcome / Backup Seed ====
 		if mvi.model.balance.msat == 0 && Prefs.shared.isNewWallet {
 
 			// Reserved for potential "welcome" message.
@@ -380,6 +363,56 @@ struct HomeView : MVIView {
 				.font(.caption)
 			} // </NoticeBox>
 			
+		}
+		
+		// === Custom Electrum Server Problems ====
+		if customElectrumServerObserver.problem == .badCertificate {
+			
+			NoticeBox {
+				HStack(alignment: VerticalAlignment.top, spacing: 0) {
+					Image(systemName: "exclamationmark.shield")
+						.imageScale(.large)
+						.padding(.trailing, 10)
+				}
+				.font(.caption)
+				Button {
+					navigationToElecrumServer()
+				} label: {
+					Group {
+						Text("Custom electrum server: bad certificate ! ")
+							.foregroundColor(.primary)
+						+
+						Text("Check it ")
+							.foregroundColor(.appAccent)
+						+
+						Text(Image(systemName: "arrowtriangle.forward"))
+							.foregroundColor(.appAccent)
+					}
+					.multilineTextAlignment(.leading)
+					.allowsTightening(true)
+				}
+			} // </NoticeBox>
+		}
+		
+		// === Mempool Full Warning ====
+		if isMempoolFull {
+			
+			NoticeBox {
+				HStack(alignment: VerticalAlignment.top, spacing: 0) {
+					Image(systemName: "tray.full")
+						.imageScale(.large)
+						.padding(.trailing, 10)
+					VStack(alignment: HorizontalAlignment.leading, spacing: 5) {
+						Text("Bitcoin mempool is full and fees are high.")
+						Button {
+							mempoolFullInfo()
+						} label: {
+							Text("See how Phoenix is affected".uppercased())
+						}
+					}
+				}
+				.font(.caption)
+			}
 		}
 	}
 
@@ -452,7 +485,7 @@ struct HomeView : MVIView {
 	}
 	
 	fileprivate func navLinkTagChanged(_ tag: NavLinkTag?) {
-		log.trace("navLinkTagChanged()")
+		log.trace("navLinkTagChanged() => \(tag?.rawValue ?? "nil")")
 		
 		if tag == nil {
 			// If we pushed the SendView, triggered by an external lightning url,
@@ -779,14 +812,22 @@ struct HomeView : MVIView {
 		deepLinkManager.broadcast(DeepLink.backup)
 	}
 	
-	func deepLinkChanged(_ value: DeepLink?) {
-		log.trace("deepLinkChanged()")
+	func navigationToElecrumServer() {
+		log.trace("navigateToElectrumServer()")
 		
-		switch value {
-		case .backup:
-			self.navLinkTag = .ConfigurationView
-		default:
-			break
+		deepLinkManager.broadcast(DeepLink.electrum)
+	}
+	
+	func deepLinkChanged(_ value: DeepLink?) {
+		log.trace("deepLinkChanged() => \(value?.rawValue ?? "nil")")
+		
+		if let value = value {
+			switch value {
+			case .backup:
+				self.navLinkTag = .ConfigurationView
+			case .electrum:
+				self.navLinkTag = .ConfigurationView
+			}
 		}
 	}
 }
@@ -1026,7 +1067,7 @@ fileprivate struct AppStatusButton: View, ViewName {
 	var buttonContent: some View {
 		
 		let connectionStatus = connectionsManager.connections.global
-		if connectionStatus == .closed {
+		if connectionStatus is Lightning_kmpConnection.CLOSED {
 			HStack(alignment: .firstTextBaseline, spacing: 3) {
 				Image(systemName: "bolt.slash.fill")
 					.imageScale(.large)
@@ -1035,7 +1076,7 @@ fileprivate struct AppStatusButton: View, ViewName {
 			}
 			.font(.caption2)
 		}
-		else if connectionStatus == .establishing {
+		else if connectionStatus is Lightning_kmpConnection.ESTABLISHING {
 			HStack(alignment: .firstTextBaseline, spacing: 3) {
 				Image(systemName: "bolt.slash")
 					.imageScale(.large)
@@ -1366,9 +1407,9 @@ fileprivate struct BottomBar: View, ViewName {
 class HomeView_Previews: PreviewProvider {
 	
 	static let connections = Connections(
-		internet : .established,
-		peer     : .established,
-		electrum : .closed
+		internet : Lightning_kmpConnection.ESTABLISHED(),
+		peer     : Lightning_kmpConnection.ESTABLISHED(),
+		electrum : Lightning_kmpConnection.CLOSED(reason: nil)
 	)
 
 	static var previews: some View {

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/ElectrumAddressSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/ElectrumAddressSheet.swift
@@ -783,6 +783,7 @@ struct ElectrumAddressSheet: View {
 	func tlsConnectionCheckDidFinish(_ result: Result<TLSConnectionStatus, TLSConnectionError>) {
 		log.trace("tlsConnectionCheckDidFinish()")
 		
+		var isTrustedCert = false
 		switch result {
 		case .failure(let error):
 			switch error {
@@ -798,6 +799,7 @@ struct ElectrumAddressSheet: View {
 			switch status {
 			case .trusted:
 				log.debug("SUCCESS: trusted")
+				isTrustedCert = true
 			case .untrusted(_):
 				log.debug("SUCCESS: untrusted")
 			}
@@ -805,6 +807,9 @@ struct ElectrumAddressSheet: View {
 		
 		activeCheck = nil
 		checkResult = result
+		if isTrustedCert {
+			saveConfig() // closes sheet too
+		}
 	}
 }
 

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/ElectrumAddressSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/ElectrumAddressSheet.swift
@@ -1,0 +1,850 @@
+import SwiftUI
+import Combine
+import CryptoKit
+import PhoenixShared
+import os.log
+
+#if DEBUG && true
+fileprivate var log = Logger(
+	subsystem: Bundle.main.bundleIdentifier!,
+	category: "ElectrumAddressSheet"
+)
+#else
+fileprivate var log = Logger(OSLog.disabled)
+#endif
+
+enum CertInfoType: Int {
+	case sha256Fingerprint
+	case sha1Fingerprint
+	case commonName
+	case subjectSummary
+	case email
+	
+	static func first() -> CertInfoType {
+		return CertInfoType(rawValue: 0)!
+	}
+	
+	func next() -> CertInfoType {
+		if let next = CertInfoType(rawValue: self.rawValue + 1) {
+			return next
+		} else {
+			return CertInfoType.first()
+		}
+	}
+}
+
+struct ElectrumAddressSheet: View {
+	
+	let DEFAULT_PORT: UInt16 = 50002
+	
+	@ObservedObject var mvi: MVIState<ElectrumConfiguration.Model, ElectrumConfiguration.Intent>
+	
+	@State var isCustomized: Bool
+	@State var host: String
+	@State var port: String
+	
+	@State var invalidHost = false
+	@State var invalidPort = false
+	
+	@State var userHasMadeChanges: Bool = false
+	@State var disableTextFields: Bool = false
+	
+	@State var activeCheck: AnyCancellable? = nil
+	@State var checkResult: Result<TLSConnectionStatus, TLSConnectionError>? = nil
+	
+	@State var certInfoType: CertInfoType = .sha256Fingerprint
+	@State var shouldTrustPubKey: Bool = false
+	
+	@StateObject var toast = Toast()
+	
+	var untrustedCert: SecCertificate? {
+		switch checkResult {
+			case .success(let status):
+				switch status {
+					case .untrusted(let cert): return cert
+					default: return nil
+				}
+			default: return nil
+		}
+	}
+	
+	var isUntrustedCert: Bool {
+		return (untrustedCert != nil)
+	}
+	
+	enum TitleWidth: Preference {}
+	let titleWidthReader = GeometryPreferenceReader(
+		key: AppendValue<TitleWidth>.self,
+		value: { [$0.size.width] }
+	)
+	@State var titleWidth: CGFloat? = nil
+	
+	@Environment(\.colorScheme) var colorScheme: ColorScheme
+	@Environment(\.shortSheetState) var shortSheetState: ShortSheetState
+	
+	init(mvi: MVIState<ElectrumConfiguration.Model, ElectrumConfiguration.Intent>) {
+		self.mvi = mvi
+		
+		_isCustomized = State(initialValue: mvi.model.isCustom())
+		let customConfig = mvi.model.configuration as? ElectrumConfig.Custom
+		let host = customConfig?.server.host ?? ""
+		let port = customConfig?.server.port ?? 0
+		
+		if mvi.model.isCustom() && host.count > 0 {
+			_host = State(initialValue: host)
+			_port = State(initialValue: String(port))
+		} else {
+			_host = State(initialValue: "")
+			_port = State(initialValue: "")
+		}
+	}
+
+	// --------------------------------------------------
+	// MARK: ViewBuilders
+	// --------------------------------------------------
+	
+	@ViewBuilder
+	var body: some View {
+		
+		ZStack(alignment: Alignment.bottom) {
+			content()
+			toast.view().padding(.bottom, 75)
+		}
+	}
+	
+	@ViewBuilder
+	func content() -> some View {
+		
+		VStack(alignment: HorizontalAlignment.center, spacing: 0) {
+			
+			VStack(alignment: HorizontalAlignment.leading) {
+				
+				Toggle(isOn: $isCustomized.animation()) {
+					Text("Use a custom server")
+				}
+				.onChange(of: isCustomized) { _ in
+					onToggleDidChange()
+				}
+				.padding(.trailing, 2) // Toggle draws outside its bounds
+			}
+			.padding(.bottom, 15)
+			.background(Color(UIColor.systemBackground))
+			.zIndex(2)
+			
+			if isCustomized { // animation control
+			
+				customizeServerView()
+					.transition(.move(edge: .top).animation(.easeInOut(duration: 0.3)))
+					.zIndex(1)
+				
+			} else {
+				
+				randomServerView()
+					.transition(.asymmetric(
+						insertion : .opacity.animation(.easeInOut(duration: 0.1).delay(0.3)),
+						removal   : .identity // .opacity.animation(.linear(duration: 0.05))
+					))
+					.zIndex(0)
+			}
+			
+			footer()
+				.padding(.top)
+			
+		} // </VStack>
+		.clipped()
+		.padding()
+		
+	} // </var body: some View>
+	
+	@ViewBuilder
+	func randomServerView() -> some View {
+		
+		HStack(alignment: VerticalAlignment.center, spacing: 0) {
+			
+			Text("A random Electrum server will be selected on each connection attempt.")
+				.font(.footnote)
+			
+			Spacer()
+		}
+		.padding(.top, 10)
+	}
+	
+	@ViewBuilder
+	func customizeServerView() -> some View {
+		
+		VStack(alignment: HorizontalAlignment.leading) {
+
+			// == Server: ([TextField][X]) ===
+			HStack(alignment: .firstTextBaseline) {
+				Text("Server")
+					.font(.subheadline)
+					.fontWeight(.thin)
+					.foregroundColor(invalidHost ? Color.appNegative : Color.primary)
+					.read(titleWidthReader)
+					.frame(width: titleWidth, alignment: .leading)
+
+				HStack {
+					TextField("example.com", text: $host,
+						onCommit: {
+							onHostDidCommit()
+						}
+					)
+					.keyboardType(.URL)
+					.disableAutocorrection(true)
+					.autocapitalization(.none)
+					.foregroundColor(disableTextFields ? .secondary : .primary)
+					.onChange(of: host) { _ in
+						onHostDidChange()
+					}
+
+					Button {
+						host = ""
+					} label: {
+						Image(systemName: "multiply.circle.fill")
+							.foregroundColor(Color(UIColor.tertiaryLabel))
+					}
+					.isHidden(!isCustomized || host == "")
+
+				} // </HStack> (textfield with clear button)
+				.disabled(disableTextFields)
+				.padding([.top, .bottom], 8)
+				.padding(.leading, 16)
+				.padding(.trailing, 8)
+				.background(
+					ZStack {
+						Capsule()
+							.fill(disableTextFields
+								? Color(UIColor.systemFill)
+								: Color(UIColor.systemBackground)
+							)
+						Capsule()
+							.strokeBorder(Color(UIColor.separator))
+					}
+				)
+			} // </HStack> (row)
+			.frame(maxWidth: .infinity)
+			.padding(.bottom)
+
+			// == Port: ([TextField][X]) ===
+			HStack(alignment: .firstTextBaseline) {
+				Text("Port")
+					.font(.subheadline)
+					.fontWeight(.thin)
+					.foregroundColor(invalidPort ? Color.appNegative : Color.primary)
+					.read(titleWidthReader)
+					.frame(width: titleWidth, alignment: .leading)
+
+				HStack {
+					TextField(verbatim: "\(DEFAULT_PORT)", text: $port,
+						onCommit: {
+							onPortDidCommit()
+						}
+					)
+					.keyboardType(.numberPad)
+					.disableAutocorrection(true)
+					.foregroundColor(disableTextFields ? .secondary : .primary)
+					.onChange(of: port) { _ in
+						onPortDidChange()
+					}
+
+					Button {
+						port = ""
+					} label: {
+						Image(systemName: "multiply.circle.fill")
+							.foregroundColor(Color(UIColor.tertiaryLabel))
+					}
+					.isHidden(!isCustomized || port == "")
+				} // </HStack> (textfield with clear button)
+				.disabled(disableTextFields)
+				.padding([.top, .bottom], 8)
+				.padding(.leading, 16)
+				.padding(.trailing, 8)
+				.background(
+					ZStack {
+						Capsule()
+							.fill(disableTextFields
+								? Color(UIColor.systemFill)
+								: Color(UIColor.systemBackground)
+							)
+						Capsule()
+							.strokeBorder(Color(UIColor.separator))
+					}
+				)
+			} // </HStack> (row)
+			.frame(maxWidth: .infinity)
+			.padding(.bottom, 30)
+
+			customizeServerView_status()
+
+		} // </VStack>
+		.assignMaxPreference(for: titleWidthReader.key, to: $titleWidth)
+		
+	}
+	
+	@ViewBuilder
+	func customizeServerView_status() -> some View {
+		
+		if invalidHost {
+			Text("Invalid server. Use format: domain.tld")
+				.bold()
+				.foregroundColor(Color.appNegative)
+				.font(.footnote)
+		} else if invalidPort {
+			Text("Invalid port. Valid range: [1 - 65535]")
+				.bold()
+				.foregroundColor(Color.appNegative)
+				.font(.footnote)
+		} else if activeCheck != nil {
+			Text("Checking server certificate…")
+				.italic()
+				.font(.footnote)
+		} else if let checkResult = checkResult {
+			customizeServerView_status_checkResult(checkResult)
+		} else {
+			Text("Note: Server must have a certificate")
+				.italic()
+				.font(.footnote)
+		}
+	}
+	
+	@ViewBuilder
+	func customizeServerView_status_checkResult(
+		_ result: Result<TLSConnectionStatus, TLSConnectionError>
+	) -> some View {
+		
+		switch result {
+		case .success(let status):
+			switch status {
+			case .trusted:
+				Text("Server certificate is trusted.")
+					.italic()
+					.font(.footnote)
+			case .untrusted(let cert):
+				customizeServerView_status_untrusted(cert)
+			}
+		case .failure(_):
+			Text("Check spelling & internet connection")
+				.bold()
+				.foregroundColor(Color.appNegative)
+				.font(.footnote)
+		}
+	}
+	
+	@ViewBuilder
+	func customizeServerView_status_untrusted(_ cert: SecCertificate) -> some View {
+		
+		VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
+			
+			Text("Server has untrusted certificate.")
+				.bold()
+				.foregroundColor(Color.appNegative)
+				.font(.footnote)
+				.padding(.bottom, 8)
+			
+			HStack(alignment: VerticalAlignment.bottom, spacing: 0) {
+				Group {
+					switch certInfoType {
+					case .sha256Fingerprint:
+						Text("SHA256 Fingerprint:")
+					case .sha1Fingerprint:
+						Text("SHA1 Fingerprint:")
+					case .commonName:
+						Text("Common Name:")
+					case .subjectSummary:
+						Text("Subject:")
+					case .email:
+						Text("Email:")
+					}
+				}
+				.font(.footnote)
+				
+				Spacer()
+				Button {
+					certInfoType = certInfoType.next()
+				} label: {
+					Image(systemName: "arrowshape.turn.up.forward.fill")
+				}
+				.font(.body)
+			}
+			.padding(.bottom, 4)
+			
+			Group {
+				switch certInfoType {
+				case .sha256Fingerprint:
+					Text(verbatim: "\(sha256Fingerprint(cert))")
+				case .sha1Fingerprint:
+					Text(verbatim: "\(sha1Fingerprint(cert))")
+				case .commonName:
+					Text(verbatim: "\(commonName(cert))")
+				case .subjectSummary:
+					Text(verbatim: "\(subjectSummary(cert))")
+				case .email:
+					Text(verbatim: "\(email(cert))")
+				}
+			}
+			.font(.footnote)
+			
+			Spacer().frame(height: 16)
+			
+			Toggle(isOn: $shouldTrustPubKey) {
+				Text("Trust certificate & pin public key")
+					.lineLimit(nil)
+					.alignmentGuide(VerticalAlignment.center) { d in
+						d[VerticalAlignment.firstTextBaseline]
+					}
+			}
+			.toggleStyle(CheckboxToggleStyle(
+				onImage: checkmarkImage_on(),
+				offImage: checkmarkImage_off()
+			))
+		}
+	}
+	
+	@ViewBuilder
+	func footer() -> some View {
+		
+		if isCustomized {
+			footer_customServer()
+		} else {
+			footer_randomServer()
+		}
+	}
+	
+	@ViewBuilder
+	func footer_randomServer() -> some View {
+		
+		HStack(alignment: VerticalAlignment.center, spacing: 0) {
+			
+			Spacer()
+			
+			Button("Cancel") {
+				closeSheet()
+			}
+			.padding(.trailing)
+				
+			Button("Save") {
+				saveConfig()
+			}
+			.disabled(!userHasMadeChanges)
+		}
+		.font(.title2)
+	}
+	
+	@ViewBuilder
+	func footer_customServer() -> some View {
+		
+		HStack(alignment: VerticalAlignment.center, spacing: 0) {
+			
+			if activeCheck != nil {
+			
+				ProgressView()
+					.progressViewStyle(CircularProgressViewStyle(tint: Color.appAccent))
+					.padding(.trailing, 6)
+				
+				Button("cancel") {
+					cancelServerConnectionCheck()
+				}
+				.font(.callout)
+				
+			} else if isUntrustedCert {
+				
+				Button {
+					copyCert()
+				} label: {
+					HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 4) {
+						Image(systemName: "square.on.square")
+						Text("Copy certificate")
+					}
+					.font(.callout)
+				}
+			}
+			
+			Spacer()
+			
+			if activeCheck == nil {
+				Button("Cancel") {
+					closeSheet()
+				}
+				.padding(.trailing)
+				.font(.title2)
+			}
+			
+			Button("Save") {
+				if isUntrustedCert {
+					saveConfig()
+				} else {
+					checkServerConnection()
+				}
+			}
+			.disabled(!userHasMadeChanges || activeCheck != nil || (isUntrustedCert && !shouldTrustPubKey))
+			.font(.title2)
+		}
+	}
+	
+	@ViewBuilder
+	func checkmarkImage_on() -> some View {
+		Image(systemName: "checkmark.square.fill")
+			.imageScale(.large)
+	}
+	
+	@ViewBuilder
+	func checkmarkImage_off() -> some View {
+		Image(systemName: "square")
+			.imageScale(.large)
+	}
+	
+	// --------------------------------------------------
+	// MARK: UI Content Helpers
+	// --------------------------------------------------
+	
+	/**
+	 * The fingerprint of an X509 cert is simply the hash of the raw DER-encoded data.
+	 * The hash used is typically either SHA1 or SHA256.
+	 * And the display format is typically upper-case hexadecimal.
+	 * Example for SHA1 Fingerprint:
+	 *
+	 * C1:62:FA:5C:48:73:EC:06:0C:FC:AE:65:93:73:96:E0:66:03:A7:E6
+	 */
+	func sha1Fingerprint(_ cert: SecCertificate) -> String {
+		
+		let data = SecCertificateCopyData(cert) as Data
+		let fingerprint = Insecure.SHA1.hash(data: data).map { String(format: "%02X:", $0) }.joined()
+		return String(fingerprint.dropLast(1))
+	}
+	
+	func sha256Fingerprint(_ cert: SecCertificate) -> String {
+		
+		let data = SecCertificateCopyData(cert) as Data
+		let fingerprint = SHA256.hash(data: data).map { String(format: "%02X:", $0) }.joined()
+		return String(fingerprint.dropLast(1))
+	}
+	
+	func commonName(_ cert: SecCertificate) -> String {
+		
+		var cfstr: CFString? = nil
+		SecCertificateCopyCommonName(cert, &cfstr)
+		
+		return cfstr as String? ?? ""
+	}
+	
+	func subjectSummary(_ cert: SecCertificate) -> String {
+		
+		let cfstr = SecCertificateCopySubjectSummary(cert)
+		return cfstr as String? ?? ""
+	}
+	
+	func email(_ cert: SecCertificate) -> String {
+		
+		var cfarray: CFArray? = nil
+		SecCertificateCopyEmailAddresses(cert, &cfarray)
+		
+		let array = cfarray as? [String] ?? []
+		return array.first ?? ""
+	}
+	
+	func pubKey(_ cert: SecCertificate) -> String? {
+		
+		guard let key = SecCertificateCopyKey(cert) else {
+			return nil
+		}
+		
+		var cferr: Unmanaged<CFError>? = nil
+		let cfdata = SecKeyCopyExternalRepresentation(key, &cferr)
+		
+		if let cfdata = cfdata {
+			let data = cfdata as Data
+			return data.base64EncodedString()
+		} else {
+			return nil
+		}
+	}
+	
+	func encodePEM(_ cert: SecCertificate) -> String {
+		
+		let derData = SecCertificateCopyData(cert) as Data
+		var pemString = derData.base64EncodedString(options: [.lineLength64Characters, .endLineWithLineFeed])
+		
+		pemString = "-----BEGIN CERTIFICATE-----\n" + pemString
+		if !pemString.hasSuffix("\n") {
+			pemString += "\n"
+		}
+		pemString += "-----END CERTIFICATE-----"
+		
+		return pemString
+	}
+	
+	// --------------------------------------------------
+	// MARK: Actions
+	// --------------------------------------------------
+	
+	func onToggleDidChange() -> Void {
+		log.trace("onToggleDidChange()")
+		
+		userHasMadeChanges = true
+		if !isCustomized {
+			disableTextFields = false
+			invalidHost = false
+			invalidPort = false
+			activeCheck?.cancel()
+			activeCheck = nil
+			checkResult = nil
+			certInfoType = CertInfoType.first()
+			shouldTrustPubKey = false
+		}
+	}
+	
+	func onHostDidChange() {
+		log.trace("onHostDidChange()")
+		userHasMadeChanges = true
+	}
+	
+	func onHostDidCommit() {
+		log.trace("onHostDidCommit()")
+		checkHost()
+	}
+	
+	func onPortDidChange() {
+		log.trace("onPortDidChange()")
+		userHasMadeChanges = true
+	}
+	
+	func onPortDidCommit() {
+		log.trace("onPortDidCommit()")
+		checkPort()
+	}
+	
+	func closeSheet() {
+		log.trace("closeSheet()")
+		shortSheetState.close()
+	}
+	
+	func copyCert() {
+		log.trace("copyCert()")
+		
+		guard let cert = untrustedCert else {
+			return
+		}
+		let pem = encodePEM(cert)
+		
+		UIPasteboard.general.string = pem
+		toast.pop(
+			Text("Copied to pasteboard!").anyView,
+			colorScheme: colorScheme.opposite,
+			alignment: .none
+		)
+	}
+	
+	func checkServerConnection() {
+		log.trace("checkServerConnection()")
+		
+		guard
+			let checkedHost: String = checkHost(),
+			let checkedPort: UInt16 = checkPort()
+		else {
+			// Either invalidHost or invalidPort set to true
+			return
+		}
+		
+		var thisCheck: AnyCancellable? = nil
+		let completion = {(result: Result<TLSConnectionStatus, TLSConnectionError>) in
+			if thisCheck == self.activeCheck {
+				self.tlsConnectionCheckDidFinish(result)
+			}
+		}
+		
+//	#if DEBUG
+//		let cert = TLSConnectionCheck.debugCert()
+//		thisCheck = TLSConnectionCheck.debug(
+//			result: Result.success(TLSConnectionStatus.untrusted(cert: cert)),
+//			delay: 1.0,
+//			completion: completion
+//		)
+//	#endif
+		
+		thisCheck = TLSConnectionCheck.check(
+			host: checkedHost,
+			port: checkedPort,
+			completion: completion
+		)
+		
+		disableTextFields = true
+		checkResult = nil
+		activeCheck = thisCheck
+	}
+	
+	func cancelServerConnectionCheck() {
+		log.trace("cancelServerConnectionCheck()")
+		
+		disableTextFields = false
+		checkResult = nil
+		activeCheck?.cancel()
+		activeCheck = nil
+	}
+	
+	func saveConfig() -> Void {
+		log.trace("saveConfig()")
+		
+		if isCustomized,
+		   let checkedHost: String = checkHost(),
+		   let checkedPort: UInt16 = checkPort()
+		{
+			let pinnedPubKey: String?
+			let tls: Lightning_kmpTcpSocketTLS
+			if let cert = untrustedCert {
+				guard let pubKey = pubKey(cert) else {
+					return toast.pop(
+						Text("Unable to extract public key!").anyView,
+						colorScheme: colorScheme.opposite,
+						alignment: .none
+					)
+				}
+				pinnedPubKey = pubKey
+				tls = Lightning_kmpTcpSocketTLS.PINNED_PUBLIC_KEY(pubKey: pubKey)
+			} else {
+				pinnedPubKey = nil
+				tls = Lightning_kmpTcpSocketTLS.TRUSTED_CERTIFICATES()
+			}
+			
+			Prefs.shared.electrumConfig = ElectrumConfigPrefs(
+				host: checkedHost,
+				port: checkedPort,
+				pinnedPubKey: pinnedPubKey
+			)
+			mvi.intent(ElectrumConfiguration.IntentUpdateElectrumServer(server: Lightning_kmpServerAddress(
+				host: checkedHost,
+				port: Int32(checkedPort),
+				tls: tls
+			)))
+			
+		} else {
+			
+			Prefs.shared.electrumConfig = nil
+			mvi.intent(ElectrumConfiguration.IntentUpdateElectrumServer(server: nil))
+		}
+		
+		shortSheetState.close()
+	}
+	
+	@discardableResult
+	func checkHost() -> String? {
+		log.trace("checkHost()")
+		
+		if isCustomized {
+			
+			let rawHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+			let urlStr = "http://\(rawHost)"
+			
+			// careful: URL(string: "http://") return non-nil
+			
+			if (rawHost.count > 0) && (URL(string: urlStr) != nil) {
+				invalidHost = false
+				return rawHost
+			} else {
+				invalidHost = true
+				return nil
+			}
+			
+		} else {
+			
+			invalidHost = false
+			return ""
+		}
+	}
+	
+	@discardableResult
+	func checkPort() -> UInt16? {
+		log.trace("checkPort()")
+		
+		if isCustomized {
+			
+			if port.isEmpty {
+				invalidPort = false
+				return DEFAULT_PORT
+				
+			} else {
+				let rawPort = port.trimmingCharacters(in: .whitespacesAndNewlines)
+				
+				if let parsedPort = UInt16(rawPort), parsedPort != 0 {
+					invalidPort = false
+					return parsedPort
+				} else {
+					invalidPort = true
+					return nil
+				}
+			}
+			
+		} else {
+			
+			invalidPort = false
+			return 0
+		}
+	}
+	
+	func tlsConnectionCheckDidFinish(_ result: Result<TLSConnectionStatus, TLSConnectionError>) {
+		log.trace("tlsConnectionCheckDidFinish()")
+		
+		switch result {
+		case .failure(let error):
+			switch error {
+			case .invalidPort:
+				log.debug("FAILURE: invalidPort")
+			case .cancelled:
+				log.debug("FAILURE: cancelled")
+			case .network(_):
+				log.debug("FAILURE: network")
+			}
+			
+		case .success(let status):
+			switch status {
+			case .trusted:
+				log.debug("SUCCESS: trusted")
+			case .untrusted(_):
+				log.debug("SUCCESS: untrusted")
+			}
+		}
+		
+		activeCheck = nil
+		checkResult = result
+	}
+}
+
+// MARK:-
+/*
+class ElectrumConfigurationView_Previews: PreviewProvider {
+	
+	static let electrumServer1 = Lightning_kmpServerAddress(
+		host: "tn.not.fyi",
+		port: 55002,
+		tls: nil
+	)
+	
+	static let electrumServer2 = Lightning_kmpServerAddress(
+		host: "",
+		port: 0,
+		tls: nil
+	)
+	
+	static let mockModel = ElectrumConfiguration.Model(
+		configuration: ElectrumConfig.Custom(server: electrumServer2),
+		currentServer: nil,
+		connection: Lightning_kmpConnection.closed,
+		feeRate: 9999,
+		blockHeight: 1234,
+		tipTimestamp: 1234567890,
+		walletIsInitialized: true,
+		error: nil
+	)
+
+	static var previews: some View {
+
+		ElectrumAddressSheet(
+			model: mockModel,
+			postIntent: { _ in },
+			showing: $isShowing
+		)
+		.padding()
+		.preferredColorScheme(.light)
+		.previewDevice("iPhone 8")
+	}
+}
+*/

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/ElectrumAddressSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/ElectrumAddressSheet.swift
@@ -362,7 +362,7 @@ struct ElectrumAddressSheet: View {
 				Button {
 					certInfoType = certInfoType.next()
 				} label: {
-					Image(systemName: "arrowshape.turn.up.forward.fill")
+					Image(systemName: "chevron.forward.circle.fill")
 				}
 				.font(.body)
 			}

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/ElectrumConfigurationView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/ElectrumConfigurationView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 import PhoenixShared
+import Combine
 import os.log
 
-#if DEBUG && false
+#if DEBUG && true
 fileprivate var log = Logger(
 	subsystem: Bundle.main.bundleIdentifier!,
 	category: "ElectrumConfigurationView"
@@ -15,17 +16,21 @@ struct ElectrumConfigurationView: MVIView {
 	
 	@StateObject var mvi = MVIState({ $0.electrumConfiguration() })
 	
+	@State var didAppear = false
+	
+	@EnvironmentObject var deepLinkManager: DeepLinkManager
+	
 	@Environment(\.controllerFactory) var factoryEnv
 	var factory: ControllerFactory { return factoryEnv }
 	
-	@State var isModifying = false
+	@Environment(\.shortSheetState) var shortSheetState: ShortSheetState
 	
 	func connectionInfo() -> (String, String) {
 		
 		var status: String
 		var address: String
 		
-		if mvi.model.connection == Lightning_kmpConnection.established {
+		if mvi.model.connection is Lightning_kmpConnection.ESTABLISHED {
 			
 			status = NSLocalizedString("Connected to:", comment: "Connection status")
 			if let server = mvi.model.currentServer {
@@ -34,7 +39,7 @@ struct ElectrumConfigurationView: MVIView {
 				address = "?" // this state shouldn't be possible
 			}
 			
-		} else if mvi.model.connection == .establishing {
+		} else if mvi.model.connection is Lightning_kmpConnection.ESTABLISHING {
 			
 			status = NSLocalizedString("Connecting to:", comment: "Connection status")
 			if let server = mvi.model.currentServer {
@@ -84,7 +89,7 @@ struct ElectrumConfigurationView: MVIView {
 						
 						Spacer()
 						Button {
-							isModifying = true
+							didTapModify()
 						} label: {
 							HStack {
 								Image(systemName: "square.and.pencil").imageScale(.small)
@@ -127,57 +132,36 @@ struct ElectrumConfigurationView: MVIView {
 						Text(verbatim: "-")
 					}
 				}
-
-			/*	Why is this removed ?
-
-				if let xpub = mvi.model.xpub {
-					ListItem(header: Text("Master public key")) {
-						Text(xpub)
-							.contextMenu {
-								Button(action: {
-									UIPasteboard.general.string = xpub
-								}) {
-									Text("Copy")
-								}
-							}
-					}
-				}
-				
-				if let path = mvi.model.path {
-					ListItem(header: Text("Path")) {
-						Text(path)
-							.contextMenu {
-								Button(action: {
-									UIPasteboard.general.string = path
-								}) {
-									Text("Copy")
-								}
-							}
-					}
-				}
-			*/
 				
 			} // </Section: Status>
 			
 		} // </List>
 		.listStyle(GroupedListStyle())
-		.sheet(isPresented: $isModifying) {
-		
-			ElectrumAddressPopup(
-				model: mvi.model,
-				postIntent: mvi.intent,
-				showing: $isModifying
-			).padding()
-		}
-		.onAppear {
+		.onAppear() {
 			onAppear()
 		}
 	}
 	
-	func onAppear() -> Void {
+	func onAppear() {
 		log.trace("onAppear()")
 		
-		log.debug("mvi.model: \(mvi.model)")
+		if !didAppear {
+			didAppear = true
+			
+			if deepLinkManager.deepLink == .electrum {
+				// Reached our destination
+				deepLinkManager.broadcast(nil)
+			}
+		}
+	}
+	
+	func didTapModify() {
+		log.trace("didTapModify()")
+		
+		shortSheetState.display(dismissable: false) {
+			
+			ElectrumAddressSheet(mvi: mvi)
+		}
 	}
 	
 	struct ListHeader: View {
@@ -219,364 +203,5 @@ struct ElectrumConfigurationView: MVIView {
 			}
 			.frame(maxWidth: .infinity, alignment: .leading)
 		}
-	}
-}
-
-struct ElectrumAddressPopup: View {
-	
-	let model: ElectrumConfiguration.Model
-	let postIntent: (ElectrumConfiguration.Intent) -> Void
-	
-	@Binding var showing: Bool
-	
-	@State var isCustomized: Bool
-	@State var host: String
-	@State var port: String
-	
-	@State var userHasMadeChanges: Bool = false
-	@State var invalidHost = false
-	@State var invalidPort = false
-	
-	init(
-		model: ElectrumConfiguration.Model,
-		postIntent: @escaping (ElectrumConfiguration.Intent) -> Void,
-		showing: Binding<Bool>
-	) {
-		self.model = model
-		self.postIntent = postIntent
-		_showing = showing
-		
-		_isCustomized = State(initialValue: model.isCustom())
-		let customConfig = model.configuration as? ElectrumConfig.Custom
-		let host = customConfig?.server.host ?? ""
-		let port = customConfig?.server.port ?? 0
-		
-		if model.isCustom() && host.count > 0 {
-			_host = State(initialValue: host)
-			_port = State(initialValue: String(port))
-		} else {
-			_host = State(initialValue: "")
-			_port = State(initialValue: "")
-		}
-	}
-
-	var body: some View {
-		
-		let titleWidth: CGFloat = 60
-		
-		VStack(alignment: .trailing, spacing: 0) {
-			
-			VStack(alignment: .leading) {
-				
-				Toggle(isOn: $isCustomized.animation()) {
-					Text("Use a custom server")
-				}
-				.onChange(of: isCustomized) { _ in
-					onToggleDidChange()
-				}
-				.padding(.trailing, 2) // Toggle draws outside its bounds
-			}
-			.padding(.bottom, 15)
-			.background(Color(UIColor.systemBackground))
-			.zIndex(2)
-			
-			if isCustomized { // animation control
-			
-				VStack(alignment: .leading) {
-		
-					// == Server: ([TextField][X]) ===
-					HStack(alignment: .firstTextBaseline) {
-						Text("Server")
-							.font(.subheadline)
-							.fontWeight(.thin)
-							.foregroundColor(invalidHost ? Color.appNegative : Color.primary)
-							.frame(width: titleWidth)
-	
-						HStack {
-							TextField("example.com", text: $host,
-								onCommit: {
-									onHostDidCommit()
-								}
-							)
-							.keyboardType(.URL)
-							.disableAutocorrection(true)
-							.autocapitalization(.none)
-							.onChange(of: host) { _ in
-								onHostDidChange()
-							}
-	
-							Button {
-								host = ""
-							} label: {
-								Image(systemName: "multiply.circle.fill")
-									.foregroundColor(.secondary)
-							}
-							.isHidden(!isCustomized || host == "")
-						}
-						.disabled(!isCustomized)
-						.padding([.top, .bottom], 8)
-						.padding(.leading, 16)
-						.padding(.trailing, 8)
-						.background(
-							Capsule()
-								.strokeBorder(Color(UIColor.separator))
-						)
-					}
-					.frame(maxWidth: .infinity)
-					.padding(.bottom)
-					
-					// == Port: ([TextField][X]) ===
-					HStack(alignment: .firstTextBaseline) {
-						Text("Port")
-							.font(.subheadline)
-							.fontWeight(.thin)
-							.foregroundColor(invalidPort ? Color.appNegative : Color.primary)
-							.frame(width: titleWidth)
-						
-						HStack {
-							HStack {
-								TextField(verbatim: "50002", text: $port,
-									onCommit: {
-										onPortDidCommit()
-									}
-								)
-								.keyboardType(.numberPad)
-								.disableAutocorrection(true)
-								.onChange(of: port) { _ in
-									onPortDidChange()
-								}
-		
-								Button {
-									port = ""
-								} label: {
-									Image(systemName: "multiply.circle.fill")
-										.foregroundColor(.secondary)
-								}
-								.isHidden(!isCustomized || port == "")
-							}
-							.disabled(!isCustomized)
-							.padding([.top, .bottom], 8)
-							.padding(.leading, 16)
-							.padding(.trailing, 8)
-							.background(
-								Capsule()
-									.strokeBorder(Color(UIColor.separator))
-							)
-						}
-					}
-					.frame(maxWidth: .infinity)
-					.padding(.bottom, 30)
-					
-					if invalidHost {
-						Text("Invalid server. Use format: domain.tld")
-							.italic()
-							.foregroundColor(Color.appNegative)
-							.font(.footnote)
-					} else if invalidPort {
-						Text("Invalid port. Valid range: [1 - 65535]")
-							.italic()
-							.foregroundColor(Color.appNegative)
-							.font(.footnote)
-					} else {
-						Text("Note: Server must have a valid certificate")
-							.italic()
-							.font(.footnote)
-					}
-			
-				} // </VStack>
-				.transition(.move(edge: .top).animation(.easeInOut(duration: 0.3)))
-				.zIndex(1)
-				
-			} /* </if isCustomized> */ else {
-				
-				HStack(alignment: VerticalAlignment.center, spacing: 0) {
-					
-					Text("A random Electrum server will be selected on each connection attempt.")
-						.font(.footnote)
-					
-					Spacer()
-				}
-				.padding(.top, 10)
-				.transition(.asymmetric(
-					insertion : .opacity.animation(.easeInOut(duration: 0.1).delay(0.3)),
-					removal   : .identity // .opacity.animation(.linear(duration: 0.05))
-				))
-				.zIndex(0)
-			}
-			
-			Spacer()
-			
-			HStack {
-				
-				Button("Cancel") {
-					onCancelButtonTapped()
-				}
-				.font(.title2)
-				.padding(.trailing, 30)
-				
-				Button("Save") {
-					onSaveButtonTapped()
-				}
-				.font(.title2)
-			}
-			
-		} // </VStack>
-		.clipped()
-		
-	} // </var body: some View>
-	
-	func onToggleDidChange() -> Void {
-		log.trace("onToggleDidChange()")
-		userHasMadeChanges = true
-	}
-	
-	func onHostDidChange() -> Void {
-		log.trace("onHostDidChange()")
-		userHasMadeChanges = true
-	}
-	
-	func onHostDidCommit() -> Void {
-		log.trace("onHostDidCommit()")
-		checkHost()
-	}
-	
-	func onPortDidChange() -> Void {
-		log.trace("onPortDidChange()")
-		userHasMadeChanges = true
-	}
-	
-	func onPortDidCommit() -> Void {
-		log.trace("onPortDidCommit()")
-		checkPort()
-	}
-	
-	func onCancelButtonTapped() -> Void {
-		log.trace("onCancelButtonTapped()")
-		showing = false
-	}
-	
-	func onSaveButtonTapped() -> Void {
-		log.trace("onSaveButtonTapped()")
-		
-		let checkedHost: String? = checkHost()
-		let checkedPort: UInt16? = checkPort()
-		
-		if let checkedHost = checkedHost, // test not nil
-		   let checkedPort = checkedPort  // test not nil
-		{
-			if isCustomized {
-				Prefs.shared.electrumConfig = ElectrumConfigPrefs(host: checkedHost, port: checkedPort)
-				let address = "\(checkedHost):\(checkedPort)"
-				postIntent(ElectrumConfiguration.IntentUpdateElectrumServer(address: address))
-			} else {
-				Prefs.shared.electrumConfig = nil
-				postIntent(ElectrumConfiguration.IntentUpdateElectrumServer(address: nil))
-			}
-			
-			showing = false
-		}
-	}
-	
-	@discardableResult
-	func checkHost() -> String? {
-		log.trace("checkHost()")
-		
-		if isCustomized {
-			
-			let rawHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
-			let urlStr = "http://\(rawHost)"
-			
-			// careful: URL(string: "http://") return non-nil
-			
-			if (rawHost.count > 0) && (URL(string: urlStr) != nil) {
-				invalidHost = false
-				return rawHost
-			} else {
-				invalidHost = true
-				return nil
-			}
-			
-		} else {
-			
-			invalidHost = false
-			return ""
-		}
-	}
-	
-	@discardableResult
-	func checkPort() -> UInt16? {
-		log.trace("checkPort()")
-		
-		if isCustomized {
-			
-			let rawPort = port.trimmingCharacters(in: .whitespacesAndNewlines)
-			
-			if let parsedPort = UInt16(rawPort), parsedPort != 0 {
-				invalidPort = false
-				return parsedPort
-			} else {
-				invalidPort = true
-				return nil
-			}
-			
-		} else {
-			
-			invalidPort = false
-			return 0
-		}
-	}
-}
-
-// MARK:-
-
-class ElectrumConfigurationView_Previews: PreviewProvider {
-	
-	static let electrumServer1 = Lightning_kmpServerAddress(
-		host: "tn.not.fyi",
-		port: 55002,
-		tls: nil
-	)
-	
-	static let electrumServer2 = Lightning_kmpServerAddress(
-		host: "",
-		port: 0,
-		tls: nil
-	)
-	
-	static let mockModel = ElectrumConfiguration.Model(
-		configuration: ElectrumConfig.Custom(server: electrumServer2),
-		currentServer: nil,
-		connection: Lightning_kmpConnection.closed,
-		feeRate: 9999,
-		blockHeight: 1234,
-		tipTimestamp: 1234567890,
-		walletIsInitialized: true,
-		error: nil
-	)
-	
-	@State static var isShowing: Bool = true
-
-	static var previews: some View {
-		
-		NavigationView {
-			ElectrumConfigurationView()//.mock(model1)
-		}
-		.preferredColorScheme(.light)
-		.previewDevice("iPhone 8")
-
-//		NavigationView {
-//			ElectrumConfigurationView().mock(model2)
-//		}
-//		.preferredColorScheme(.dark)
-//		.previewDevice("iPhone 8")
-
-//		ElectrumAddressPopup(
-//			model: mockModel,
-//			postIntent: { _ in },
-//			showing: $isShowing
-//		)
-//		.padding()
-//		.preferredColorScheme(.light)
-//		.previewDevice("iPhone 8")
 	}
 }

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/ElectrumConfigurationView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/ElectrumConfigurationView.swift
@@ -16,6 +16,8 @@ struct ElectrumConfigurationView: MVIView {
 	
 	@StateObject var mvi = MVIState({ $0.electrumConfiguration() })
 	
+	@StateObject var customElectrumServerObserver = CustomElectrumServerObserver()
+	
 	@State var didAppear = false
 	
 	@EnvironmentObject var deepLinkManager: DeepLinkManager
@@ -101,8 +103,8 @@ struct ElectrumConfigurationView: MVIView {
 					Text(address).bold()
 						.padding(.top, 2)
 					
-					if let errMsg = mvi.model.error?.message {
-						Text(errMsg)
+					if customElectrumServerObserver.problem == .badCertificate {
+						Text("Bad certificate !")
 							.foregroundColor(Color.appNegative)
 							.padding(.top, 2)
 					}

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/PrivacyView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/PrivacyView.swift
@@ -1,5 +1,15 @@
 import SwiftUI
 import PhoenixShared
+import os.log
+
+#if DEBUG && true
+fileprivate var log = Logger(
+	subsystem: Bundle.main.bundleIdentifier!,
+	category: "PrivacyView"
+)
+#else
+fileprivate var log = Logger(OSLog.disabled)
+#endif
 
 
 fileprivate enum NavLinkTag: String {
@@ -11,6 +21,13 @@ fileprivate enum NavLinkTag: String {
 struct PrivacyView: View {
 	
 	@State private var navLinkTag: NavLinkTag? = nil
+	
+	@EnvironmentObject var deepLinkManager: DeepLinkManager
+	
+	@State private var swiftUiBugWorkaround: NavLinkTag? = nil
+	@State private var swiftUiBugWorkaroundIdx = 0
+	
+	@State var didAppear = false
 	
 	@ViewBuilder
 	var body: some View {
@@ -56,6 +73,15 @@ struct PrivacyView: View {
 			NSLocalizedString("Privacy", comment: "Navigation bar title"),
 			displayMode: .inline
 		)
+		.onAppear() {
+			onAppear()
+		}
+		.onChange(of: deepLinkManager.deepLink) {
+			deepLinkChanged($0)
+		}
+		.onChange(of: navLinkTag) {
+			navLinkTagChanged($0)
+		}
 	}
 	
 	func hasWallet() -> Bool {
@@ -67,6 +93,79 @@ struct PrivacyView: View {
 			return value.boolValue
 		} else {
 			return false
+		}
+	}
+	
+	func onAppear() {
+		log.trace("onAppear()")
+		
+		if !didAppear {
+			didAppear = true
+			if let deepLink = deepLinkManager.deepLink {
+				deepLinkChanged(deepLink)
+			}
+			
+		}
+	}
+	
+	func deepLinkChanged(_ value: DeepLink?) {
+		log.trace("deepLinkChanged() => \(value?.rawValue ?? "nil")")
+		
+		// This is a hack, courtesy of bugs in Apple's NavigationLink:
+		// https://developer.apple.com/forums/thread/677333
+		//
+		// Summary:
+		// There's some quirky code in SwiftUI that is resetting our navLinkTag.
+		// Several bizarre workarounds have been proposed.
+		// I've tried every one of them, and none of them work (at least, without bad side-effects).
+		//
+		// The only clean solution I've found is to listen for SwiftUI's bad behaviour,
+		// and forcibly undo it.
+		
+		if value == nil {
+			// We reached the final destination of the deep link
+			clearSwiftUiBugWorkaround(delay: 1.0)
+		
+		} else {
+			
+			// Navigate towards deep link (if needed)
+			var newNavLinkTag: NavLinkTag? = nil
+			switch value {
+				case .electrum : newNavLinkTag = NavLinkTag.ElectrumConfigurationView
+				default        : break
+			}
+			
+			if let newNavLinkTag = newNavLinkTag {
+				
+				self.swiftUiBugWorkaround = newNavLinkTag
+				self.swiftUiBugWorkaroundIdx += 1
+				clearSwiftUiBugWorkaround(delay: 5.0)
+				
+				self.navLinkTag = newNavLinkTag // Trigger/push the view
+			}
+		}
+	}
+	
+	fileprivate func navLinkTagChanged(_ tag: NavLinkTag?) {
+		log.trace("navLinkTagChanged() => \(tag?.rawValue ?? "nil")")
+		
+		if tag == nil, let forcedNavLinkTag = swiftUiBugWorkaround {
+				
+			log.trace("Blocking SwiftUI's attempt to reset our navLinkTag")
+			self.navLinkTag = forcedNavLinkTag
+		}
+	}
+	
+	func clearSwiftUiBugWorkaround(delay: TimeInterval) {
+		
+		let idx = self.swiftUiBugWorkaroundIdx
+		
+		DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+			
+			if self.swiftUiBugWorkaroundIdx == idx {
+				log.trace("swiftUiBugWorkaround = nil")
+				self.swiftUiBugWorkaround = nil
+			}
 		}
 	}
 }

--- a/phoenix-ios/phoenix-ios/views/configuration/general/recovery phrase/RecoveryPhraseView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/general/recovery phrase/RecoveryPhraseView.swift
@@ -49,6 +49,8 @@ struct RecoveryPhraseList: View {
 	@Namespace var sectionID_button
 	@Namespace var sectionID_legal
 	@Namespace var sectionID_cloudBackup
+
+	@EnvironmentObject var deepLinkManager: DeepLinkManager
 	
 	@Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 	
@@ -298,6 +300,12 @@ struct RecoveryPhraseList: View {
 		
 		if !didAppear {
 			didAppear = true
+			
+			if deepLinkManager.deepLink == .backup {
+				// Reached our destination
+				deepLinkManager.broadcast(nil)
+			}
+			
 			DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
 				withAnimation(Animation.linear(duration: 1.0).repeatForever(autoreverses: true)) {
 					animatingLegalToggleColor = true

--- a/phoenix-ios/phoenix-ios/views/environment/DeepLink.swift
+++ b/phoenix-ios/phoenix-ios/views/environment/DeepLink.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-enum DeepLink: Equatable {
+enum DeepLink: String, Equatable {
 	case backup
+	case electrum
 }
 
 class DeepLinkManager: ObservableObject {
@@ -11,12 +12,18 @@ class DeepLinkManager: ObservableObject {
 	
 	func broadcast(_ value: DeepLink?) {
 		self.deepLinkIdx += 1
-		let idx = self.deepLinkIdx
-		
 		self.deepLink = value
-		DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-			if self.deepLinkIdx == idx {
-				self.deepLink = nil
+		
+		if value != nil {
+			
+			// The value should get unset when the UI reaches the final destination.
+			// But if anything prevents that for any reason, this acts as a backup.
+			
+			let idx = self.deepLinkIdx
+			DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+				if self.deepLinkIdx == idx {
+					self.deepLink = nil
+				}
 			}
 		}
 	}

--- a/phoenix-ios/phoenix-ios/views/send/ScanView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/ScanView.swift
@@ -445,7 +445,7 @@ struct ScanView: View {
 					colorScheme: colorScheme.opposite,
 					style: .chrome,
 					duration: 10.0,
-					location: .middle,
+					alignment: .middle,
 					showCloseButton: true
 				)
 			}

--- a/phoenix-ios/phoenix-ios/views/send/SendView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/SendView.swift
@@ -211,7 +211,7 @@ struct SendView: MVIView {
 			colorScheme: colorScheme.opposite,
 			style: .chrome,
 			duration: 30.0,
-			location: .middle,
+			alignment: .middle,
 			showCloseButton: true
 		)
 	}

--- a/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
@@ -189,7 +189,7 @@ struct ValidateView: View {
 	@ViewBuilder
 	var content: some View {
 	
-		let isDisconnected = connectionsManager.connections.global != .established
+		let isDisconnected = !(connectionsManager.connections.global is Lightning_kmpConnection.ESTABLISHED)
 		VStack {
 	
 			if let host = paymentHost() {
@@ -566,13 +566,13 @@ struct ValidateView: View {
 	
 	func disconnectedText() -> String {
 		
-		if connectionsManager.connections.internet != Lightning_kmpConnection.established {
+		if !(connectionsManager.connections.internet is Lightning_kmpConnection.ESTABLISHED) {
 			return NSLocalizedString("waiting for internet", comment: "button text")
 		}
-		if connectionsManager.connections.peer != Lightning_kmpConnection.established {
+		if !(connectionsManager.connections.peer is Lightning_kmpConnection.ESTABLISHED) {
 			return NSLocalizedString("connecting to peer", comment: "button text")
 		}
-		if connectionsManager.connections.electrum != Lightning_kmpConnection.established {
+		if !(connectionsManager.connections.electrum is Lightning_kmpConnection.ESTABLISHED) {
 			return NSLocalizedString("connecting to electrum", comment: "button text")
 		}
 		return ""

--- a/phoenix-ios/phoenix-ios/views/widgets/AppStatusPopover.swift
+++ b/phoenix-ios/phoenix-ios/views/widgets/AppStatusPopover.swift
@@ -81,7 +81,7 @@ struct AppStatusPopover: View {
 			Group {
 				
 				let globalStatus = monitor.connections.global
-				if globalStatus == .closed {
+				if globalStatus is Lightning_kmpConnection.CLOSED {
 					
 					Label {
 						Text("Offline")
@@ -92,7 +92,7 @@ struct AppStatusPopover: View {
 							.frame(width: titleIconWidth, alignment: .center)
 					}
 				
-				} else if globalStatus == .establishing {
+				} else if globalStatus is Lightning_kmpConnection.ESTABLISHING {
 					
 					Label {
 						Text("Connecting...")
@@ -360,13 +360,13 @@ fileprivate struct ConnectionCell: View {
 		HStack(alignment: VerticalAlignment.center) {
 			let bullet = Image(systemName: "circle.fill").imageScale(.small)
 
-			if connection == .established {
+			if connection is Lightning_kmpConnection.ESTABLISHED{
 				bullet.foregroundColor(.appPositive)
 			}
-			else if connection == .establishing {
+			else if connection is Lightning_kmpConnection.ESTABLISHING {
 				bullet.foregroundColor(.appWarn)
 			}
-			else if connection == .closed {
+			else if connection is Lightning_kmpConnection.CLOSED {
 				bullet.foregroundColor(.appNegative)
 			}
 

--- a/phoenix-ios/phoenix-ios/views/widgets/Toast.swift
+++ b/phoenix-ios/phoenix-ios/views/widgets/Toast.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 class Toast: ObservableObject {
 	
-	enum ToastLocation {
-		case bottom
-		case middle
+	enum ToastAlignment {
 		case top
+		case middle
+		case bottom
+		case none
 	}
 	
 	enum ToastStyle {
@@ -22,7 +23,7 @@ class Toast: ObservableObject {
 	
 	@Published private var colorScheme: ColorScheme = ColorScheme.light
 	@Published private var style: ToastStyle = .regular
-	@Published private var location: ToastLocation = .bottom
+	@Published private var alignment: ToastAlignment = .bottom
 	@Published private var showCloseButton: Bool = false
 	
 	func pop(
@@ -30,7 +31,7 @@ class Toast: ObservableObject {
 		colorScheme: ColorScheme,
 		style: ToastStyle = .regular,
 		duration: TimeInterval = 1.5,
-		location: ToastLocation = .bottom,
+		alignment: ToastAlignment = .bottom,
 		showCloseButton: Bool = false
 	) {
 		
@@ -41,7 +42,7 @@ class Toast: ObservableObject {
 			self.content = content
 			self.colorScheme = colorScheme
 			self.style = style
-			self.location = location
+			self.alignment = alignment
 			self.showCloseButton = showCloseButton
 		}
 		DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
@@ -66,19 +67,25 @@ class Toast: ObservableObject {
 	@ViewBuilder
 	private func aligned(_ content: AnyView) -> some View {
 		
-		VStack {
-			switch location {
-			case .bottom:
-				Spacer()
-				wrapped(content).padding(.bottom, 45)
-			case .middle:
-				Spacer()
-				wrapped(content)
-				Spacer()
-			case .top:
+		switch alignment {
+		case .top:
+			VStack {
 				wrapped(content).padding(.top, 45)
 				Spacer()
 			}
+		case .middle:
+			VStack {
+				Spacer()
+				wrapped(content)
+				Spacer()
+			}
+		case .bottom:
+			VStack {
+				Spacer()
+				wrapped(content).padding(.bottom, 45)
+			}
+		case .none:
+			wrapped(content)
 		}
 	}
 	

--- a/phoenix-shared/src/androidMain/kotlin/fr/acinq/phoenix/data/androidElectrumRegtestConf.kt
+++ b/phoenix-shared/src/androidMain/kotlin/fr/acinq/phoenix/data/androidElectrumRegtestConf.kt
@@ -1,3 +1,3 @@
 package fr.acinq.phoenix.data
 
-actual fun platformElectrumRegtestConf(): ElectrumAddress = ElectrumAddress(host = "10.0.2.2", tcpPort = 51001, sslPort = 51002)
+actual fun platformElectrumRegtestConf(): ElectrumAddress = ElectrumAddress(host = "10.0.2.2", tlsPort = 51002)

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/config/ElectrumConfiguration.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/config/ElectrumConfiguration.kt
@@ -21,7 +21,6 @@ object ElectrumConfiguration {
     }
 
     sealed class Intent : MVI.Intent() {
-        data class UpdateElectrumServer(val address: String?) : Intent()
+        data class UpdateElectrumServer(val server: ServerAddress?) : Intent()
     }
-
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/config/ElectrumConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/config/ElectrumConfigurationController.kt
@@ -1,13 +1,10 @@
 package fr.acinq.phoenix.controllers.config
 
 import fr.acinq.lightning.blockchain.electrum.ElectrumClient
-import fr.acinq.lightning.io.TcpSocket
-import fr.acinq.lightning.utils.ServerAddress
 import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.managers.AppConfigurationManager
 import fr.acinq.phoenix.managers.AppConnectionsDaemon
 import fr.acinq.phoenix.controllers.AppController
-import fr.acinq.phoenix.data.InvalidElectrumAddress
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
@@ -46,38 +43,17 @@ class AppElectrumConfigurationController(
                         blockHeight = message?.height ?: 0,
                         tipTimestamp = message?.header?.time ?: 0,
                     )
-                })
-                .collect {
-                    model(it)
                 }
+            ).collect {
+                model(it)
+            }
         }
     }
-
 
     override fun process(intent: ElectrumConfiguration.Intent) {
         when (intent) {
             is ElectrumConfiguration.Intent.UpdateElectrumServer -> {
-                val error: Error? = when {
-                    intent.address.isNullOrBlank() -> {
-                        configurationManager.updateElectrumConfig(null)
-                        null
-                    }
-                    intent.address.matches("""(.*):(\d*)""".toRegex()) -> {
-                        intent.address.split(":").let {
-                            val host = it.first()
-                            val port = it.last()
-                            val serverAddress = ServerAddress(host, port.toInt(), TcpSocket.TLS.TRUSTED_CERTIFICATES)
-                            configurationManager.updateElectrumConfig(serverAddress)
-                        }
-                        null
-                    }
-                    else -> {
-                        InvalidElectrumAddress
-                    }
-                }
-                launch {
-                    model { copy(error = error) }
-                }
+                configurationManager.updateElectrumConfig(intent.server)
             }
         }
     }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/electrumConfs.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/electrumConfs.kt
@@ -3,37 +3,143 @@ package fr.acinq.phoenix.data
 
 data class ElectrumAddress(
     val host: String,
-    val sslPort: Int = 50002,
-    val tcpPort: Int = 50001,
-    val version: String = "1.4"
+    val tlsPort: Int = 50002,
+    // DER-encoded publicKey as base64 string.
+    // (I.e. same as PEM format, without BEGIN/END header/footer)
+    val pinnedPublicKey: String? = null
 )
 
 val electrumMainnetConfigurations = listOf(
     ElectrumAddress(host = "electrum.acinq.co"),
-    ElectrumAddress(host = "E-X.not.fyi"),
-    ElectrumAddress(host = "VPS.hsmiths.com"),
-    ElectrumAddress(host = "btc.cihar.com"),
+    ElectrumAddress(host = "E-X.not.fyi", pinnedPublicKey =
+        "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAz4l1L5f4+6VMN/3a3JcI" +
+        "qpyBSlpqYevUQ9uJIoKa8zOoEWWfRiRSBW1kcplRybPXRzUTR0mFduFNYsuAw5Kj" +
+        "nNQ3BeHRwnu0IxcLmP/+Oj9Q7rdUxHggYwkXJ4K5AUFT07fr6jKIFiwS5z/zXzWV" +
+        "9ngzNhieGeUWqZy8YF4OPUQx9Wz5KsFqG7PSS2GYAUe8dLr4VNvgAF46U1yVQetO" +
+        "6abJfLdnKzh2EVh3pIpJL3+6ggjpqyNgR+YXEDYSmES3KMwglUf34PKd6rKOQ/sE" +
+        "ddRKEJvsxfysWrJvNbbQ7PFOt2czj2x/+Is0iCpvH3UsIe4pQD03CJHywwjgyp6l" +
+        "RWWZIeUHJSSq9zDlkX9HqJJcu4cHv9cCGMx8Zsv/DwoDOIitZNKUbNq35PWxStlJ" +
+        "Q904A86GV5U52IBRXnF9Zcom6dvp1qchd5TuNnFC+5T+nvFH0NStxsa+b9VBoCDB" +
+        "yY6UxL5QEgn+9fZbvXYTtUZSJv/fqUKJY7NPtXRYgKVO5o7FbpF4HIFYBGNhfpw6" +
+        "4ps3qHAIXh1tISWT45BsLuTfsvjXsvSoPTDgzGt51zUpHrgEZSXhMrMSmDflIKjR" +
+        "g7AjlGkm/MsUTmL6McDn3lOduAas+496FX65vAQY7Ag5GR8yNzrtsLlRsGT2aPLA" +
+        "0PGxtnsWR6+sAjsv4VX+Z98CAwEAAQ=="
+    ),
+//  ElectrumAddress(host = "VPS.hsmiths.com"), // no longer working
+    ElectrumAddress(host = "btc.cihar.com", pinnedPublicKey =
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs0gd2ZsghxUZNwjY6cAD" +
+        "eZRRvk4sGUvkp5SEENNotiwCFPWXdNxCWxh1aiXpLc/h1+1NmwDHDhFXZDZNGFEW" +
+        "GPjW92uZWlcGVZffJWqc8XAvVmTKXUgCDv5daEtyTxk/69NDmmDWSeltV8020ykD" +
+        "FcU5cE/xEmBCfFRoR6yIGwIsCQAIX7XnfbDg1+JdN2N3ZSOOlY4B9r7n3Pm0Q0MW" +
+        "kRykSFk8EEQYmtk383aFZVDuvUkgLLFsBb0zmkWEVrm6Jy1hXyfWqdsrLaipqhy7" +
+        "2n62mHT9vfKhTGIoOXR989v6FA+EIYAklIL2ptX3vLqqvOnRjB122b9eT5ZpZhNi" +
+        "uwIDAQAB"
+    ),
     ElectrumAddress(host = "e.keff.org"),
-    ElectrumAddress(host = "electrum.qtornado.com"),
-    ElectrumAddress(host = "electrum.emzy.de"),
-    ElectrumAddress(host = "tardis.bauerj.eu"),
-    ElectrumAddress(host = "ecdsa.net", sslPort = 110),
+    ElectrumAddress(host = "electrum.qtornado.com", pinnedPublicKey =
+        "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAm78Y1pLds3BzsHpo9Bz2" +
+        "2lzu9tS/7loMcdL6AVJ3zVgGycI5whOWuaQntG0aYSiHammZNgGzjv44oU/PluzX" +
+        "PhMxzPlNgSEHnVi2K9mzG7HuGMQh5tEJfvt1zoMmnV4qTaZSLgKKcvrG9112LGQF" +
+        "UZBhV2J3gN21c8rqj/b6NfEqtItKVU173nqYchYu1GBGrHK1nDWWwTVrtHzY4Qos" +
+        "etyCPPnj/JWkO6I8kW2CIevpbXh5PROb+YvdbIsqvRODFgo1oLHmwf09Y7ZxE/nS" +
+        "LZ8yI67U1O39EcRQnoob6pbaqbaoNr0KZSR3xXcJTz2RkhlErMVNH850QGxlXMOr" +
+        "wNKgVrHhUFEBklbsk11Mx+mYWoeHrvZn55xwpTYGaZmZmAVwwUvherz/Tg490XD2" +
+        "2+2T78Zu3mmfmHKfD9uhC+ewyn+REHiz9vrvmMeh+YMBOEwf8lp1Jqte7/8xgdfq" +
+        "kDguOkN6azG64+LyzgWrB79Dfql858Rwn+ezpBZKcSyIL7o1r0T/WeCuR6vLiQ8q" +
+        "YbwAm61pUM9aVshda2WGRRUkhpy7Uj5OHpEQsnXqtoeEzTuiCr1y19VJgwabcUQH" +
+        "MVN1HGHiBl5eU4xBhDUG0l/268Ulk2lcRSI0udRtu7jjQzhSnKQL6HUhCm7PCdXg" +
+        "SqOSwa1yPuHtg/rNBXcqK8cCAwEAAQ=="
+    ),
+    ElectrumAddress(host = "electrum.emzy.de", pinnedPublicKey =
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAufqDv0nJICJPoP86wOPY" +
+        "M/XIfFs6vmVrGEeBZmy9MmMNubulhnyE+sWuFhnIX+0uuFlJ18LJYFOIg0fAaFdN" +
+        "5xh4vagBNXP9dCcxfVfMGfv9xBQZfWhKrDjC4DCJ82n3K+Q4RqpK/yS9GIZIcqrG" +
+        "3rxELBZ8NHVPIXveW0PnagGeQ31NDdOAq9MBKiKRcmfKem5daUEo/xM4nTt+tOTx" +
+        "l5sHicdQSCePHXewMXzmkM/Vw1rMJZKeTwnLX44TsppEi47fXUFcduB2+A1xHQIg" +
+        "E9wa4Bqc2ZoUtKKBayeeU02C2SBFgVxtAWT6YESdcPP8u+pR7lADA7QZNUVNKMvM" +
+        "NwIDAQAB"
+    ),
+//  ElectrumAddress(host = "tardis.bauerj.eu"), // no longer working
+    ElectrumAddress(host = "ecdsa.net", tlsPort = 110, pinnedPublicKey =
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzGHtaM37N0tgS7xcWmSq" +
+        "S2eOHBOtsZIGkkccbQbdmkgSpMGZSJgr23OofrlhmcdzFIzlqK2nXii7+5KW3Lgs" +
+        "zHKt9pArroFRRRFvoWHp5ijWYRATo7GKVPCngCPbg4fl4wxPYp9yg14BPe7BJfSN" +
+        "Stz6gV+akcCmKMVfqN5JFqPuuzOmSib270TgHCtIUccgDqHdP1muPQWZjCCxjePT" +
+        "f6e6J478Bh+Eop4lqvpEiLGeU/6Qj2oZ2tmO7j09J6Ycp0FHBISuCWWUCuZmIEk/" +
+        "NGOIUagggRU2tVFeW6wjSm1T3Q/z/b6G5oIaldZnklqo//79d3B4Fjj+C8lnFhpP" +
+        "/wIDAQAB"
+    ),
     ElectrumAddress(host = "e2.keff.org"),
     ElectrumAddress(host = "electrum3.hodlister.co"),
     ElectrumAddress(host = "electrum5.hodlister.co"),
-    ElectrumAddress(host = "fortress.qtornado.com"),
-    ElectrumAddress(host = "electrumx.erbium.eu"),
-    ElectrumAddress(host = "electrum.bitkoins.nl", sslPort = 50512),
+    ElectrumAddress(host = "fortress.qtornado.com", pinnedPublicKey =
+        "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAy7xI+hVU3rUSAyMMX8OI" +
+        "LdCs5m5Az1rzFL/8MTSnCBUnXY+YjmN8vFg8ktc/ebwSnjxCfjjXjPPcf0qSS2Xa" +
+        "WZ3M7nAlzYLpZCTuGBWE2ZbQ30QzXiMzh3Ucum4EJUeGOTEDtisdCrv3jjDs/P96" +
+        "UgR8MMA1fJqIpxAKnbEj5I9FX9t4eFVhYl6aiykJUFpV3aUZiDsqH8v5MiXCWHAc" +
+        "EGx1nfzY/os5xYYm/w0+VJiyX6HN0AViA2zF1wnWZFRqwCWpffaZAAPQdYaJ+bGl" +
+        "zR2PQneczw01EfJwMgb8QfMy3GbZFga7gT5NcZGzEAztL8Y7EzhtjcLksvhm5TB7" +
+        "iZbvNlCTmyv6F/jm90sZZAwYsg+9Dzl5ciJTKigQnMbPlDaOiRUKXkdw114Q2emO" +
+        "XKxs74fBl2g/XNO+3Jt7LSDrHEN38ygrHROxPbCTJmUawQ29KUBDULlnsWgzb9Ni" +
+        "uWMdaPJTXPUQSEYcux1jkVED1l5vANds0bTgM3fipb1MhvFb2GYJiVJkwu342fiG" +
+        "ADGpTzzjMqhsxevph8zh72MdaxyHCLlvk5OswTEoGNdo6ZFRBpmWDJF9zMnXCPEM" +
+        "vk2PS8RRlECPNORxSDsu79uXVm0+VmhLshcLOEEb+9qhLid063YLZrwEqZJshbm9" +
+        "Gcc9FdI7SUP85+RR9XnyL9cCAwEAAQ=="
+    ),
+    ElectrumAddress(host = "electrumx.erbium.eu", pinnedPublicKey =
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7IjEBAKC+2BnsfIekktU" +
+        "IzmHyQCB3SLVbvc50Ds3kaUEJX7wi/GxC/SGwVAjlE6zf135ruteTNqd4eJgG6pb" +
+        "kvgIImvCdMzfsGc+zupkOkVhImPXbr/mlPMG9hBoIp0yxKlBtOGsZDFuGdhLt6lJ" +
+        "navfrxLN3jU0nA9VrlS5cqs2S1WROSSRk2vh/jTQHius7ZQHwdAUSOBZTnIpni03" +
+        "wmvWa/hxTR5iRauDuVhkksyBSC8x6aIyON1F5mS29AHzL3uf4qByV6FUIFsE8az6" +
+        "bryC5GfdeKRVZdz1Bsd+3HncCdtC3S0x0QAD7rvQJ+NFLBsvyzplqBQZuj7IoFL6" +
+        "mwIDAQAB"
+    ),
+    ElectrumAddress(host = "electrum.bitkoins.nl", tlsPort = 50512),
     ElectrumAddress(host = "electrum.blockstream.info"),
     ElectrumAddress(host = "blockstream.info", 700)
 )
 
 val electrumTestnetConfigurations = listOf(
-    ElectrumAddress(host = "testnet.qtornado.com", sslPort= 51002),
-    ElectrumAddress(host = "tn.not.fyi", sslPort= 55002),
-    ElectrumAddress(host = "testnet1.electrum.acinq.co", sslPort = 51002),
-    ElectrumAddress(host = "blockstream.info", sslPort = 993),
-    ElectrumAddress(host = "testnet.aranguren.org", sslPort = 51002),
+    ElectrumAddress(host = "testnet.qtornado.com", tlsPort= 51002, pinnedPublicKey =
+        "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAwkLgqNkkTbwpV3gMdgDA" +
+        "+jJFdzrOp8vIDT/qxVIox8NZ53pxPc2N44aeY1NJx4TyfpHUGcI7l+gxZfLr8a13" +
+        "o3CIQSotDbZZdJhS6Ir5tT4iRqwZJch+HayTQf9rztv8OQWgrflWDzCiYtBA5PGx" +
+        "6LEQWyah/xPPUbeANe/ndEzlfAhXjNcynSfrkikzTgFNBqnc5CcTkHjYgzCXqMwy" +
+        "ZCD6kQTQG+eqIHSHul21dwUougfCWCR+P0zFA7LeUfPz2mLZktmGXjqTyYZ+0ZTU" +
+        "gJz/MMZt9PDWGJZsHQzoFSCMicukKtnvZ4Q0gbPOoYp8+WjD4SH+WmC3MZdLagsi" +
+        "05hUDdm7PHIM1VHQTALLGRnW3yTOaqhsvYGAM5UOkDcmgUqIr6IztHGWCKldfbhS" +
+        "c4l7BIgvwW2M6FxYlSAcavIodNfvEC1ythdMzl8bZsBjGIOZ39WtiM0grgcg7bb8" +
+        "W5ovZpLOXpzZBjS0zB0sZJnumjS+3jCSjy9rZXGUn3JmMdqtTV8RQxkB8OBJhFf5" +
+        "qtMSZXiJIr9RH71VoJKjnds/hoILHuCKU3HOJeo0+4KSD8+q4g3tZLr/haIrsHg5" +
+        "uifT9db6tDML1PTKpbHkW+f3w9PdhSmsNUUXrgNmQ0MoBhxV7U2Qcug3jX3xaf1P" +
+        "gwWDg3nZZizhuvBceY0IYLECAwEAAQ=="
+    ),
+    ElectrumAddress(host = "tn.not.fyi", tlsPort= 55002, pinnedPublicKey =
+        "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA7/z3CDZ2d6gJ/7mEt9yI" +
+        "9KNKxs5dbwzhKB99uYdWp1QogMHEo9Jg+uYGg2M7UhO76vOFaf1Hp2gstd1Q0n2G" +
+        "Lwtq3a0JSam3EIaC7QuX8V190IexyPSVdwaPtPBzN4KCZd8smfiR01oMJkhCH2MK" +
+        "aCrJKL7PJrSZMmrLMzo5yYTnHtBZVR9gL0T5bJeO3NTNuQBV1ft6kYaKa30d5zMO" +
+        "7j/CkzclQkh6d07RrS/YnkZNswfnqKdEqNNGa3FfuZ8vwSwRtpEQRAdkjxSFsLSo" +
+        "Iv+HoTx1nFhbmaqdZasFIxmn9Zp30KMb328k5j9fszcAn78y7tVodiddODBMgGSp" +
+        "ofq+nJDkNlKD0NVNLML50IB2U2BL/62+7c2RguvLYljNkTSB3HhF+b6DiGLZDbg4" +
+        "8ea12Hr+9Nxf4lW+hIKO3s/88MMlrB2lORORiuFtmiqYiiTc5YzJPXzXGhoCCmgQ" +
+        "xij6XYi0v4bpFr8wANtDobZhziWZSHm6T+u5RsSSkMGHc6hJaZmVg9xGznsD7RmR" +
+        "a+Wmf/Tl4sY0hI+nea4YyrN7+i1KT04EA9HrG6nBUKgKJkp2OciKmGGrINmdSCvk" +
+        "Z9laCxcGpEuAL0sI/WalmAXDTm/rjNdMZ0AClD3gCweqsblKZ07Ewtzh0DE65B7v" +
+        "tZWgWZM/wz4dnMYwY9VIrcUCAwEAAQ=="
+    ),
+    ElectrumAddress(host = "testnet1.electrum.acinq.co", tlsPort = 51002),
+    ElectrumAddress(host = "blockstream.info", tlsPort = 993),
+    ElectrumAddress(host = "testnet.aranguren.org", tlsPort = 51002, pinnedPublicKey =
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+RL/AH7wn08YKlRCswER" +
+        "M0JBdGycRuGBgQbM0guzDxi7Ov01WB9AM0DX7GC09pAOefbRP8QzXEhyKO0qpnin" +
+        "+5Vz4jKS+xv4zPGx2MpTqjJxzom/6v13cumZxWXMzVSeNUTjVp2sOPQ1JQaHqqjs" +
+        "2lTgShWu+pAgKUH1KPWxMSz21cI+AQkT8NuuXe0USYYIeiXzyTpciIaBf50j6185" +
+        "u+4bUwA3hvdPZyrkJDtSluJ0HiJzCSFlmNYNHLqbvZNAYrgUM3qJRTsvmD0JK6mm" +
+        "8m7iXW4m6mKX22VgR93meD/3rdcrJ8FbMbVlkS3wimzcYezls9JytaXupyeRKhQj" +
+        "TQIDAQAB"
+    ),
 )
 
 expect fun platformElectrumRegtestConf(): ElectrumAddress

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/errors.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/errors.kt
@@ -1,3 +1,3 @@
 package fr.acinq.phoenix.data
 
-object InvalidElectrumAddress: Error("Invalid electrum address.")
+// reserved for future error types

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConfigurationManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConfigurationManager.kt
@@ -188,7 +188,11 @@ class AppConfigurationManager(
         Chain.Testnet -> electrumTestnetConfigurations.random()
         Chain.Regtest -> platformElectrumRegtestConf()
     }.let {
-        ServerAddress(it.host, it.sslPort, TcpSocket.TLS.UNSAFE_CERTIFICATES)
+        if (it.pinnedPublicKey != null) {
+            ServerAddress(it.host, it.tlsPort, TcpSocket.TLS.PINNED_PUBLIC_KEY(it.pinnedPublicKey))
+        }  else {
+            ServerAddress(it.host, it.tlsPort, TcpSocket.TLS.TRUSTED_CERTIFICATES)
+        }
     }
 
     /** The flow containing the electrum header responses messages. */

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConnectionsDaemon.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConnectionsDaemon.kt
@@ -232,8 +232,7 @@ class AppConnectionsDaemon(
                     is ElectrumConfig.Custom -> {
                         when (newElectrumConfig) {
                             is ElectrumConfig.Custom -> { // custom -> custom
-                                newElectrumConfig.server.host != oldElectrumConfig.server.host ||
-                                newElectrumConfig.server.port != oldElectrumConfig.server.port
+                                newElectrumConfig == oldElectrumConfig
                             }
                             is ElectrumConfig.Random -> true // custom -> random
                             else -> true // custom -> null

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConnectionsDaemon.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConnectionsDaemon.kt
@@ -232,7 +232,7 @@ class AppConnectionsDaemon(
                     is ElectrumConfig.Custom -> {
                         when (newElectrumConfig) {
                             is ElectrumConfig.Custom -> { // custom -> custom
-                                newElectrumConfig == oldElectrumConfig
+                                newElectrumConfig != oldElectrumConfig
                             }
                             is ElectrumConfig.Random -> true // custom -> random
                             else -> true // custom -> null
@@ -253,7 +253,7 @@ class AppConnectionsDaemon(
                     }
                 }
                 if (changed) {
-                    logger.info { "electrum server config changed to=$newElectrumConfig, reconnecting..." }
+                    logger.info { "electrum config changed: reconnecting..." }
                     electrumControlChanges.send { incrementDisconnectCount() }
                     if (previousElectrumConfig != null) {
                         // The electrumConfig is only null on app launch.
@@ -264,6 +264,8 @@ class AppConnectionsDaemon(
                     // We need to delay the next connection vote because the collector WILL skip fast updates (see documentation)
                     // and ignore the change since the TrafficControl object would not have changed.
                     electrumControlChanges.send { decrementDisconnectCount() }
+                } else {
+                    logger.info { "electrum config: no changes" }
                 }
                 previousElectrumConfig = newElectrumConfig
             }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/LightningExtensions.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/LightningExtensions.kt
@@ -1,6 +1,5 @@
 package fr.acinq.phoenix.utils
 
-import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.db.WalletPayment
@@ -50,107 +49,22 @@ fun WalletPayment.errorMessage(): String? = when (this) {
     is IncomingPayment -> null
 }
 
-// This function exists because the `freeze()`
-// function isn't exposed to iOS.
-//
+/**
+ * This function exists because the `freeze()` function isn't exposed to iOS.
+ */
 fun WalletPayment.copyAndFreeze(): WalletPayment {
     return this.freeze()
 }
 
 /**
- * Many class types are not exported to iOS unless we explicitly
- * reference them within PhoenixShared.
+ * In Objective-C, the function name `description()` is already in use (part of NSObject).
+ * So we need to alias it.
  */
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun IncomingPayment.Origin.asInvoice(): IncomingPayment.Origin.Invoice? = when (this) {
-    is IncomingPayment.Origin.Invoice -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun IncomingPayment.Origin.asKeySend(): IncomingPayment.Origin.KeySend? = when (this) {
-    is IncomingPayment.Origin.KeySend -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun IncomingPayment.Origin.asSwapIn(): IncomingPayment.Origin.SwapIn? = when (this) {
-    is IncomingPayment.Origin.SwapIn -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun IncomingPayment.ReceivedWith.asLightningPayment(): IncomingPayment.ReceivedWith.LightningPayment? = when (this) {
-    is IncomingPayment.ReceivedWith.LightningPayment -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun IncomingPayment.ReceivedWith.asNewChannel(): IncomingPayment.ReceivedWith.NewChannel? = when (this) {
-    is IncomingPayment.ReceivedWith.NewChannel -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun OutgoingPayment.Details.asNormal(): OutgoingPayment.Details.Normal? = when (this) {
-    is OutgoingPayment.Details.Normal -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun OutgoingPayment.Details.asKeySend(): OutgoingPayment.Details.KeySend? = when (this) {
-    is OutgoingPayment.Details.KeySend -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun OutgoingPayment.Details.asSwapOut(): OutgoingPayment.Details.SwapOut? = when (this) {
-    is OutgoingPayment.Details.SwapOut -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun OutgoingPayment.Details.asChannelClosing(): OutgoingPayment.Details.ChannelClosing? = when (this) {
-    is OutgoingPayment.Details.ChannelClosing -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun OutgoingPayment.Status.asPending(): OutgoingPayment.Status.Pending? = when (this) {
-    is OutgoingPayment.Status.Pending -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun OutgoingPayment.Status.asFailed(): OutgoingPayment.Status.Completed.Failed? = when (this) {
-    is OutgoingPayment.Status.Completed.Failed -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun OutgoingPayment.Status.asSucceeded(): OutgoingPayment.Status.Completed.Succeeded? = when (this) {
-    is OutgoingPayment.Status.Completed.Succeeded -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun OutgoingPayment.Status.asOffChain(): OutgoingPayment.Status.Completed.Succeeded.OffChain? = when (this) {
-    is OutgoingPayment.Status.Completed.Succeeded.OffChain -> this
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun OutgoingPayment.Status.asOnChain(): OutgoingPayment.Status.Completed.Succeeded.OnChain? = when (this) {
-    is OutgoingPayment.Status.Completed.Succeeded.OnChain -> this
-    else -> null
-}
-
-// In Objective-C, the function name `description()` is already in use (part of NSObject).
-// So we need to alias it.
 fun PaymentRequest.desc(): String? = this.description
 
-// Since unix epoch
+/**
+ * Since unix epoch
+ */
 fun PaymentRequest.expiryTimestampSeconds(): Long? = this.expirySeconds?.let {
     this.timestampSeconds + it
 }
@@ -159,23 +73,5 @@ fun PaymentRequest.chain(): Chain? = when (this.prefix) {
     "lnbc" -> Chain.Mainnet
     "lntb" -> Chain.Testnet
     "lnbcrt" -> Chain.Regtest
-    else -> null
-}
-
-// Class type not exported to iOS unless we explicitly reference it in PhoenixShared.
-fun ChannelState.asOffline(): Offline? = when (this) {
-    is Offline -> this
-    else -> null
-}
-fun ChannelState.asClosing(): Closing? = when (this) {
-    is Closing -> this
-    else -> null
-}
-fun ChannelState.asClosed(): Closed? = when (this) {
-    is Closed -> this
-    else -> null
-}
-fun ChannelState.asAborted(): Aborted? = when (this) {
-    is Aborted -> this
     else -> null
 }

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/data/iosElectrumRegtestConf.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/data/iosElectrumRegtestConf.kt
@@ -1,3 +1,3 @@
 package fr.acinq.phoenix.data
 
-actual fun platformElectrumRegtestConf(): ElectrumAddress = ElectrumAddress(host = "127.0.0.1", tcpPort = 51001, sslPort = 51002)
+actual fun platformElectrumRegtestConf(): ElectrumAddress = ElectrumAddress(host = "127.0.0.1", tlsPort = 51002)

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
@@ -1,0 +1,152 @@
+package fr.acinq.phoenix.utils
+
+import fr.acinq.lightning.channel.*
+import fr.acinq.lightning.db.IncomingPayment
+import fr.acinq.lightning.db.OutgoingPayment
+import fr.acinq.lightning.io.NativeSocketException
+import fr.acinq.lightning.io.TcpSocket
+import fr.acinq.lightning.utils.Connection
+
+/**
+ * Class types from lightning-kmp & bitcoin-kmp are not exported to iOS unless we explicitly
+ * reference them within PhoenixShared, either as a public parameter or return type.
+ *
+ * This problem is restricted to iOS, and doesn't not affect Android.
+ */
+
+fun IncomingPayment.Origin.asInvoice(): IncomingPayment.Origin.Invoice? = when (this) {
+    is IncomingPayment.Origin.Invoice -> this
+    else -> null
+}
+
+fun IncomingPayment.Origin.asKeySend(): IncomingPayment.Origin.KeySend? = when (this) {
+    is IncomingPayment.Origin.KeySend -> this
+    else -> null
+}
+
+fun IncomingPayment.Origin.asSwapIn(): IncomingPayment.Origin.SwapIn? = when (this) {
+    is IncomingPayment.Origin.SwapIn -> this
+    else -> null
+}
+
+fun IncomingPayment.ReceivedWith.asLightningPayment(): IncomingPayment.ReceivedWith.LightningPayment? = when (this) {
+    is IncomingPayment.ReceivedWith.LightningPayment -> this
+    else -> null
+}
+
+fun IncomingPayment.ReceivedWith.asNewChannel(): IncomingPayment.ReceivedWith.NewChannel? = when (this) {
+    is IncomingPayment.ReceivedWith.NewChannel -> this
+    else -> null
+}
+
+fun OutgoingPayment.Details.asNormal(): OutgoingPayment.Details.Normal? = when (this) {
+    is OutgoingPayment.Details.Normal -> this
+    else -> null
+}
+
+fun OutgoingPayment.Details.asKeySend(): OutgoingPayment.Details.KeySend? = when (this) {
+    is OutgoingPayment.Details.KeySend -> this
+    else -> null
+}
+
+fun OutgoingPayment.Details.asSwapOut(): OutgoingPayment.Details.SwapOut? = when (this) {
+    is OutgoingPayment.Details.SwapOut -> this
+    else -> null
+}
+
+fun OutgoingPayment.Details.asChannelClosing(): OutgoingPayment.Details.ChannelClosing? = when (this) {
+    is OutgoingPayment.Details.ChannelClosing -> this
+    else -> null
+}
+
+fun OutgoingPayment.Status.asPending(): OutgoingPayment.Status.Pending? = when (this) {
+    is OutgoingPayment.Status.Pending -> this
+    else -> null
+}
+
+fun OutgoingPayment.Status.asFailed(): OutgoingPayment.Status.Completed.Failed? = when (this) {
+    is OutgoingPayment.Status.Completed.Failed -> this
+    else -> null
+}
+
+fun OutgoingPayment.Status.asSucceeded(): OutgoingPayment.Status.Completed.Succeeded? = when (this) {
+    is OutgoingPayment.Status.Completed.Succeeded -> this
+    else -> null
+}
+
+fun OutgoingPayment.Status.asOffChain(): OutgoingPayment.Status.Completed.Succeeded.OffChain? = when (this) {
+    is OutgoingPayment.Status.Completed.Succeeded.OffChain -> this
+    else -> null
+}
+
+fun OutgoingPayment.Status.asOnChain(): OutgoingPayment.Status.Completed.Succeeded.OnChain? = when (this) {
+    is OutgoingPayment.Status.Completed.Succeeded.OnChain -> this
+    else -> null
+}
+
+fun ChannelState.asOffline(): Offline? = when (this) {
+    is Offline -> this
+    else -> null
+}
+fun ChannelState.asClosing(): Closing? = when (this) {
+    is Closing -> this
+    else -> null
+}
+fun ChannelState.asClosed(): Closed? = when (this) {
+    is Closed -> this
+    else -> null
+}
+fun ChannelState.asAborted(): Aborted? = when (this) {
+    is Aborted -> this
+    else -> null
+}
+
+fun TcpSocket.TLS.asDisabled(): TcpSocket.TLS.DISABLED? = when (this) {
+    is TcpSocket.TLS.DISABLED -> this
+    else -> null
+}
+
+fun TcpSocket.TLS.asTrustedCertificates(): TcpSocket.TLS.TRUSTED_CERTIFICATES? = when (this) {
+    is TcpSocket.TLS.TRUSTED_CERTIFICATES -> this
+    else -> null
+}
+
+fun TcpSocket.TLS.asPinnedPublicKey(): TcpSocket.TLS.PINNED_PUBLIC_KEY? = when (this) {
+    is TcpSocket.TLS.PINNED_PUBLIC_KEY -> this
+    else -> null
+}
+
+fun TcpSocket.TLS.asUnsafeCertificates(): TcpSocket.TLS.UNSAFE_CERTIFICATES? = when (this) {
+    is TcpSocket.TLS.UNSAFE_CERTIFICATES -> this
+    else -> null
+}
+
+fun Connection.asClosed(): Connection.CLOSED? = when (this) {
+    is Connection.CLOSED -> this
+    else -> null
+}
+
+fun Connection.asEstablishing(): Connection.ESTABLISHING? = when (this) {
+    is Connection.ESTABLISHING -> this
+    else -> null
+}
+
+fun Connection.isEstablished(): Connection.ESTABLISHED? = when (this) {
+    is Connection.ESTABLISHED -> this
+    else -> null
+}
+
+fun NativeSocketException.asPOSIX(): NativeSocketException.POSIX? = when (this) {
+    is NativeSocketException.POSIX -> this
+    else -> null
+}
+
+fun NativeSocketException.asDNS(): NativeSocketException.DNS? = when (this) {
+    is NativeSocketException.DNS -> this
+    else -> null
+}
+
+fun NativeSocketException.asTLS(): NativeSocketException.TLS? = when (this) {
+    is NativeSocketException.TLS -> this
+    else -> null
+}


### PR DESCRIPTION
Fixes issue #182 

<img height="500" src="https://user-images.githubusercontent.com/304604/167908933-cb263554-7f1d-4475-b545-d02f4987454f.gif"/>

Notes: 
- This fixes the iOS build (matches latest lightning-kmp changes)
- This PR contains a **breaking change for Android**. In particular, in `ElectrumConfiguration.kt`:

```kotlin
// OLD:
sealed class Intent : MVI.Intent() {
  data class UpdateElectrumServer(val address: String?) : Intent()
}

// NEW
sealed class Intent : MVI.Intent() {
  data class UpdateElectrumServer(val server: ServerAddress?) : Intent()
}
```

So the difference here is that previously we passed a string, and the ElectrumConfigurationController handled parsing it to a ServerAddress. But now the client is expected to directly pass the ServerAddress. Which is because the `ServerAddress` class now allows you to pin a public key.

The solution for now (until Android implements custom UI for pubKey pinning) is to copy the old parsing code from `ElectrumConfigurationController`, which was something like this:

```kotlin
intent.address.matches("""(.*):(\d*)""".toRegex()) -> {
    intent.address.split(":").let {
        val host = it.first()
        val port = it.last()
        val serverAddress = ServerAddress(host, port.toInt(), TcpSocket.TLS.TRUSTED_CERTIFICATES)
     }
}
```

- This PR increases security by pinning the public keys for the default list of Electrum servers. (See `electrumConfs.kt`) To verify these pub key values, you can:

```
$ openssl s_client -connect testnet.qtornado.com:51002
``` 

^ This command will print the server's certificate to the console. (The part that starts with `-----BEGIN CERTIFICATE-----` and ends with `-----END CERTIFICATE-----`) Write that to a file (e.g. `testnet.qtornado.com.pem`). And then use this command to extract the public key from the certificate:

```
openssl x509 -in testnet.qtornado.com.pem -noout -pubkey
```

