### PR TITLE
Distinguish between "balance is 0" and "balance is unknown"

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/ProgressView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/ProgressView.kt
@@ -30,12 +30,14 @@ fun ProgressView(
     text: String,
     modifier: Modifier = Modifier,
     padding: PaddingValues = PaddingValues(16.dp),
-    space: Dp = 8.dp
+    progressCircleSize: Dp = 20.dp,
+    progressCircleWidth: Dp = 2.dp,
+    space: Dp = 8.dp,
 ) {
     Row(
         modifier.padding(padding)
     ) {
-        CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+        CircularProgressIndicator(Modifier.size(progressCircleSize), strokeWidth = progressCircleWidth)
         Spacer(Modifier.width(space))
         Text(text =text)
     }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
@@ -88,6 +88,7 @@ fun HomeView(
         drawerContent = { SideMenu(onSettingsClick) },
         content = {
             MVIView(homeViewModel) { model, _ ->
+                val balance = remember(model) { model.balance }
                 Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                     TopBar(
                         onConnectionsStateButtonClick = {
@@ -96,17 +97,22 @@ fun HomeView(
                         connectionsState = connectionsState
                     )
                     Spacer(modifier = Modifier.height(16.dp))
-                    AmountView(
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(horizontal = 16.dp),
-                        amount = model.balance,
-                        amountTextStyle = MaterialTheme.typography.h1,
-                        unitTextStyle = MaterialTheme.typography.h3.copy(color = MaterialTheme.colors.primary),
-                    )
-                    model.incomingBalance?.run {
+
+                    if (balance == null) {
+                        ProgressView(text = stringResource(id = R.string.home__balance_loading))
+                    } else {
+                        AmountView(
+                            modifier = Modifier
+                                .align(Alignment.CenterHorizontally)
+                                .padding(horizontal = 16.dp),
+                            amount = balance,
+                            amountTextStyle = MaterialTheme.typography.h1,
+                            unitTextStyle = MaterialTheme.typography.h3.copy(color = MaterialTheme.colors.primary),
+                        )
+                    }
+                    model.incomingBalance?.let { incomingSwapAmount ->
                         Spacer(modifier = Modifier.height(8.dp))
-                        IncomingAmountNotif(this)
+                        IncomingAmountNotif(incomingSwapAmount)
                     }
                     Spacer(modifier = Modifier.height(24.dp))
                     PrimarySeparator()

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeViewModel.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeViewModel.kt
@@ -33,10 +33,8 @@ import fr.acinq.phoenix.managers.Connections
 import fr.acinq.phoenix.managers.PaymentsManager
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 data class PaymentRowState(
@@ -44,7 +42,6 @@ data class PaymentRowState(
     val paymentInfo: WalletPaymentInfo?
 )
 
-@ExperimentalCoroutinesApi
 class HomeViewModel(
     val connectionsFlow: StateFlow<Connections>,
     val paymentsManager: PaymentsManager,

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -351,6 +351,7 @@
 
     <!-- //////////////// home //////////////////// -->
 
+    <string name="home__balance_loading">Loading…</string>
     <string name="home__swapin_incoming">+%1$s incoming</string>
     <string name="home__drawer__copy_nodeid">Copy node id</string>
     <string name="home__drawer__settings">Settings</string>

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/main/Home.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/main/Home.kt
@@ -6,13 +6,13 @@ import fr.acinq.phoenix.controllers.MVI
 object Home {
 
     data class Model(
-        val balance: MilliSatoshi,
+        val balance: MilliSatoshi?,
         val incomingBalance: MilliSatoshi?,
         val paymentsCount: Long
     ) : MVI.Model()
 
     val emptyModel = Model(
-        balance = MilliSatoshi(0),
+        balance = null,
         incomingBalance = null,
         paymentsCount = 0
     )


### PR DESCRIPTION
Previously the Home.Model was setup as:
```kotlin
data class Model(
    val balance: MilliSatoshi,
    val incomingBalance: MilliSatoshi?,
    val paymentsCount: Long
)
```

However, this has the unintended consequence that the UI cannot distinguish between "balance is zero" vs "balance is unknown". This was been more noticeable since iOS 16, where the app & UI seem to load very quickly, before the channel states in the database have been read. Perhaps this is because iOS 16 launches apps quicker, or perhaps it's related to how many channels the wallet has. Whatever the case, the consequence is the same: the app quickly launches and proudly tells the user that she has ZERO sats in her wallet :scream:

The fix is simple, but also requires a corresponding change in Android:
```kotlin
data class Model(
    val balance: MilliSatoshi?,
    val incomingBalance: MilliSatoshi?,
    val paymentsCount: Long
) 
```

In iOS I changed the UI to display 3 dashed circles (kinda like loading symbols) while we're waiting for the balance to be fetched.