### PR TITLE
Updating UI for "Drain wallet" screen

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -724,7 +724,6 @@
 				DC27E4C02791BFFC00C777CC /* privacy */,
 				53BEF0A8669F9379E4E4596F /* logs */,
 				53BEF648B3A03C66B611BC06 /* ChannelsConfigurationView.swift */,
-				DCF360CF2591018300E92031 /* CloseChannelsView.swift */,
 				DC9B8EE125D72CC200E13818 /* ForceCloseChannelsView.swift */,
 			);
 			path = advanced;
@@ -736,6 +735,7 @@
 				C8D7A2327BC90150A3E1493D /* AboutView.swift */,
 				C8D7A986A61CCD64FA661B88 /* DisplayConfigurationView.swift */,
 				DC0732EB263CA6C3004CB88D /* PaymentOptionsView.swift */,
+				DCF360CF2591018300E92031 /* CloseChannelsView.swift */,
 				DC27E4CD2791D18600C777CC /* recovery phrase */,
 			);
 			path = general;

--- a/phoenix-ios/phoenix-ios/ar.lproj/Localizable.strings
+++ b/phoenix-ios/phoenix-ios/ar.lproj/Localizable.strings
@@ -473,9 +473,9 @@
 "The address is for %@, but you're on %@" = "العنوان لـ %@ ، لكنك على %@";
 "The bitcoin mempool is congested and fees are very high. The on-chain swap service has been temporarily disabled." = "الـ mempool (المعاملات المعلقة) الخاصة بالبيتكوين مزدحمة حالياً والرسوم مرتفعة للغاية. تم تعطيل خدمة مبادلة الايداعات على السلسلة الرئيسية مؤقتًا.";
 /* label text */
-"The closing transaction is in your transactions list on the __main__ screen. And you can view the status of your channels in the __channels list__ screen." = "معاملة إغلاق القناة موجودة في قائمة المعاملات الخاصة بك على __الشاشة الرئيسية__. ويمكنك عرض حالة قنواتك في شاشة __قائمة القنوات__.";
+"The closing transaction is in your transactions list." = "معاملة إغلاق القناة موجودة في قائمة المعاملات الخاصة بك على __الشاشة الرئيسية__. ويمكنك عرض حالة قنواتك في شاشة __قائمة القنوات__.";
 /* label text */
-"The closing transactions are in your transactions list on the __main__ screen. And you can view the status of your channels in the __channels list__ screen." = "معاملات إغلاق القنوات موجودة في قائمة المعاملات الخاصة بك على __الشاشة الرئيسية__. ويمكنك عرض حالة قنواتك في شاشة __قائمة القنوات__.";
+"The closing transactions are in your transactions list." = "معاملات إغلاق القنوات موجودة في قائمة المعاملات الخاصة بك على __الشاشة الرئيسية__. ويمكنك عرض حالة قنواتك في شاشة __قائمة القنوات__.";
 "The data stored in the cloud is encrypted, and can only be decrypted with your seed." = "يتم تشفير البيانات المخزنة في السحابة، ولا يمكن فك تشفيرها إلا بعبارة الاسترداد الخاصة بك.";
 /* IntroView */
 "The fee is **%@%%** with a minimum fee of **%@**." = "الرسوم **%@٪** مع حد أدنى للرسوم **%@**.";

--- a/phoenix-ios/phoenix-ios/cs.lproj/Localizable.strings
+++ b/phoenix-ios/phoenix-ios/cs.lproj/Localizable.strings
@@ -832,10 +832,7 @@
 "The bitcoin mempool is congested and fees are very high. The on-chain swap service has been temporarily disabled." = "Bitcoinový mempool je přetížený a poplatky jsou velmi vysoké. Služba swapu na on-chainu byla dočasně deaktivována.";
 
 /* label text */
