### PR TITLE
Inconsistent balance in Home vs Channels screen

### DIFF
--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/ChannelsConfigurationView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/ChannelsConfigurationView.swift
@@ -195,24 +195,24 @@ struct ChannelHeaderView: View {
 	
 	func balances() -> (FormattedAmount, FormattedAmount) {
 		
-		let localSats = mvi.model.channels.map { channel in
-			channel.localBalance?.sat ?? Int64(0)
+		let localMsats = mvi.model.channels.map { channel in
+			channel.localBalance?.msat ?? Int64(0)
 		}
 		.reduce(into: Int64(0)) { result, next in
 			result += next
 		}
-		let remoteSats = mvi.model.channels.map { channel in
-			channel.remoteBalance?.sat ?? Int64(0)
+		let remoteMsats = mvi.model.channels.map { channel in
+			channel.remoteBalance?.msat ?? Int64(0)
 		}
 		.reduce(into: Int64(0)) { result, next in
 			result += next
 		}
 		
-		let numerator_sats = localSats
-		let denominator_sats = showChannelsRemoteBalance ? remoteSats : (localSats + remoteSats)
+		let numerator_msats = localMsats
+		let denominator_msats = showChannelsRemoteBalance ? remoteMsats : (localMsats + remoteMsats)
 		
-		let numerator = Utils.formatBitcoin(sat: numerator_sats, bitcoinUnit: .sat)
-		let denominator = Utils.formatBitcoin(sat: denominator_sats, bitcoinUnit: .sat)
+		let numerator = Utils.formatBitcoin(msat: numerator_msats, bitcoinUnit: .sat, policy: .showMsatsIfZeroSats)
+		let denominator = Utils.formatBitcoin(msat: denominator_msats, bitcoinUnit: .sat, policy: .hideMsats)
 		
 		return (numerator, denominator)
 	}
@@ -263,17 +263,17 @@ fileprivate struct ChannelRowView: View {
 	
 	func balances() -> (FormattedAmount, FormattedAmount)? {
 		
-		guard let localSats = channel.localBalance?.sat,
-				let remoteSats = channel.remoteBalance?.sat
+		guard let localMsats = channel.localBalance?.msat,
+				let remoteMsats = channel.remoteBalance?.msat
 		else {
 			return nil
 		}
 		
-		let numerator_sats = localSats
-		let denominator_sats = showChannelsRemoteBalance ? remoteSats : (localSats + remoteSats)
+		let numerator_msats = localMsats
+		let denominator_msats = showChannelsRemoteBalance ? remoteMsats : (localMsats + remoteMsats)
 		
-		let numerator = Utils.formatBitcoin(sat: numerator_sats, bitcoinUnit: .sat)
-		let denominator = Utils.formatBitcoin(sat: denominator_sats, bitcoinUnit: .sat)
+		let numerator = Utils.formatBitcoin(msat: numerator_msats, bitcoinUnit: .sat, policy: .showMsatsIfZeroSats)
+		let denominator = Utils.formatBitcoin(msat: denominator_msats, bitcoinUnit: .sat, policy: .hideMsats)
 		
 		return (numerator, denominator)
 	}
@@ -507,8 +507,8 @@ class ChannelsConfigurationView_Previews : PreviewProvider {
 		id: "b50bf19d16156de8231f6d3d3fb3dd105ba338de5366d0421b0954b9ceb0d4f8",
 		isOk: true,
 		stateName: "Normal",
-		localBalance: Bitcoin_kmpSatoshi(sat: 50_000),
-		remoteBalance: Bitcoin_kmpSatoshi(sat: 200_000),
+		localBalance: Lightning_kmpMilliSatoshi(msat: 50_000_000),
+		remoteBalance: Lightning_kmpMilliSatoshi(msat: 200_000_000),
 		json: "{Everything is normal!}",
 		txId: nil
 	)
@@ -517,8 +517,8 @@ class ChannelsConfigurationView_Previews : PreviewProvider {
 		id: "e5366d0421b0954b9ceb0d4f8b50bf19d16156de8231f6d3d3fb3dd105ba338d",
 		isOk: false,
 		stateName: "Woops",
-		localBalance: Bitcoin_kmpSatoshi(sat: 0),
-		remoteBalance: Bitcoin_kmpSatoshi(sat: 0),
+		localBalance: Lightning_kmpMilliSatoshi(msat: 0),
+		remoteBalance: Lightning_kmpMilliSatoshi(msat: 0),
 		json: "{Woops!}",
 		txId: nil
 	)

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/config/ChannelsConfiguration.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/config/ChannelsConfiguration.kt
@@ -1,6 +1,6 @@
 package fr.acinq.phoenix.controllers.config
 
-import fr.acinq.bitcoin.Satoshi
+import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.phoenix.controllers.MVI
 
 object ChannelsConfiguration {
@@ -15,8 +15,8 @@ object ChannelsConfiguration {
             val id: String,
             val isOk: Boolean,
             val stateName: String,
-            val localBalance: Satoshi?,
-            val remoteBalance: Satoshi?,
+            val localBalance: MilliSatoshi?,
+            val remoteBalance: MilliSatoshi?,
             val json: String,
             val txId: String?
         )

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/config/ChannelsConfigurationController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/config/ChannelsConfigurationController.kt
@@ -61,10 +61,10 @@ class AppChannelsConfigurationController(
                             isOk = state is Normal,
                             stateName = state::class.simpleName ?: "Unknown",
                             localBalance = state.localCommitmentSpec?.let {
-                                it.toLocal.truncateToSatoshi()
+                                it.toLocal
                             },
                             remoteBalance = state.localCommitmentSpec?.let {
-                                it.toRemote.truncateToSatoshi()
+                                it.toRemote
                             },
                             json = json.encodeToString(
                                 fr.acinq.lightning.serialization.v1.ChannelState.serializer(),


### PR DESCRIPTION
This commit addresses issue #245 

> We should use [the .showMsatsIfZeroSats] policy for the balance display in the home screen and for the user's balance in the channels-configuration screen (only for the user's balance, not for the capacity or for the remote's balance).

This commit updates the channels-configuration screen to use the new policy. Note that previously, the channel balance was being exported (from phoenix-shared) in Satoshi's. So I had to change that to MilliSatoshi's... which probably also means we need another commit here for the Android UI.