-"The closing transaction is in your transactions list on the __main__ screen. And you can view the status of your channels in the __channels list__ screen." = "Uzavírací transakce je ve vašem seznamu transakcí na __hlavní__ obrazovce. A stav svých kanálů můžete zobrazit na obrazovce __list kanálů__.";
-
-/* label text */
-"The closing transactions are in your transactions list on the __main__ screen. And you can view the status of your channels in the __channels list__ screen." = "Uzavírací transakce jsou ve vašem seznamu transakcí na __hlavní__ obrazovce. A stav svých kanálů můžete zobrazit na obrazovce __list kanálů__.";
+"The closing transaction is in your transactions list." = "Uzavírací transakce je ve vašem seznamu transakcí.";
 
 /* No comment provided by engineer. */
 "The data stored in the cloud is encrypted, and can only be decrypted with your seed." = "Data uložená v cloudu jsou šifrována a lze je dešifrovat pouze pomocí jejich seedu.";

--- a/phoenix-ios/phoenix-ios/es.lproj/Localizable.strings
+++ b/phoenix-ios/phoenix-ios/es.lproj/Localizable.strings
@@ -1116,10 +1116,7 @@
 "The bitcoin mempool is congested and fees are very high. The on-chain swap service has been temporarily disabled." = "El mempool de Bitcoin está congestionado y las tarifas son muy altas. El servicio de intercambio en cadena se ha desactivado temporalmente.";
 
 /* label text */
-"The closing transaction is in your transactions list on the __main__ screen. And you can view the status of your channels in the __channels list__ screen." = "La transacción de cierre está en su lista de transacciones en la pantalla __principal__. Y puede ver el estado de sus canales en la opción __lista de canales__.";
-
-/* label text */
-"The closing transactions are in your transactions list on the __main__ screen. And you can view the status of your channels in the __channels list__ screen." = "La transacción de cierre está en su lista de transacciones en la pantalla __principal__. Y puede ver el estado de sus canales en la opción __lista de canales__.";
+"The closing transaction is in your transactions list." = "La transacción de cierre está en su lista de transacciones.";
 
 /* No comment provided by engineer. */
 "The data stored in the cloud is encrypted, and can only be decrypted with your seed." = "Los datos almacenados en la nube están encriptados y solo se pueden desencriptar con su semilla.";

--- a/phoenix-ios/phoenix-ios/fr.lproj/Localizable.strings
+++ b/phoenix-ios/phoenix-ios/fr.lproj/Localizable.strings
@@ -1182,10 +1182,7 @@
 "The bitcoin mempool is congested and fees are very high. The on-chain swap service has been temporarily disabled." = "Le réseau Bitcoin est saturé et les frais sont très élevés. Le service de swap on-chain a été désactivé temporairement.";
 
 /* label text */
-"The closing transaction is in your transactions list on the __main__ screen. And you can view the status of your channels in the __channels list__ screen." = "La transaction de fermeture est visible dans la liste des transaction, dans l’écran __principal__. Vous pouvez voir le statut de vos canaux de paiement dans l’écran __list des canaux__.";
-
-/* label text */
-"The closing transactions are in your transactions list on the __main__ screen. And you can view the status of your channels in the __channels list__ screen." = "Les transactions de fermeture sont visibles dans la liste des transaction, dans l’écran __principal__. Vous pouvez voir le statut de vos canaux de paiement dans l’écran __liste des canaux__.";
+"The closing transaction is in your transactions list." = "La transaction de fermeture est visible dans la liste des transaction.";
 
 /* No comment provided by engineer. */
 "The data stored in the cloud is encrypted, and can only be decrypted with your seed." = "Les données stockées dans le cloud sont chiffrées, et ne peuvent être lues sans votre clé secrète.";

--- a/phoenix-ios/phoenix-ios/views/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/HomeView.swift
@@ -825,6 +825,8 @@ struct HomeView : MVIView {
 			switch value {
 			case .backup:
 				self.navLinkTag = .ConfigurationView
+			case .drainWallet:
+				self.navLinkTag = .ConfigurationView
 			case .electrum:
 				self.navLinkTag = .ConfigurationView
 			}

--- a/phoenix-ios/phoenix-ios/views/configuration/ConfigurationView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/ConfigurationView.swift
@@ -18,13 +18,13 @@ fileprivate enum NavLinkTag: String {
 	case DisplayConfigurationView
 	case PaymentOptionsView
 	case RecoveryPhraseView
+	case CloseChannelsView
 	// Security
 	case AppAccessView
 	// Advanced
 	case PrivacyView
 	case LogsConfigurationView
 	case ChannelsConfigurationView
-	case CloseChannelsView
 	case ForceCloseChannelsView
 }
 
@@ -127,6 +127,16 @@ struct ConfigurationView: View {
 							Image(systemName: "squareshape.split.3x3")
 						}
 					}
+					
+					NavigationLink(
+						destination: CloseChannelsView(),
+						tag: NavLinkTag.CloseChannelsView,
+						selection: $navLinkTag
+					) {
+						Label { Text("Drain wallet") } icon: {
+							Image(systemName: "xmark.circle")
+						}
+					}
 				
 				} // </if: hasWallet>
 				
@@ -161,16 +171,6 @@ struct ConfigurationView: View {
 					}
 				}
 
-				NavigationLink(
-					destination: LogsConfigurationView(),
-					tag: NavLinkTag.LogsConfigurationView,
-					selection: $navLinkTag
-				) {
-					Label { Text("Logs") } icon: {
-						Image(systemName: "doc.text")
-					}
-				}
-
 				if hasWallet {
 
 					NavigationLink(
@@ -183,27 +183,28 @@ struct ConfigurationView: View {
 						}
 					}
 
-					NavigationLink(
-						destination: CloseChannelsView(),
-						tag: NavLinkTag.CloseChannelsView,
-						selection: $navLinkTag
-					) {
-						Label { Text("Close all channels") } icon: {
-							Image(systemName: "xmark.circle")
-						}
-					}
-
-					NavigationLink(
-						destination: ForceCloseChannelsView(),
-						tag: NavLinkTag.ForceCloseChannelsView,
-						selection: $navLinkTag
-					) {
-						Label { Text("Danger zone") } icon: {
-							Image(systemName: "exclamationmark.triangle")
-						}
-					}.foregroundColor(.appNegative)
+//					NavigationLink(
+//						destination: ForceCloseChannelsView(),
+//						tag: NavLinkTag.ForceCloseChannelsView,
+//						selection: $navLinkTag
+//					) {
+//						Label { Text("Danger zone") } icon: {
+//							Image(systemName: "exclamationmark.triangle")
+//						}
+//					}.foregroundColor(.appNegative)
 
 				} // </if: hasWallet>
+				
+				NavigationLink(
+					destination: LogsConfigurationView(),
+					tag: NavLinkTag.LogsConfigurationView,
+					selection: $navLinkTag
+				) {
+					Label { Text("Logs") } icon: {
+						Image(systemName: "doc.text")
+					}
+				}
+				
 			} // </Section: Advanced>
 		} // </List>
 		.listStyle(.insetGrouped)
@@ -306,18 +307,14 @@ struct ConfigurationView: View {
 		// The only clean solution I've found is to listen for SwiftUI's bad behaviour,
 		// and forcibly undo it.
 		
-		if value == nil {
-			// We reached the final destination of the deep link
-			clearSwiftUiBugWorkaround(delay: 1.0)
-			
-		} else {
+		if let value = value {
 			
 			// Navigate towards deep link (if needed)
 			var newNavLinkTag: NavLinkTag? = nil
 			switch value {
-				case .backup   : newNavLinkTag = NavLinkTag.RecoveryPhraseView
-				case .electrum : newNavLinkTag = NavLinkTag.PrivacyView
-				default        : break
+				case .backup      : newNavLinkTag = NavLinkTag.RecoveryPhraseView
+				case .drainWallet : newNavLinkTag = NavLinkTag.CloseChannelsView
+				case .electrum    : newNavLinkTag = NavLinkTag.PrivacyView
 			}
 			
 			if let newNavLinkTag = newNavLinkTag {
@@ -328,6 +325,10 @@ struct ConfigurationView: View {
 				
 				self.navLinkTag = newNavLinkTag // Trigger/push the view
 			}
+			
+		} else {
+			// We reached the final destination of the deep link
+			clearSwiftUiBugWorkaround(delay: 1.0)
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/ForceCloseChannelsView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/ForceCloseChannelsView.swift
@@ -11,9 +11,6 @@ fileprivate var log = Logger(
 fileprivate var log = Logger(OSLog.disabled)
 #endif
 
-fileprivate let CONTENT_PADDING_TOP: CGFloat = 30
-fileprivate let CONTENT_PADDING_LEFT_RIGHT: CGFloat = 30
-fileprivate let CONTENT_PADDING_BOTTOM: CGFloat = 20
 
 struct ForceCloseChannelsView : MVIView {
 	
@@ -22,112 +19,84 @@ struct ForceCloseChannelsView : MVIView {
 	@Environment(\.controllerFactory) var factoryEnv
 	var factory: ControllerFactory { return factoryEnv }
 	
+	@Environment(\.popoverState) var popoverState: PopoverState
+	
+	// --------------------------------------------------
+	// MARK: ViewBuilders
+	// --------------------------------------------------
+	
 	@ViewBuilder
 	var view: some View {
 		
-		main.navigationBarTitle(
-			NSLocalizedString("Force close channels", comment: "Navigation bar title"),
-			displayMode: .inline
-		)
-		
-		// Note:
-		//   Some views use a ScrollView,
-		//   so the CONTENT_PADDING is applied to the scrollViewContent,
-		//   and NOT to the ScrollView itself.
+		content()
+			.navigationBarTitle(
+				NSLocalizedString("Force close channels", comment: "Navigation bar title"),
+				displayMode: .inline
+			)
 	}
 	
 	@ViewBuilder
-	var main: some View {
+	func content() -> some View {
 		
-		if let model = mvi.model as? CloseChannelsConfiguration.ModelReady {
-			if model.channels.count == 0 {
-				EmptyWalletView()
-			} else {
-				StandardWalletView(model: model, postIntent: mvi.intent)
+		List {
+			if mvi.model is CloseChannelsConfiguration.ModelLoading {
+				section_loading()
+
+			} else if mvi.model is CloseChannelsConfiguration.ModelReady {
+				if channelsCount() == 0 {
+					section_zeroChannels()
+				} else {
+					section_disclaimer()
+					if let address = address() {
+						section_address(address)
+					}
+					section_button()
+				}
+
+			} else if mvi.model is CloseChannelsConfiguration.ModelChannelsClosed {
+				section_done()
 			}
-		} else if let model = mvi.model as? CloseChannelsConfiguration.ModelChannelsClosed {
-			FundsSentView(model: model)
-		} else {
-			LoadingWalletView()
 		}
-	}
-}
-
-fileprivate struct LoadingWalletView : View {
-	
-	var body: some View {
-		
-		VStack(alignment: .center) {
-		
-			ProgressView()
-				.progressViewStyle(CircularProgressViewStyle())
-				.padding(.bottom, 5)
-			
-			Text("Checking channel state...")
-			
-			Spacer()
-		}
-		.padding(.top, CONTENT_PADDING_TOP)
-		.padding([.leading, .trailing], CONTENT_PADDING_LEFT_RIGHT)
-		.padding(.bottom, CONTENT_PADDING_BOTTOM)
-	}
-}
-
-fileprivate struct EmptyWalletView : View {
-	
-	var body: some View {
-		
-		VStack(alignment: .leading) {
-			
-			Text("You currently don't have any channels that can be closed.")
-				.padding(.bottom)
-			
-			Text(styled: NSLocalizedString(
-				"""
-				Payment channels are automatically created when you receive payments. \
-				Use the **Receive** screen to receive via the Lightning network.
-				""",
-				comment: "ForceCloseChannelsView"
-			))
-			.padding(.bottom)
-			
-			Text(styled: NSLocalizedString(
-				"""
-				You can also use the **Payment Channels** screen to inspect the state of your channels.
-				""",
-				comment: "ForceCloseChannelsView"
-			))
-
-			Spacer()
-		}
-		.padding(.top, CONTENT_PADDING_TOP)
-		.padding([.leading, .trailing], CONTENT_PADDING_LEFT_RIGHT)
-		.padding(.bottom, CONTENT_PADDING_BOTTOM)
-	}
-}
-
-fileprivate struct StandardWalletView : View {
-	
-	let model: CloseChannelsConfiguration.ModelReady
-	let postIntent: (CloseChannelsConfiguration.Intent) -> Void
-	
-	@Environment(\.popoverState) var popoverState: PopoverState
-	
-	var body: some View {
-		
-		ScrollView {
-			scrollViewContent
-		}
+		.listStyle(.insetGrouped)
 	}
 	
-	var scrollViewContent: some View {
+	@ViewBuilder
+	func section_loading() -> some View {
 		
-		VStack(alignment: HorizontalAlignment.center, spacing: 0) {
+		Section {
+			HStack(alignment: VerticalAlignment.center, spacing: 8) {
+				ProgressView()
+					.progressViewStyle(CircularProgressViewStyle())
+				Text("Loading wallet...")
+			}
+		} // </Section>
+	}
+	
+	@ViewBuilder
+	func section_zeroChannels() -> some View {
+		
+		Section {
+			VStack(alignment: HorizontalAlignment.leading, spacing: 16) {
+				
+				Text("You currently don't have any channels that can be closed.")
+				
+				Text("Payment channels are automatically created when you receive payments.")
+					.font(.subheadline)
+					.foregroundColor(.secondary)
+				
+			} // </VStack>
+			.padding(.vertical, 8)
 			
-			VStack(alignment: .leading) {
+		} // </Section>
+	}
+	
+	@ViewBuilder
+	func section_disclaimer() -> some View {
+		
+		Section {
+			VStack(alignment: HorizontalAlignment.leading, spacing: 35) {
 				
 				Text("Force close allows you to unilaterally close your channels.")
-					.padding(.bottom)
 				
 				Text(styled: NSLocalizedString(
 					"""
@@ -140,7 +109,6 @@ fileprivate struct StandardWalletView : View {
 					""",
 					comment: "ForceCloseChannelsView"
 				))
-				.padding(.bottom)
 				
 				Text(styled: NSLocalizedString(
 					"""
@@ -150,20 +118,22 @@ fileprivate struct StandardWalletView : View {
 					""",
 					comment: "ForceCloseChannelsView"
 				))
-				.padding(.bottom)
 				
 				Text("Do not use this feature if you don't fully understand what it does.")
 					.bold()
 				
 			} // </VStack>
+			.padding(.vertical, 8)
 			
-			Line()
-				.stroke(Color.appAccent, style: StrokeStyle(lineWidth: 2, lineCap: .round))
-				.frame(width: 40, height: 2)
-				.padding([.top, .bottom], 25)
-			
-			VStack(alignment: .leading) {
-			
+		} // </Section>
+	}
+	
+	@ViewBuilder
+	func section_address(_ address: String) -> some View {
+		
+		Section {
+			VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
+				
 				Text("Funds will eventually be sent to:")
 					.padding(.bottom)
 				
@@ -173,13 +143,13 @@ fileprivate struct StandardWalletView : View {
 						.imageScale(.large)
 						.padding(.trailing, 4)
 					
-					Text(model.address)
+					Text(address)
 						.font(.system(.body, design: .monospaced))
 						.lineLimit(nil)
 						.minimumScaleFactor(0.5) // problems with truncation
 						.contextMenu {
 							Button(action: {
-								UIPasteboard.general.string = model.address
+								UIPasteboard.general.string = address
 							}) {
 								Text("Copy")
 							}
@@ -192,32 +162,118 @@ fileprivate struct StandardWalletView : View {
 					.foregroundColor(.secondary)
 				
 			} // </VStack>
-			.padding(.bottom)
-			
-			Button {
-				forceCloseChannels()
-			} label: {
-				HStack {
-					Image(systemName: "cross.circle")
-						.imageScale(.small)
-
-					Text("Force close channels")
-				}
-				.font(.body)
-				.foregroundColor(Color(red: 0.99, green: 0.99, blue: 1.0))
-			}
-			.buttonStyle(PlainButtonStyle())
-			.padding([.top, .bottom], 8)
-			.padding(.leading, 8)
-			.padding(.trailing, 12)
-			.background(Color.appNegative)
-			.cornerRadius(16)
-			
-		} // </VStack>
-		.padding(.top, CONTENT_PADDING_TOP)
-		.padding([.leading, .trailing], CONTENT_PADDING_LEFT_RIGHT)
-		.padding(.bottom, CONTENT_PADDING_BOTTOM)
+		} // </Section>
 	}
+	
+	@ViewBuilder
+	func section_button() -> some View {
+		
+		Section {
+			
+			VStack(alignment: HorizontalAlignment.center, spacing: 0) {
+				Button {
+					forceCloseChannels()
+				} label: {
+					Label {
+						Text("Force close channels")
+					} icon: {
+						Image(systemName: "cross.circle")
+					}
+					.foregroundColor(.appNegative)
+				}
+				.padding(.vertical, 8)
+				
+			} // </VStack>
+			.frame(maxWidth: .infinity)
+			
+		} // </Section>
+	}
+	
+	@ViewBuilder
+	func section_done() -> some View {
+		
+		Section {
+			VStack(alignment: HorizontalAlignment.center, spacing: 0) {
+				
+				Image(systemName: "paperplane.fill")
+					.renderingMode(.template)
+					.resizable()
+					.aspectRatio(contentMode: .fit)
+					.frame(width: 64, height: 64)
+					.foregroundColor(Color.appPositive)
+					.padding(.bottom, 10)
+
+				Text("Funds sent")
+					.font(.title)
+					.padding(.bottom, 30)
+
+				let expectedTxCount = nonZeroChannelsCount()
+				let msg = (expectedTxCount > 1)
+					? String(format: NSLocalizedString(
+						"Expect to receive %d separate payments.",
+						comment:	"label text"
+					), expectedTxCount)
+					: NSLocalizedString(
+						"The closing transaction is in your transactions list.",
+						comment: "label text"
+					)
+					
+				Text(styled: msg)
+					.multilineTextAlignment(.leading)
+					.fixedSize(horizontal: false, vertical: true) // Workaround for SwiftUI bugs
+
+			} // </VStack>
+			.padding(.vertical, 8)
+			.frame(maxWidth: .infinity)
+			
+		} // </Section>
+	}
+	
+	// --------------------------------------------------
+	// MARK: UI Content Helpers
+	// --------------------------------------------------
+	
+	func address() -> String? {
+		
+		if let model = mvi.model as? CloseChannelsConfiguration.ModelReady {
+			return model.address
+		} else {
+			return nil
+		}
+	}
+	
+	func channels() -> [CloseChannelsConfiguration.ModelChannelInfo]? {
+		
+		if let model = mvi.model as? CloseChannelsConfiguration.ModelReady {
+			return model.channels
+		} else if let model = mvi.model as? CloseChannelsConfiguration.ModelChannelsClosed {
+			return model.channels
+		} else {
+			return nil
+		}
+	}
+	
+	func channelsCount() -> Int {
+		
+		if let channels = channels() {
+			return channels.count
+		} else {
+			return 0
+		}
+	}
+	
+	func nonZeroChannelsCount() -> Int {
+		
+		if let channels = channels() {
+			return channels.filter { $0.balance > 0 }.count
+		} else {
+			return 0
+		}
+	}
+	
+	// --------------------------------------------------
+	// MARK: Actions
+	// --------------------------------------------------
 	
 	func forceCloseChannels() -> Void {
 		log.debug("forceCloseChannels()")
@@ -232,79 +288,7 @@ fileprivate struct StandardWalletView : View {
 	func confirmForceCloseChannels() -> Void {
 		log.trace("confirmForceCloseChannels()")
 		
-		postIntent(
-			CloseChannelsConfiguration.IntentForceCloseAllChannels()
-		)
-	}
-}
-
-fileprivate struct FundsSentView : View {
-	
-	let model: CloseChannelsConfiguration.ModelChannelsClosed
-	
-	var body: some View {
-		
-		ScrollView {
-			scrollViewContent
-		}
-	}
-	
-	@ViewBuilder
-	var scrollViewContent: some View {
-		
-		VStack(alignment: HorizontalAlignment.center, spacing: 0) {
-			
-			Image(systemName: "paperplane.fill")
-				.renderingMode(.template)
-				.resizable()
-				.aspectRatio(contentMode: .fit)
-				.frame(width: 64, height: 64)
-				.foregroundColor(Color.appPositive)
-				.padding(.bottom, 10)
-
-			Text("Funds sent")
-				.font(.title)
-				.padding(.bottom, 30)
-
-			VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
-				
-				let channelsCount = model.channels.count
-				if channelsCount > 1 {
-					Text(String(format: NSLocalizedString(
-						"Expect to receive %d separate payments.",
-						comment:	"label text"),
-						channelsCount
-					))
-					.padding(.bottom, 10)
-				}
-
-				let msg = (channelsCount <= 1)
-					? NSLocalizedString(
-						"""
-						The closing transaction is in your transactions list on the __main__ screen. \
-						And you can view the status of your channels in the __channels list__ screen.
-						""",
-						comment: "label text"
-					)
-					: NSLocalizedString(
-						"""
-						The closing transactions are in your transactions list on the __main__ screen. \
-						And you can view the status of your channels in the __channels list__ screen.
-						""",
-						comment: "label text"
-					)
-				
-				Text(styled: msg)
-					.multilineTextAlignment(.leading)
-					.lineLimit(nil)          // Workaround for SwiftUI bugs
-					.minimumScaleFactor(0.5) // Workaround for SwiftUI bugs
-				
-			} // </VStack>
-
-		} // </VStack>
-		.padding(.top, CONTENT_PADDING_TOP)
-		.padding([.leading, .trailing], CONTENT_PADDING_LEFT_RIGHT)
-		.padding(.bottom, CONTENT_PADDING_BOTTOM)
+		mvi.intent(CloseChannelsConfiguration.IntentForceCloseAllChannels())
 	}
 }
 

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/PrivacyView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/privacy/PrivacyView.swift
@@ -122,17 +122,14 @@ struct PrivacyView: View {
 		// The only clean solution I've found is to listen for SwiftUI's bad behaviour,
 		// and forcibly undo it.
 		
-		if value == nil {
-			// We reached the final destination of the deep link
-			clearSwiftUiBugWorkaround(delay: 1.0)
-		
-		} else {
+		if let value = value {
 			
 			// Navigate towards deep link (if needed)
 			var newNavLinkTag: NavLinkTag? = nil
 			switch value {
-				case .electrum : newNavLinkTag = NavLinkTag.ElectrumConfigurationView
-				default        : break
+				case .backup      : break
+				case .drainWallet : break
+				case .electrum    : newNavLinkTag = NavLinkTag.ElectrumConfigurationView
 			}
 			
 			if let newNavLinkTag = newNavLinkTag {
@@ -143,6 +140,10 @@ struct PrivacyView: View {
 				
 				self.navLinkTag = newNavLinkTag // Trigger/push the view
 			}
+			
+		} else {
+			// We reached the final destination of the deep link
+			clearSwiftUiBugWorkaround(delay: 1.0)
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/environment/DeepLink.swift
+++ b/phoenix-ios/phoenix-ios/views/environment/DeepLink.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum DeepLink: String, Equatable {
 	case backup
+	case drainWallet
 	case electrum
 }
 


### PR DESCRIPTION
This PR attempts to simplify the UI for the user. Here's what the settings screen looked like before:

<img height="500" alt="ss0" src="https://user-images.githubusercontent.com/304604/172654502-6c350711-bff3-46c3-9e3f-30f670264409.png">

The problem is that the "average user" doesn't know what payment channels are. They are akin to UTXO's on L1 - a technical detail the user is shielded from.

What's worse is that, if the average user wants to drain their wallet, they might mistakenly think that the only way to do this is thru the "Danger zone" screen.

With these ideas in mind, we've made minor adjustments to simplify things for the user:

<img height="500" alt="ss1" src="https://user-images.githubusercontent.com/304604/172657191-0b6a2b45-8580-45df-8697-e1d669fa4fdb.png">

<img height="500" alt="ss2" src="https://user-images.githubusercontent.com/304604/172657348-6e3691a7-68ec-443d-a0cd-dd10e513c5c7.png">

And the force-close channels option is still available via the payment channels screen:

<img height="500" alt="ss5" src="https://user-images.githubusercontent.com/304604/172657844-f4958b84-e83f-47c9-b6df-22b028ad77eb.png">

