### PR TITLE
Dual funding UI

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/LnurlPayView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/LnurlPayView.kt
@@ -59,7 +59,7 @@ fun LnurlPayView(
     log.info { "init lnurl-pay view with url=${model.lnurlPay}" }
 
     val context = LocalContext.current
-    val balance = business.peerManager.balance.collectAsState(null).value
+    val balance = business.balanceManager.balance.collectAsState(null).value
     val prefUnit = preferredAmountUnit
     val rate = fiatRate
 

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/SendLightningView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/SendLightningView.kt
@@ -56,7 +56,7 @@ fun SendLightningPaymentView(
     log.info { "init sendview amount=${paymentRequest.amount} desc=${paymentRequest.description}" }
 
     val context = LocalContext.current
-    val balance = business.peerManager.balance.collectAsState(null).value
+    val balance = business.balanceManager.balance.collectAsState(null).value
     val prefBitcoinUnit = LocalBitcoinUnit.current
 
     val requestedAmount = paymentRequest.amount

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/SendSwapOutView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/SendSwapOutView.kt
@@ -70,7 +70,7 @@ fun SendSwapOutView(
     val requestedAmount = model.address.amount
     var amount by remember { mutableStateOf(model.address.amount) }
     var amountErrorMessage by remember { mutableStateOf("") }
-    val balance = business.peerManager.balance.collectAsState(null).value
+    val balance = business.balanceManager.balance.collectAsState(null).value
     val swapOutConfig = business.appConfigurationManager.chainContext.collectAsState(initial = null).value?.swapOut?.v1 ?: WalletContext.V0.SwapOut.V1(
         minFeerateSatByte = 20,
         minAmountSat = 10_000,

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/MutualCloseView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/MutualCloseView.kt
@@ -51,7 +51,7 @@ fun MutualCloseView(
 ) {
     val log = logger("MutualCloseView")
     val context = LocalContext.current
-    val balance by business.peerManager.balance.collectAsState(0.msat)
+    val balance by business.balanceManager.balance.collectAsState(0.msat)
 
     var address by remember { mutableStateOf("") }
     var addressErrorMessage by remember { mutableStateOf<String?>(null) }

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		DC74174B270F332700F7E3E3 /* KotlinTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC74174A270F332700F7E3E3 /* KotlinTypes.swift */; };
 		DC74174D270F455D00F7E3E3 /* AES256.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC74174C270F455D00F7E3E3 /* AES256.swift */; };
 		DC81B79F25BF2AA200F5A52C /* MVI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC81B79E25BF2AA200F5A52C /* MVI.swift */; };
+		DC87806F292D69C90061715B /* IncomingDepositPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC87806E292D69C90061715B /* IncomingDepositPopover.swift */; };
 		DC89857F25914747007B253F /* UIApplicationState+Phoenix.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC89857E25914747007B253F /* UIApplicationState+Phoenix.swift */; };
 		DC9473FA261270B4008D7242 /* MVI+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9473F9261270B4008D7242 /* MVI+Mock.swift */; };
 		DC99E90925B78FA800FB20F7 /* EnabledSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC99E90825B78FA800FB20F7 /* EnabledSecurity.swift */; };
@@ -431,6 +432,7 @@
 		DC74174A270F332700F7E3E3 /* KotlinTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinTypes.swift; sourceTree = "<group>"; };
 		DC74174C270F455D00F7E3E3 /* AES256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AES256.swift; sourceTree = "<group>"; };
 		DC81B79E25BF2AA200F5A52C /* MVI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MVI.swift; sourceTree = "<group>"; };
+		DC87806E292D69C90061715B /* IncomingDepositPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncomingDepositPopover.swift; sourceTree = "<group>"; };
 		DC89857E25914747007B253F /* UIApplicationState+Phoenix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplicationState+Phoenix.swift"; sourceTree = "<group>"; };
 		DC9473F9261270B4008D7242 /* MVI+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MVI+Mock.swift"; sourceTree = "<group>"; };
 		DC99E90825B78FA800FB20F7 /* EnabledSecurity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnabledSecurity.swift; sourceTree = "<group>"; };
@@ -881,6 +883,7 @@
 				DC1706D826A71D8E00BAFCD0 /* UnlockErrorView.swift */,
 				DC71E7322728645B0063613D /* CurrencyConverterView.swift */,
 				DC09086225B626B300A46136 /* AppStatusPopover.swift */,
+				DC87806E292D69C90061715B /* IncomingDepositPopover.swift */,
 			);
 			path = tools;
 			sourceTree = "<group>";
@@ -1463,6 +1466,7 @@
 				DC09086325B626B300A46136 /* AppStatusPopover.swift in Sources */,
 				DC0732EC263CA6C3004CB88D /* PaymentOptionsView.swift in Sources */,
 				DC49DA8E258BB882005BC4BC /* ScaledButtonStyle.swift in Sources */,
+				DC87806F292D69C90061715B /* IncomingDepositPopover.swift in Sources */,
 				DCAEF8D9275E69B000015993 /* SyncSeedManager_State.swift in Sources */,
 				DCB04685260D162C007FDA37 /* ViewName.swift in Sources */,
 				DCFA876D260E91E600AE8953 /* IntroContainer.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Other.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Other.swift
@@ -10,6 +10,17 @@ extension PhoenixBusiness {
 	}
 }
 
+extension PeerManager {
+	
+	func swapInWalletBalanceValue() -> WalletBalance {
+		if let value = swapInWalletBalance.value_ as? WalletBalance {
+			return value
+		} else {
+			return WalletBalance.companion.empty()
+		}
+	}
+}
+
 extension Lightning_kmpConnection {
 	
 	func localizedText() -> String {

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Other.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Other.swift
@@ -10,7 +10,7 @@ extension PhoenixBusiness {
 	}
 }
 
-extension PeerManager {
+extension BalanceManager {
 	
 	func swapInWalletBalanceValue() -> WalletBalance {
 		if let value = swapInWalletBalance.value_ as? WalletBalance {

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Payments.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Payments.swift
@@ -33,7 +33,7 @@ extension WalletPaymentInfo {
 		let sanitize = { (input: String?) -> String? in
 			
 			if let trimmedInput = input?.trimmingCharacters(in: .whitespacesAndNewlines) {
-				if trimmedInput.count > 0 {
+				if !trimmedInput.isEmpty {
 					return trimmedInput
 				}
 			}
@@ -54,26 +54,64 @@ extension WalletPaymentInfo {
 			
 			if let invoice = incomingPayment.origin.asInvoice() {
 				return sanitize(invoice.paymentRequest.description_)
-			} else if let _ = incomingPayment.origin.asKeySend() {
-				return NSLocalizedString("Donation", comment: "Payment description for received KeySend")
-			} else if let swapIn = incomingPayment.origin.asSwapIn() {
-				return sanitize(swapIn.address)
 			}
 			
 		} else if let outgoingPayment = payment as? Lightning_kmpOutgoingPayment {
 			
 			if let normal = outgoingPayment.details.asNormal() {
 				return sanitize(normal.paymentRequest.desc())
-			} else if let _ = outgoingPayment.details.asKeySend() {
-				return NSLocalizedString("Donation", comment: "Payment description for received KeySend")
 			} else if let swapOut = outgoingPayment.details.asSwapOut() {
 				return sanitize(swapOut.address)
-			} else if let _ = outgoingPayment.details.asChannelClosing() {
-				return NSLocalizedString("Channel closing", comment: "Payment description for channel closing")
 			}
 		}
 		
 		return nil
+	}
+	
+	func defaultPaymentDescription() -> String {
+	
+		if let incomingPayment = payment as? Lightning_kmpIncomingPayment {
+			
+			if let _ = incomingPayment.origin.asKeySend() {
+				return NSLocalizedString("Donation", comment: "Payment description for received KeySend")
+			} else if let _ = incomingPayment.origin.asSwapIn() {
+				return NSLocalizedString("On-chain deposit", comment: "Payment description for received deposit")
+			} else if let _ = incomingPayment.origin.asDualSwapIn() {
+				return NSLocalizedString("On-chain deposit", comment: "Payment description for received deposit")
+			}
+			
+		} else if let outgoingPayment = payment as? Lightning_kmpOutgoingPayment {
+	
+			if let _ = outgoingPayment.details.asKeySend() {
+				return NSLocalizedString("Donation", comment: "Payment description for received KeySend")
+			} else if let _ = outgoingPayment.details.asChannelClosing() {
+				return NSLocalizedString("Channel closing", comment: "Payment description for channel closing")
+			}
+		}
+	
+		return NSLocalizedString("No description", comment: "placeholder text")
+	}
+	
+	func isOnChain() -> Bool {
+		
+		if let incomingPayment = payment as? Lightning_kmpIncomingPayment {
+			
+			if let _ = incomingPayment.origin.asSwapIn() {
+				return true
+			} else if let _ = incomingPayment.origin.asDualSwapIn() {
+				return true
+			}
+			
+		} else if let outgoingPayment = payment as? Lightning_kmpOutgoingPayment {
+			
+			if let _ = outgoingPayment.details.asSwapOut() {
+				return true
+			} else if let _ = outgoingPayment.details.asChannelClosing() {
+				return true
+			}
+		}
+		
+		return false
 	}
 }
 

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Payments.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Payments.swift
@@ -91,10 +91,13 @@ extension WalletPaymentInfo {
 	
 		return NSLocalizedString("No description", comment: "placeholder text")
 	}
-	
+}
+
+extension Lightning_kmpWalletPayment {
+
 	func isOnChain() -> Bool {
 		
-		if let incomingPayment = payment as? Lightning_kmpIncomingPayment {
+		if let incomingPayment = self as? Lightning_kmpIncomingPayment {
 			
 			if let _ = incomingPayment.origin.asSwapIn() {
 				return true
@@ -102,7 +105,7 @@ extension WalletPaymentInfo {
 				return true
 			}
 			
-		} else if let outgoingPayment = payment as? Lightning_kmpOutgoingPayment {
+		} else if let outgoingPayment = self as? Lightning_kmpOutgoingPayment {
 			
 			if let _ = outgoingPayment.details.asSwapOut() {
 				return true

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers.swift
@@ -15,23 +15,7 @@ fileprivate var log = Logger(OSLog.disabled)
 extension PeerManager {
 	
 	fileprivate struct _Key {
-		static var balancePublisher = 0
 		static var peerStatePublisher = 0
-		static var swapInWalletBalancePublisher = 0
-	}
-	
-	func balancePublisher() -> AnyPublisher<Lightning_kmpMilliSatoshi?, Never> {
-		
-		self.getSetAssociatedObject(storageKey: &_Key.balancePublisher) {
-			
-			// Transforming from Kotlin:
-			// `balance: StateFlow<MilliSatoshi?>`
-			//
-			KotlinCurrentValueSubject<Lightning_kmpMilliSatoshi, Lightning_kmpMilliSatoshi?>(
-				self.balance
-			)
-			.eraseToAnyPublisher()
-		}
 	}
 	
 	func peerStatePublisher() -> AnyPublisher<Lightning_kmpPeer, Never> {
@@ -46,21 +30,6 @@ extension PeerManager {
 				self.peerState
 			)
 			.compactMap { $0 }
-			.eraseToAnyPublisher()
-		}
-	}
-	
-	func swapInWalletBalancePublisher() -> AnyPublisher<WalletBalance, Never> {
-		
-		self.getSetAssociatedObject(storageKey: &_Key.swapInWalletBalancePublisher) {
-			
-			// Transforming from Kotlin:
-			// ```
-			// swapInWalletBalance: StateFlow<WalletBalance>
-			// ```
-			KotlinCurrentValueSubject<WalletBalance, WalletBalance>(
-				self.swapInWalletBalance
-			)
 			.eraseToAnyPublisher()
 		}
 	}
@@ -84,6 +53,44 @@ extension AppConfigurationManager {
 				self.chainContext
 			)
 			.compactMap { $0 }
+			.eraseToAnyPublisher()
+		}
+	}
+}
+
+// MARK: -
+extension BalanceManager {
+	
+	fileprivate struct _Key {
+		static var balancePublisher = 0
+		static var swapInWalletBalancePublisher = 0
+	}
+	
+	func balancePublisher() -> AnyPublisher<Lightning_kmpMilliSatoshi?, Never> {
+		
+		self.getSetAssociatedObject(storageKey: &_Key.balancePublisher) {
+			
+			// Transforming from Kotlin:
+			// `balance: StateFlow<MilliSatoshi?>`
+			//
+			KotlinCurrentValueSubject<Lightning_kmpMilliSatoshi, Lightning_kmpMilliSatoshi?>(
+				self.balance
+			)
+			.eraseToAnyPublisher()
+		}
+	}
+	
+	func swapInWalletBalancePublisher() -> AnyPublisher<WalletBalance, Never> {
+		
+		self.getSetAssociatedObject(storageKey: &_Key.swapInWalletBalancePublisher) {
+			
+			// Transforming from Kotlin:
+			// ```
+			// swapInWalletBalance: StateFlow<WalletBalance>
+			// ```
+			KotlinCurrentValueSubject<WalletBalance, WalletBalance>(
+				self.swapInWalletBalance
+			)
 			.eraseToAnyPublisher()
 		}
 	}

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers.swift
@@ -12,6 +12,84 @@ fileprivate var log = Logger(
 fileprivate var log = Logger(OSLog.disabled)
 #endif
 
+extension PeerManager {
+	
+	fileprivate struct _Key {
+		static var balancePublisher = 0
+		static var peerStatePublisher = 0
+		static var swapInWalletBalancePublisher = 0
+	}
+	
+	func balancePublisher() -> AnyPublisher<Lightning_kmpMilliSatoshi?, Never> {
+		
+		self.getSetAssociatedObject(storageKey: &_Key.balancePublisher) {
+			
+			// Transforming from Kotlin:
+			// `balance: StateFlow<MilliSatoshi?>`
+			//
+			KotlinCurrentValueSubject<Lightning_kmpMilliSatoshi, Lightning_kmpMilliSatoshi?>(
+				self.balance
+			)
+			.eraseToAnyPublisher()
+		}
+	}
+	
+	func peerStatePublisher() -> AnyPublisher<Lightning_kmpPeer, Never> {
+
+		self.getSetAssociatedObject(storageKey: &_Key.peerStatePublisher) {
+			
+			// Transforming from Kotlin:
+			// ```
+			// peerState: StateFlow<Peer?>
+			// ```
+			KotlinCurrentValueSubject<Lightning_kmpPeer, Lightning_kmpPeer?>(
+				self.peerState
+			)
+			.compactMap { $0 }
+			.eraseToAnyPublisher()
+		}
+	}
+	
+	func swapInWalletBalancePublisher() -> AnyPublisher<WalletBalance, Never> {
+		
+		self.getSetAssociatedObject(storageKey: &_Key.swapInWalletBalancePublisher) {
+			
+			// Transforming from Kotlin:
+			// ```
+			// swapInWalletBalance: StateFlow<WalletBalance>
+			// ```
+			KotlinCurrentValueSubject<WalletBalance, WalletBalance>(
+				self.swapInWalletBalance
+			)
+			.eraseToAnyPublisher()
+		}
+	}
+}
+
+// MARK: -
+extension AppConfigurationManager {
+	
+	fileprivate struct _Key {
+		static var chainContextPublisher = 0
+	}
+	
+	func chainContextPublisher() -> AnyPublisher<WalletContext.V0ChainContext, Never> {
+		
+		self.getSetAssociatedObject(storageKey: &_Key.chainContextPublisher) {
+			
+			// Transforming from Kotlin:
+			// `chainContext: StateFlow<WalletContext.V0.ChainContext?>`
+			//
+			KotlinCurrentValueSubject<WalletContext.V0ChainContext, WalletContext.V0ChainContext?>(
+				self.chainContext
+			)
+			.compactMap { $0 }
+			.eraseToAnyPublisher()
+		}
+	}
+}
+
+// MARK: -
 extension CurrencyManager {
 	
 	fileprivate struct _Key {
@@ -51,49 +129,11 @@ extension CurrencyManager {
 	}
 }
 
-extension PeerManager {
-	
-	fileprivate struct _Key {
-		static var balancePublisher = 0
-		static var peerStatePublisher = 0
-	}
-	
-	func balancePublisher() -> AnyPublisher<Lightning_kmpMilliSatoshi?, Never> {
-		
-		self.getSetAssociatedObject(storageKey: &_Key.balancePublisher) {
-			
-			// Transforming from Kotlin:
-			// `balance: StateFlow<MilliSatoshi?>`
-			//
-			KotlinCurrentValueSubject<Lightning_kmpMilliSatoshi, Lightning_kmpMilliSatoshi?>(
-				self.balance
-			)
-			.eraseToAnyPublisher()
-		}
-	}
-	
-	func peerStatePublisher() -> AnyPublisher<Lightning_kmpPeer, Never> {
-
-		self.getSetAssociatedObject(storageKey: &_Key.peerStatePublisher) {
-			
-			// Transforming from Kotlin:
-			// ```
-			// peerState: StateFlow<Peer?>
-			// ```
-			KotlinCurrentValueSubject<Lightning_kmpPeer, Lightning_kmpPeer?>(
-				self.peerState
-			)
-			.compactMap { $0 }
-			.eraseToAnyPublisher()
-		}
-	}
-}
-
+// MARK: -
 extension PaymentsManager {
 	
 	fileprivate struct _Key {
 		static var paymentsCountPublisher = 0
-		static var incomingSwapsPublisher = 0
 		static var lastCompletedPaymentPublisher = 0
 		static var lastIncomingPaymentPublisher = 0
 		static var inFlightOutgoingPaymentsPublisher = 0
@@ -108,20 +148,6 @@ extension PaymentsManager {
 			//
 			KotlinCurrentValueSubject<KotlinLong, Int64>(
 				self.paymentsCount
-			)
-			.eraseToAnyPublisher()
-		}
-	}
-	
-	func incomingSwapsPublisher() -> AnyPublisher<[String: Lightning_kmpMilliSatoshi], Never> {
-		
-		self.getSetAssociatedObject(storageKey: &_Key.incomingSwapsPublisher) {
-			
-			// Transforming from Kotlin:
-			// `incomingSwaps: StateFlow<Map<String, MilliSatoshi>>`
-			//
-			KotlinCurrentValueSubject<NSDictionary, [String: Lightning_kmpMilliSatoshi]>(
-				self.incomingSwaps
 			)
 			.eraseToAnyPublisher()
 		}
@@ -177,6 +203,7 @@ extension PaymentsManager {
 	}
 }
 
+// MARK: -
 extension PaymentsPageFetcher {
 	
 	fileprivate struct _Key {
@@ -198,49 +225,28 @@ extension PaymentsPageFetcher {
 	}
 }
 
-extension AppConfigurationManager {
+// MARK: -
+extension CloudKitDb {
 	
 	fileprivate struct _Key {
-		static var chainContextPublisher = 0
+		static var fetchQueueCountPublisher = 0
 	}
 	
-	func chainContextPublisher() -> AnyPublisher<WalletContext.V0ChainContext, Never> {
+	func fetchQueueCountPublisher() -> AnyPublisher<Int64, Never> {
 		
-		self.getSetAssociatedObject(storageKey: &_Key.chainContextPublisher) {
-			
-			// Transforming from Kotlin:
-			// `chainContext: StateFlow<WalletContext.V0.ChainContext?>`
-			//
-			KotlinCurrentValueSubject<WalletContext.V0ChainContext, WalletContext.V0ChainContext?>(
-				self.chainContext
-			)
-			.compactMap { $0 }
-			.eraseToAnyPublisher()
-		}
-	}
-}
-
-extension Lightning_kmpElectrumWatcher {
-	
-	fileprivate struct _Key {
-		static var upToDatePublisher = 0
-	}
-	
-	func upToDatePublisher() -> AnyPublisher<Int64, Never> {
-		
-		self.getSetAssociatedObject(storageKey: &_Key.upToDatePublisher) {
+		self.getSetAssociatedObject(storageKey: &_Key.fetchQueueCountPublisher) {
 			
 			/// Transforming from Kotlin:
-			/// `openUpToDateFlow(): Flow<Long>`
+			/// `queueCount: StateFlow<Long>`
 			///
-			KotlinPassthroughSubject<KotlinLong, Int64>(
-				self.openUpToDateFlow()
-			)
-			.eraseToAnyPublisher()
+			KotlinCurrentValueSubject<KotlinLong, Int64>(
+				self.queueCount
+			).eraseToAnyPublisher()
 		}
 	}
 }
 
+// MARK: -
 extension Lightning_kmpPeer {
 	
 	fileprivate struct _Key {
@@ -264,22 +270,24 @@ extension Lightning_kmpPeer {
 	}
 }
 
-extension CloudKitDb {
+// MARK: -
+extension Lightning_kmpElectrumWatcher {
 	
 	fileprivate struct _Key {
-		static var fetchQueueCountPublisher = 0
+		static var upToDatePublisher = 0
 	}
 	
-	func fetchQueueCountPublisher() -> AnyPublisher<Int64, Never> {
+	func upToDatePublisher() -> AnyPublisher<Int64, Never> {
 		
-		self.getSetAssociatedObject(storageKey: &_Key.fetchQueueCountPublisher) {
+		self.getSetAssociatedObject(storageKey: &_Key.upToDatePublisher) {
 			
 			/// Transforming from Kotlin:
-			/// `queueCount: StateFlow<Long>`
+			/// `openUpToDateFlow(): Flow<Long>`
 			///
-			KotlinCurrentValueSubject<KotlinLong, Int64>(
-				self.queueCount
-			).eraseToAnyPublisher()
+			KotlinPassthroughSubject<KotlinLong, Int64>(
+				self.openUpToDateFlow()
+			)
+			.eraseToAnyPublisher()
 		}
 	}
 }

--- a/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
@@ -142,6 +142,7 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 				paymentReceived_amountReceived(receivedWith)
 				paymentReceived_via(receivedWith)
 				paymentReceived_channelId(receivedWith)
+				paymentReceived_fundingTxId(receivedWith)
 			}
 		}
 	}
@@ -545,6 +546,36 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 		}
 	}
 	
+	@ViewBuilder
+	func paymentReceived_fundingTxId(_ receivedWith: Lightning_kmpIncomingPayment.ReceivedWith) -> some View {
+		let identifier: String = #function
+		
+		if let newChannel = receivedWith.asNewChannel(),
+			let channelId = newChannel.channelId,
+			let fundingTxId = Biz.business.peerManager.fundingTxId(channelId: channelId)
+		{
+			InfoGridRowWrapper(
+				identifier: identifier,
+				hSpacing: horizontalSpacingBetweenColumns,
+				keyColumnWidth: keyColumnWidth(identifier: identifier)
+			) {
+				
+				keyColumn(NSLocalizedString("funding txid", comment: "Label in DetailsView_IncomingPayment"))
+				
+			} valueColumn: {
+				
+				let str = fundingTxId.toHex()
+				Text(str)
+					.contextMenu {
+						Button(action: {
+							UIPasteboard.general.string = str
+						}) {
+							Text("Copy")
+						}
+					}
+			}
+		}
+	}
 	@ViewBuilder
 	func channelClosing_channelId(_ channelClosing: Lightning_kmpOutgoingPayment.DetailsChannelClosing) -> some View {
 		let identifier: String = #function

--- a/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
@@ -552,7 +552,7 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 		
 		if let newChannel = receivedWith.asNewChannel(),
 			let channelId = newChannel.channelId,
-			let fundingTxId = Biz.business.peerManager.fundingTxId(channelId: channelId)
+			let channel = Biz.business.peerManager.getChannelWithCommitments(channelId: channelId)
 		{
 			InfoGridRowWrapper(
 				identifier: identifier,
@@ -564,7 +564,7 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 				
 			} valueColumn: {
 				
-				let str = fundingTxId.toHex()
+				let str = channel.commitments.fundingTxId.toHex()
 				Text(str)
 					.contextMenu {
 						Button(action: {

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
@@ -500,6 +500,7 @@ fileprivate struct SummaryInfoGrid: InfoGridView {
 	private let horizontalSpacingBetweenColumns: CGFloat = 8
 	
 	@State var popoverPresent_standardFees = false
+	@State var popoverPresent_minerFees = false
 	@State var popoverPresent_swapFees = false
 	
 	@Environment(\.openURL) var openURL
@@ -523,26 +524,27 @@ fileprivate struct SummaryInfoGrid: InfoGridView {
 			paymentTypeRow()
 			channelClosingRow()
 			
-			let standardFees = paymentInfo.payment.standardFees(currencyPrefs: currencyPrefs)
-			let swapOutFees = paymentInfo.payment.swapOutFees(currencyPrefs: currencyPrefs)
-			
-			if let standardFees = standardFees {
-				let title = swapOutFees == nil
-				  ? NSLocalizedString("Fees", comment: "Label in SummaryInfoGrid")
-				  : NSLocalizedString("Lightning Fees", comment: "Label in SummaryInfoGrid")
-				
+			if let standardFees = paymentInfo.payment.standardFees(currencyPrefs: currencyPrefs) {
 				paymentFeesRow(
-					title: title,
+					title: standardFees.1,
 					amount: standardFees.0,
-					explanation: standardFees.1,
+					explanation: standardFees.2,
 					binding: $popoverPresent_standardFees
 				)
 			}
-			if let swapOutFees = swapOutFees {
+			if let minerFees = paymentInfo.payment.minerFees(currencyPrefs: currencyPrefs) {
 				paymentFeesRow(
-					title: NSLocalizedString("Swap Fees", comment: "Label in SummaryInfoGrid"),
+					title: minerFees.1,
+					amount: minerFees.0,
+					explanation: minerFees.2,
+					binding: $popoverPresent_minerFees
+				)
+			}
+			if let swapOutFees = paymentInfo.payment.swapOutFees(currencyPrefs: currencyPrefs) {
+				paymentFeesRow(
+					title: swapOutFees.1,
 					amount: swapOutFees.0,
-					explanation: swapOutFees.1,
+					explanation: swapOutFees.2,
 					binding: $popoverPresent_swapFees
 				)
 			}

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
@@ -175,17 +175,33 @@ struct SummaryView: View {
 				.padding(.bottom, 30)
 				
 			case .pending:
-				Image("ic_payment_sending")
-					.renderingMode(.template)
-					.resizable()
-					.foregroundColor(Color.borderColor)
-					.frame(width: 100, height: 100)
-					.padding(.bottom, 16)
-					.accessibilityHidden(true)
-				Text("PENDING")
-					.font(Font.title2.bold())
-					.padding(.bottom, 30)
-					.accessibilityLabel("Pending payment")
+				if payment.isOnChain() {
+					Image(systemName: "hourglass.circle")
+						.renderingMode(.template)
+						.resizable()
+						.foregroundColor(Color.borderColor)
+						.frame(width: 100, height: 100)
+						.padding(.bottom, 16)
+						.accessibilityHidden(true)
+					Text("WAITING FOR CONFIRMATIONS")
+						.font(.title2.uppercaseSmallCaps())
+						.multilineTextAlignment(.center)
+						.padding(.bottom, 30)
+						.accessibilityLabel("Pending payment")
+						.accessibilityHint("Waiting for confirmations")
+				} else {
+					Image("ic_payment_sending")
+						.renderingMode(.template)
+						.resizable()
+						.foregroundColor(Color.borderColor)
+						.frame(width: 100, height: 100)
+						.padding(.bottom, 16)
+						.accessibilityHidden(true)
+					Text("PENDING")
+						.font(.title2.bold())
+						.padding(.bottom, 30)
+						.accessibilityLabel("Pending payment")
+				}
 				
 			case .failure:
 				Image(systemName: "xmark.circle")
@@ -197,12 +213,12 @@ struct SummaryView: View {
 					.accessibilityHidden(true)
 				VStack {
 					Text("FAILED")
-						.font(Font.title2.bold())
+						.font(.title2.bold())
 						.padding(.bottom, 2)
 						.accessibilityLabel("Failed payment")
 					
 					Text("NO FUNDS HAVE BEEN SENT")
-						.font(Font.title2.uppercaseSmallCaps())
+						.font(.title2.uppercaseSmallCaps())
 						.padding(.bottom, 6)
 					
 					if let completedAtDate = payment.completedAtDate() {

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
@@ -440,19 +440,20 @@ struct SummaryView: View {
 	// MARK: View Helpers
 	// --------------------------------------------------
 	
-	func minFundingDepth() -> Int? {
+	func minFundingDepth() -> Int32? {
 		
 		guard
 			let incomingPayment = paymentInfo.payment as? Lightning_kmpIncomingPayment,
 			let received = incomingPayment.received,
 			let newChannel = received.receivedWith.compactMap({ $0.asNewChannel() }).first,
 			let channelId = newChannel.channelId,
-			let minFundingDepth = Biz.business.peerManager.minDepthForFunding(channelId: channelId)
+			let channel = Biz.business.peerManager.getChannelWithCommitments(channelId: channelId),
+			let nodeParams = Biz.business.nodeParamsManager.nodeParams.value_ as? Lightning_kmpNodeParams
 		else {
 			return nil
 		}
 		
-		return minFundingDepth.intValue
+		return channel.minDepthForFunding(nodeParams: nodeParams)
 	}
 	
 	func onChainBroadcastDate() -> Date? {

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
@@ -597,8 +597,7 @@ fileprivate struct SummaryInfoGrid: InfoGridView {
 			
 		} valueColumn: {
 			
-			let description = paymentInfo.paymentDescription() ??
-			                  NSLocalizedString("No description", comment: "placeholder text")
+			let description = paymentInfo.paymentDescription() ?? paymentInfo.defaultPaymentDescription()
 			Text(description)
 				.contextMenu {
 					Button(action: {

--- a/phoenix-ios/phoenix-ios/views/inspect/WalletPaymentExtensions.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/WalletPaymentExtensions.swift
@@ -87,17 +87,25 @@ extension Lightning_kmpWalletPayment {
 		return nil
 	}
 	
-	func standardFees(currencyPrefs: CurrencyPrefs) -> (FormattedAmount, String)? {
+	func standardFees(currencyPrefs: CurrencyPrefs) -> (FormattedAmount, String, String)? {
 		
 		if let incomingPayment = self as? Lightning_kmpIncomingPayment {
 		
 			// An incomingPayment may have fees if a new channel was automatically opened
 			if let received = incomingPayment.received {
-					
-				let msat = received.receivedWith.map { $0.fees.msat }.reduce(0, +)
+				
+				let msat = received.receivedWith.map {
+					if let newChannel = $0 as? Lightning_kmpIncomingPayment.ReceivedWithNewChannel {
+						return newChannel.serviceFee.msat // exclude fundingFee (which is a minerFee)
+					} else {
+						return $0.fees.msat
+					}
+				}.reduce(0, +)
+				
 				if msat > 0 {
 					
 					let formattedAmt = Utils.format(currencyPrefs, msat: msat, policy: .showMsatsIfNonZero)
+					let title = NSLocalizedString("Service Fees", comment: "Label in SummaryInfoGrid")
 					let exp = NSLocalizedString(
 						"""
 						In order to receive this payment, a new payment channel was opened. \
@@ -106,49 +114,22 @@ extension Lightning_kmpWalletPayment {
 						comment: "Fees explanation"
 					)
 					
-					return (formattedAmt, exp)
+					return (formattedAmt, title, exp)
 				}
 				else {
 					// I think it's nice to see "Fees: 0 sat" :)
 					
 					let formattedAmt = Utils.format(currencyPrefs, msat: 0, policy: .hideMsats)
+					let title = NSLocalizedString("Fees", comment: "Label in SummaryInfoGrid")
 					let exp = ""
 					
-					return (formattedAmt, exp)
+					return (formattedAmt, title, exp)
 				}
 			}
 			
 		} else if let outgoingPayment = self as? Lightning_kmpOutgoingPayment {
 		
-			if let _ = outgoingPayment.status.asFailed() {
-				
-				// no fees for failed payments
-				return nil
-				
-			} else if let _ = outgoingPayment.status.asOnChain() {
-				
-				// for on-chain payments, the fees are extracted from the mined transaction(s)
-				
-				let fees = outgoingPayment.fees
-				let formattedAmt = Utils.format(currencyPrefs, msat: fees, policy: .showMsatsIfNonZero)
-				
-				let txCount = outgoingPayment.closingTxParts().count
-				let exp: String
-				if txCount == 1 {
-					exp = NSLocalizedString(
-						"Bitcoin network fees paid for on-chain transaction. Payment required 1 transaction.",
-						comment: "Fees explanation"
-					)
-				} else {
-					exp = NSLocalizedString(
-						"Bitcoin network fees paid for on-chain transactions. Payment required \(txCount) transactions.",
-						comment: "Fees explanation"
-					)
-				}
-				
-				return (formattedAmt, exp)
-				
-			} else if let _ = outgoingPayment.status.asOffChain() {
+			if let _ = outgoingPayment.status.asOffChain() {
 				
 				let msat = outgoingPayment.routingFee.msat // excludes swapOutFee
 				if msat == 0 {
@@ -166,6 +147,7 @@ extension Lightning_kmpWalletPayment {
 					}
 				}
 				
+				let title = NSLocalizedString("Lightning Fees", comment: "Label in SummaryInfoGrid")
 				let exp: String
 				if parts == 1 {
 					if hops == 1 {
@@ -189,35 +171,92 @@ extension Lightning_kmpWalletPayment {
 					)
 				}
 				
-				return (formattedAmt, exp)
+				return (formattedAmt, title, exp)
 			}
 		}
 		
 		return nil
 	}
 	
-	func swapOutFees(currencyPrefs: CurrencyPrefs) -> (FormattedAmount, String)? {
+	func minerFees(currencyPrefs: CurrencyPrefs) -> (FormattedAmount, String, String)? {
 		
-		guard let outgoingPayment = self as? Lightning_kmpOutgoingPayment else {
-			return nil
+		if let incomingPayment = self as? Lightning_kmpIncomingPayment {
+			
+			if let received = incomingPayment.received {
+				
+				// An incomingPayment may have minerFees if a new channel was opened using dual-funding
+				
+				let sat = received.receivedWith.map {
+					if let newChannel = $0 as? Lightning_kmpIncomingPayment.ReceivedWithNewChannel {
+						return newChannel.fundingFee.sat
+					} else {
+						return Int64(0)
+					}
+				}.reduce(0, +)
+				
+				if sat > 0 {
+					
+					let formattedAmt = Utils.format(currencyPrefs, sat: sat)
+					let title = NSLocalizedString("Miner Fees", comment: "Label in SummaryInfoGrid")
+					let exp = NSLocalizedString(
+						"Bitcoin network fees paid for on-chain transaction.",
+						comment: "Fees explanation"
+					)
+					
+					return (formattedAmt, title, exp)
+				}
+			}
+			
+		} else if let outgoingPayment = self as? Lightning_kmpOutgoingPayment {
+			
+			if let _ = outgoingPayment.status.asOnChain() {
+				
+				// For on-chain payments, the fees are extracted from the mined transaction(s)
+				
+				let fees = outgoingPayment.fees
+				let formattedAmt = Utils.format(currencyPrefs, msat: fees, policy: .showMsatsIfNonZero)
+				
+				let title = NSLocalizedString("Miner Fees", comment: "Label in SummaryInfoGrid")
+				
+				let txCount = outgoingPayment.closingTxParts().count
+				let exp: String
+				if txCount == 1 {
+					exp = NSLocalizedString(
+						"Bitcoin network fees paid for on-chain transaction. Payment required 1 transaction.",
+						comment: "Fees explanation"
+					)
+				} else {
+					exp = NSLocalizedString(
+						"Bitcoin network fees paid for on-chain transactions. Payment required \(txCount) transactions.",
+						comment: "Fees explanation"
+					)
+				}
+				
+				return (formattedAmt, title, exp)
+			}
 		}
 		
-		if let _ = outgoingPayment.details.asSwapOut() {
+		return nil
+	}
+	
+	func swapOutFees(currencyPrefs: CurrencyPrefs) -> (FormattedAmount, String, String)? {
+		
+		if let outgoingPayment = self as? Lightning_kmpOutgoingPayment,
+		   let _ = outgoingPayment.details.asSwapOut() {
 			
 			let msat = outgoingPayment.fees.msat - outgoingPayment.routingFee.msat
 			let formattedAmt = Utils.format(currencyPrefs, msat: msat, policy: .showMsatsIfNonZero)
 			
+			let title = NSLocalizedString("Swap Fees", comment: "Label in SummaryInfoGrid")
 			let exp = NSLocalizedString(
 				"Includes Bitcoin network miner fees, and the fee for the Swap-Out service.",
 				comment: "Fees explanation"
 			)
 			
-			return (formattedAmt, exp)
-			
-		} else {
-			
-			return nil
+			return (formattedAmt, title, exp)
 		}
+		
+		return nil
 	}
 	
 	/// If the OutgoingPayment succeeded or failed, reports the total elapsed time.

--- a/phoenix-ios/phoenix-ios/views/main/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/main/HomeView.swift
@@ -51,7 +51,7 @@ struct HomeView : MVIView {
 	let lastCompletedPaymentPublisher = Biz.business.paymentsManager.lastCompletedPaymentPublisher()
 	let chainContextPublisher = Biz.business.appConfigurationManager.chainContextPublisher()
 	
-	let swapInWalletBalancePublisher = Biz.business.peerManager.swapInWalletBalancePublisher()
+	let swapInWalletBalancePublisher = Biz.business.balanceManager.swapInWalletBalancePublisher()
 	@State var swapInWalletBalance: WalletBalance = WalletBalance.companion.empty()
 	
 	let incomingSwapScaleFactor_BIG: CGFloat = 1.2

--- a/phoenix-ios/phoenix-ios/views/receive/SwapInView.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/SwapInView.swift
@@ -33,7 +33,7 @@ struct SwapInView: View {
 	@State var swapIn_minFundingSat: Int64 = 0
 	
 	let swapInWalletBalancePublisher = Biz.business.peerManager.swapInWalletBalancePublisher()
-	@State var swapInWalletBalance: WalletBalance = WalletBalance.companion.empty()
+	@State var swapInWalletBalance = Biz.business.peerManager.swapInWalletBalanceValue()
 	
 	let chainContextPublisher = Biz.business.appConfigurationManager.chainContextPublisher()
 	

--- a/phoenix-ios/phoenix-ios/views/receive/SwapInView.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/SwapInView.swift
@@ -32,8 +32,8 @@ struct SwapInView: View {
 	@State var swapIn_minFeeSat: Int64 = 0
 	@State var swapIn_minFundingSat: Int64 = 0
 	
-	let swapInWalletBalancePublisher = Biz.business.peerManager.swapInWalletBalancePublisher()
-	@State var swapInWalletBalance = Biz.business.peerManager.swapInWalletBalanceValue()
+	let swapInWalletBalancePublisher = Biz.business.balanceManager.swapInWalletBalancePublisher()
+	@State var swapInWalletBalance = Biz.business.balanceManager.swapInWalletBalanceValue()
 	
 	let chainContextPublisher = Biz.business.appConfigurationManager.chainContextPublisher()
 	

--- a/phoenix-ios/phoenix-ios/views/receive/SwapInView.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/SwapInView.swift
@@ -335,7 +335,6 @@ struct SwapInView: View {
 				
 				Text(
 					"""
-					This is an address controlled by your wallet. \
 					On-chain deposits sent to this address will be converted to Lightning channels.
 					"""
 				)
@@ -345,7 +344,7 @@ struct SwapInView: View {
 				
 				Text(styled: String(format: NSLocalizedString(
 					"""
-					Deposits must be at least **%@**. The fee is **%@%%** (%@ minimum).
+					Total deposits must be at least **%@**. The fee is **%@%%** (%@ minimum).
 					""",
 					comment:	"Minimum amount description."),
 					minFunding.string, feePercent, minFee.string

--- a/phoenix-ios/phoenix-ios/views/receive/SwapInView.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/SwapInView.swift
@@ -322,7 +322,7 @@ struct SwapInView: View {
 		
 		HStack(alignment: VerticalAlignment.top, spacing: 8) {
 			
-			Image(systemName: "exclamationmark.circle")
+			Image(systemName: "info.circle")
 				.imageScale(.large)
 				.accessibilityHidden(true)
 			
@@ -335,12 +335,11 @@ struct SwapInView: View {
 				
 				Text(
 					"""
-					This is a swap address. It is not controlled by your wallet. \
+					This is an address controlled by your wallet. \
 					On-chain deposits sent to this address will be converted to Lightning channels.
 					"""
 				)
-				.lineLimit(nil)                               // text truncation bugs
-				.multilineTextAlignment(.leading)             // text truncation bugs
+				.multilineTextAlignment(.leading)
 				.fixedSize(horizontal: false, vertical: true) // text truncation bugs
 				.padding(.bottom, 14)
 				
@@ -351,8 +350,7 @@ struct SwapInView: View {
 					comment:	"Minimum amount description."),
 					minFunding.string, feePercent, minFee.string
 				))
-				.lineLimit(nil)                               // text truncation bugs
-				.multilineTextAlignment(.leading)             // text truncation bugs
+				.multilineTextAlignment(.leading)
 				.fixedSize(horizontal: false, vertical: true) // text truncation bugs
 			}
 		}

--- a/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
@@ -55,7 +55,7 @@ struct ValidateView: View {
 	
 	@State var didAppear = false
 	
-	let balancePublisher = Biz.business.peerManager.balancePublisher()
+	let balancePublisher = Biz.business.balanceManager.balancePublisher()
 	@State var balanceMsat: Int64 = 0
 	
 	let chainContextPublisher = Biz.business.appConfigurationManager.chainContextPublisher()

--- a/phoenix-ios/phoenix-ios/views/tools/IncomingDepositPopover.swift
+++ b/phoenix-ios/phoenix-ios/views/tools/IncomingDepositPopover.swift
@@ -1,0 +1,234 @@
+import SwiftUI
+import PhoenixShared
+import os.log
+
+#if DEBUG && true
+fileprivate var log = Logger(
+	subsystem: Bundle.main.bundleIdentifier!,
+	category: "MinimumDepositPopover"
+)
+#else
+fileprivate var log = Logger(OSLog.disabled)
+#endif
+
+struct IncomingDepositPopover: View {
+	
+	@State var swapInWalletBalance: WalletBalance = WalletBalance.companion.empty()
+	
+	@State var swapIn_minFundingSat: Int64 = 0
+	@State var swapIn_minFeeSat: Int64 = 0
+	@State var swapIn_feePercent: Double = 0.0
+	
+	// Toggles confirmation dialog (used to select preferred explorer)
+	@State var showBlockchainExplorerOptions = false
+	
+	let swapInWalletBalancePublisher = Biz.business.peerManager.swapInWalletBalancePublisher()
+	let chainContextPublisher = Biz.business.appConfigurationManager.chainContextPublisher()
+	
+	@Environment(\.popoverState) var popoverState: PopoverState
+	
+	@ViewBuilder
+	var body: some View {
+		
+		VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
+			content()
+			footer()
+		}
+		.onReceive(swapInWalletBalancePublisher) {
+			swapInWalletBalanceChanged($0)
+		}
+		.onReceive(chainContextPublisher) {
+			chainContextChanged($0)
+		}
+	}
+	
+	@ViewBuilder
+	func content() -> some View {
+		
+		let incomingSat = swapInWalletBalance.total.sat
+		if incomingSat >= swapIn_minFundingSat {
+			content_sufficient()
+		} else {
+			content_insufficient()
+		}
+	}
+	
+	@ViewBuilder
+	func content_sufficient() -> some View {
+		
+		let minFee = Utils.formatBitcoin(sat: swapIn_minFeeSat, bitcoinUnit: .sat)
+		let feePercent = formatFeePercent()
+		
+		VStack(alignment: HorizontalAlignment.leading, spacing: 15) {
+			
+			Text(
+				"""
+				Once the incoming payment is confirmed, Phoenix will use the funds to open a payment channel.
+				"""
+			)
+			.multilineTextAlignment(.leading)
+			.fixedSize(horizontal: false, vertical: true) // text truncation bugs
+			
+			Text(styled: String(format: NSLocalizedString(
+				"""
+				The fee is **%@%%** (%@ minimum).
+				""",
+				comment:	"Minimum amount description."),
+				feePercent, minFee.string
+			))
+			.multilineTextAlignment(.leading)
+			.fixedSize(horizontal: false, vertical: true) // text truncation bugs
+		}
+		.padding([.top, .leading, .trailing], 20)
+		.padding(.bottom, 30)
+	}
+	
+	@ViewBuilder
+	func content_insufficient() -> some View {
+		
+		let minFunding = Utils.formatBitcoin(sat: swapIn_minFundingSat, bitcoinUnit: .sat)
+		
+		let minFee = Utils.formatBitcoin(sat: swapIn_minFeeSat, bitcoinUnit: .sat)
+		let feePercent = formatFeePercent()
+		
+		VStack(alignment: HorizontalAlignment.leading, spacing: 15) {
+			
+			Text(styled: String(format: NSLocalizedString(
+				"""
+				Deposits must be at least **%@**.
+				""",
+				comment:	"Minimum amount description."),
+				minFunding.string
+			))
+			.multilineTextAlignment(.leading)
+			.fixedSize(horizontal: false, vertical: true) // text truncation bugs
+			
+			Text(styled: String(format: NSLocalizedString(
+				"""
+				Once the minimum amount is reached, Phoenix will use the funds to open a payment channel. \
+				The fee is **%@%%** (%@ minimum).
+				""",
+				comment:	"Minimum amount description."),
+				feePercent, minFee.string
+			))
+			.multilineTextAlignment(.leading)
+			.fixedSize(horizontal: false, vertical: true) // text truncation bugs
+		}
+		.padding([.top, .leading, .trailing], 20)
+		.padding(.bottom, 30)
+	}
+	
+	@ViewBuilder
+	func footer() -> some View {
+		
+		HStack {
+			if #available(iOS 15.0, *) {
+				Button {
+					showBlockchainExplorerOptions = true
+				} label: {
+					Text("Explore").font(.title2)
+				}
+				.confirmationDialog("Blockchain Explorer",
+					isPresented: $showBlockchainExplorerOptions,
+					titleVisibility: .automatic
+				) {
+					Button {
+						exploreIncomingDeposit(website: BlockchainExplorer.WebsiteMempoolSpace())
+					} label: {
+						Text(verbatim: "Mempool.space") // no localization needed
+					}
+					Button {
+						exploreIncomingDeposit(website: BlockchainExplorer.WebsiteBlockstreamInfo())
+					} label: {
+						Text(verbatim: "Blockstream.info") // no localization needed
+					}
+					Button("Copy bitcoin address") {
+						copySwapInAddress()
+					}
+				} // </confirmationDialog>
+			} // </if #available(iOS 15.0, *)>
+			
+			Spacer()
+			
+			Button {
+				close()
+			} label: {
+				Text("Close").font(.title2)
+			}
+			.accessibilityHidden(popoverState.publisher.value?.dismissable ?? false)
+		} // </HStack>
+		.padding(.vertical, 10)
+		.padding(.horizontal, 20)
+		.background(
+			Color(UIColor.secondarySystemBackground)
+		)
+	}
+	
+	// --------------------------------------------------
+	// MARK: View Helpers
+	// --------------------------------------------------
+	
+	func formatFeePercent() -> String {
+		
+		let formatter = NumberFormatter()
+		formatter.minimumFractionDigits = 0
+		formatter.maximumFractionDigits = 3
+		
+		return formatter.string(from: NSNumber(value: swapIn_feePercent))!
+	}
+	
+	// --------------------------------------------------
+	// MARK: Notifications
+	// --------------------------------------------------
+	
+	func swapInWalletBalanceChanged(_ walletBalance: WalletBalance) {
+		log.trace("swapInWalletBalanceChanged()")
+		
+		swapInWalletBalance = walletBalance
+	}
+	
+	func chainContextChanged(_ context: WalletContext.V0ChainContext) -> Void {
+		log.trace("chainContextChanged()")
+		
+		swapIn_minFundingSat = context.payToOpen.v1.minFundingSat // not yet segregated for swapIn - future work
+		swapIn_minFeeSat = context.payToOpen.v1.minFeeSat         // not yet segregated for swapIn - future work
+		swapIn_feePercent = context.swapIn.v1.feePercent * 100    // 0.01 => 1%
+	}
+	
+	// --------------------------------------------------
+	// MARK: Actions
+	// --------------------------------------------------
+	
+	func exploreIncomingDeposit(website: BlockchainExplorer.Website) {
+		log.trace("exploreIncomingDeposit()")
+		
+		guard let peer = Biz.business.getPeer() else {
+			return
+		}
+		let addr = peer.swapInAddress
+		
+		let txUrlStr = Biz.business.blockchainExplorer.addressUrl(addr: addr, website: website)
+		if let txUrl = URL(string: txUrlStr) {
+			UIApplication.shared.open(txUrl)
+		}
+	}
+	
+	func copySwapInAddress() {
+		log.trace("copySwapInAddress()")
+		
+		guard let peer = Biz.business.getPeer() else {
+			return
+		}
+		let addr = peer.swapInAddress
+		
+		UIPasteboard.general.string = addr
+	}
+	
+	func close() {
+		log.trace("close()")
+		
+		withAnimation {
+			popoverState.close()
+		}
+	}
+}

--- a/phoenix-ios/phoenix-ios/views/tools/IncomingDepositPopover.swift
+++ b/phoenix-ios/phoenix-ios/views/tools/IncomingDepositPopover.swift
@@ -95,7 +95,7 @@ struct IncomingDepositPopover: View {
 			
 			Text(styled: String(format: NSLocalizedString(
 				"""
-				Deposits must be at least **%@**.
+				Total deposits must be at least **%@**. Please make additional deposits to use the funds within Phoenix.
 				""",
 				comment:	"Minimum amount description."),
 				minFunding.string

--- a/phoenix-ios/phoenix-ios/views/tools/IncomingDepositPopover.swift
+++ b/phoenix-ios/phoenix-ios/views/tools/IncomingDepositPopover.swift
@@ -22,7 +22,7 @@ struct IncomingDepositPopover: View {
 	// Toggles confirmation dialog (used to select preferred explorer)
 	@State var showBlockchainExplorerOptions = false
 	
-	let swapInWalletBalancePublisher = Biz.business.peerManager.swapInWalletBalancePublisher()
+	let swapInWalletBalancePublisher = Biz.business.balanceManager.swapInWalletBalancePublisher()
 	let chainContextPublisher = Biz.business.appConfigurationManager.chainContextPublisher()
 	
 	@Environment(\.popoverState) var popoverState: PopoverState

--- a/phoenix-ios/phoenix-ios/views/transactions/PaymentCell.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/PaymentCell.swift
@@ -57,27 +57,39 @@ struct PaymentCell : View {
 		HStack {
 			if let payment = fetched?.payment {
 				
-				switch payment.state() {
-					case .success:
-						Image("payment_holder_def_success")
-							.foregroundColor(Color.accentColor)
-							.padding(4)
-							.background(
-								RoundedRectangle(cornerRadius: .infinity)
-									.fill(Color.appAccent)
-							)
-					case .pending:
-						Image("payment_holder_def_pending")
-							.foregroundColor(Color.appAccent)
-							.padding(4)
-					case .failure:
-						Image("payment_holder_def_failed")
-							.foregroundColor(Color.appAccent)
-							.padding(4)
-					default:
-						Image(systemName: "doc.text.magnifyingglass")
-							.padding(4)
+				if fetched?.isOnChain() ?? false {
+					
+					Image(systemName: "link.circle.fill")
+						.resizable()
+						.frame(width: 26, height: 26)
+						.foregroundColor(Color.appAccent)
+						.padding(.vertical, 4)
+					
+				} else {
+					
+					switch payment.state() {
+						case .success:
+							Image("payment_holder_def_success")
+								.foregroundColor(Color.accentColor)
+								.padding(4)
+								.background(
+									RoundedRectangle(cornerRadius: .infinity)
+										.fill(Color.appAccent)
+								)
+						case .pending:
+							Image("payment_holder_def_pending")
+								.foregroundColor(Color.appAccent)
+								.padding(4)
+						case .failure:
+							Image("payment_holder_def_failed")
+								.foregroundColor(Color.appAccent)
+								.padding(4)
+						default:
+							Image(systemName: "doc.text.magnifyingglass")
+								.padding(4)
+					}
 				}
+				
 			} else {
 				
 				Image(systemName: "doc.text.magnifyingglass")
@@ -151,7 +163,7 @@ struct PaymentCell : View {
 	func paymentDescription() -> String {
 
 		if let fetched = fetched {
-			return fetched.paymentDescription() ?? NSLocalizedString("No description", comment: "placeholder text")
+			return fetched.paymentDescription() ?? fetched.defaultPaymentDescription()
 		} else {
 			return ""
 		}

--- a/phoenix-ios/phoenix-ios/views/transactions/PaymentCell.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/PaymentCell.swift
@@ -57,37 +57,35 @@ struct PaymentCell : View {
 		HStack {
 			if let payment = fetched?.payment {
 				
-				if fetched?.isOnChain() ?? false {
-					
-					Image(systemName: "link.circle.fill")
-						.resizable()
-						.frame(width: 26, height: 26)
-						.foregroundColor(Color.appAccent)
-						.padding(.vertical, 4)
-					
-				} else {
-					
-					switch payment.state() {
-						case .success:
-							Image("payment_holder_def_success")
-								.foregroundColor(Color.accentColor)
-								.padding(4)
-								.background(
-									RoundedRectangle(cornerRadius: .infinity)
-										.fill(Color.appAccent)
-								)
-						case .pending:
-							Image("payment_holder_def_pending")
-								.foregroundColor(Color.appAccent)
-								.padding(4)
-						case .failure:
-							Image("payment_holder_def_failed")
-								.foregroundColor(Color.appAccent)
-								.padding(4)
-						default:
-							Image(systemName: "doc.text.magnifyingglass")
-								.padding(4)
+				switch payment.state() {
+				case .success:
+					if payment.isOnChain() {
+						Image(systemName: "link.circle.fill")
+							.resizable()
+							.frame(width: 26, height: 26)
+							.foregroundColor(Color.appAccent)
+							.padding(.vertical, 4)
+						
+					} else {
+						Image("payment_holder_def_success")
+							.foregroundColor(Color.accentColor)
+							.padding(4)
+							.background(
+								RoundedRectangle(cornerRadius: .infinity)
+									.fill(Color.appAccent)
+							)
 					}
+				case .pending:
+					Image("payment_holder_def_pending")
+						.foregroundColor(Color.appAccent)
+						.padding(4)
+				case .failure:
+					Image("payment_holder_def_failed")
+						.foregroundColor(Color.appAccent)
+						.padding(4)
+				default:
+					Image(systemName: "doc.text.magnifyingglass")
+						.padding(4)
 				}
 				
 			} else {
@@ -176,7 +174,11 @@ struct PaymentCell : View {
 		}
 		let timestamp = payment.completedAt()
 		guard timestamp > 0 else {
-			return NSLocalizedString("pending", comment: "timestamp string for pending transaction")
+			if payment.isOnChain() {
+				return NSLocalizedString("waiting for confirmations", comment: "explanation for pending transaction")
+			} else {
+				return NSLocalizedString("pending", comment: "timestamp string for pending transaction")
+			}
 		}
 			
 		let date = timestamp.toDate(from: .milliseconds)

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/PhoenixBusiness.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/PhoenixBusiness.kt
@@ -1,7 +1,5 @@
 package fr.acinq.phoenix
 
-import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.bitcoin.MnemonicCode
 import fr.acinq.lightning.blockchain.electrum.ElectrumClient
 import fr.acinq.lightning.blockchain.electrum.ElectrumWatcher
 import fr.acinq.lightning.io.TcpSocket
@@ -69,6 +67,7 @@ class PhoenixBusiness(
     val databaseManager by lazy { DatabaseManager(this) }
     val peerManager by lazy { PeerManager(this) }
     val paymentsManager by lazy { PaymentsManager(this) }
+    val balanceManager by lazy { BalanceManager(this) }
     val appConfigurationManager by lazy { AppConfigurationManager(this) }
     val currencyManager by lazy { CurrencyManager(this) }
     val connectionsManager by lazy { ConnectionsManager(this) }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/main/HomeController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/main/HomeController.kt
@@ -5,6 +5,7 @@ import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.utils.sum
 import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.controllers.AppController
+import fr.acinq.phoenix.managers.BalanceManager
 import fr.acinq.phoenix.managers.PaymentsManager
 import fr.acinq.phoenix.managers.PeerManager
 import fr.acinq.phoenix.utils.extensions.calculateBalance
@@ -17,7 +18,8 @@ import org.kodein.log.LoggerFactory
 class AppHomeController(
     loggerFactory: LoggerFactory,
     private val peerManager: PeerManager,
-    private val paymentsManager: PaymentsManager
+    private val paymentsManager: PaymentsManager,
+    private val balanceManager: BalanceManager
 ) : AppController<Home.Model, Home.Intent>(
     loggerFactory = loggerFactory,
     firstModel = Home.emptyModel
@@ -25,7 +27,8 @@ class AppHomeController(
     constructor(business: PhoenixBusiness): this(
         loggerFactory = business.loggerFactory,
         peerManager = business.peerManager,
-        paymentsManager = business.paymentsManager
+        paymentsManager = business.paymentsManager,
+        balanceManager = business.balanceManager
     )
 
     private var isBoot = true
@@ -50,7 +53,7 @@ class AppHomeController(
         }
 
         launch {
-            paymentsManager.incomingSwaps.collect {
+            balanceManager.incomingSwaps.collect {
                 model {
                     copy(incomingBalance = it.values.sum().takeIf { it.msat > 0 })
                 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/IncomingQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/IncomingQueries.kt
@@ -18,11 +18,12 @@ package fr.acinq.phoenix.db.payments
 
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto
-import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.utils.*
 import fr.acinq.phoenix.data.WalletPaymentId
 import fr.acinq.phoenix.db.*
+import fr.acinq.phoenix.utils.extensions.execute
+import fr.acinq.phoenix.utils.extensions.QueryExecution
 
 class IncomingQueries(private val database: PaymentsDatabase) {
 
@@ -62,72 +63,101 @@ class IncomingQueries(private val database: PaymentsDatabase) {
         )
     }
 
-    fun receivePayment(paymentHash: ByteVector32, receivedWith: Set<IncomingPayment.ReceivedWith>, receivedAt: Long) {
+    fun receivePayment(
+        paymentHash: ByteVector32,
+        receivedWith: Set<IncomingPayment.ReceivedWith>,
+        receivedAt: Long
+    ) {
         database.transaction {
-            val existingReceivedWith: Set<IncomingPayment.ReceivedWith> = queries.get(
+            val paymentInDb = queries.get(
                 payment_hash = paymentHash.toByteArray(),
                 mapper = ::mapIncomingPayment
-            ).executeAsOneOrNull()?.received?.receivedWith ?: emptySet()
-            val (receivedWithType, receivedWithBlob) = (existingReceivedWith + receivedWith).mapToDb() ?: null to null
+            ).executeAsOneOrNull() ?: throw IncomingPaymentNotFound(paymentHash)
+            val existingReceivedWith = paymentInDb.received?.receivedWith ?: emptySet()
+            val newReceivedWith = existingReceivedWith + receivedWith
+            val (receivedWithType, receivedWithBlob) = newReceivedWith.mapToDb() ?: (null to null)
+            val receivedWithNewChannel = newReceivedWith.any {
+                it is IncomingPayment.ReceivedWith.NewChannel
+            }
             queries.updateReceived(
                 received_at = receivedAt,
                 received_with_type = receivedWithType,
                 received_with_blob = receivedWithBlob,
+                received_with_new_channel = if (receivedWithNewChannel) 1 else 0,
                 payment_hash = paymentHash.toByteArray()
             )
-            if (queries.changes().executeAsOne() != 1L) {
-                throw IncomingPaymentNotFound(paymentHash)
-            }
             didCompleteWalletPayment(WalletPaymentId.IncomingPaymentId(paymentHash), database)
         }
     }
 
     fun updateNewChannelReceivedWithChannelId(paymentHash: ByteVector32, channelId: ByteVector32) {
         database.transaction {
-            val paymentInDb: IncomingPayment? = queries.get(
+            val paymentInDb = queries.get(
                 payment_hash = paymentHash.toByteArray(),
                 mapper = ::mapIncomingPayment
-            ).executeAsOneOrNull()
-            val (receivedWithType, receivedWithBlob) = paymentInDb?.received?.receivedWith?.map {
+            ).executeAsOneOrNull() ?: throw IncomingPaymentNotFound(paymentHash)
+            val newReceivedWith = paymentInDb.received?.receivedWith?.map {
                 when (it) {
                     is IncomingPayment.ReceivedWith.NewChannel -> it.copy(channelId = channelId)
                     else -> it
                 }
-            }?.toSet()?.mapToDb() ?: (null to null)
+            }?.toSet() ?: emptySet()
+            val (receivedWithType, receivedWithBlob) = newReceivedWith.mapToDb() ?: (null to null)
+            val receivedWithNewChannel = newReceivedWith.any {
+                it is IncomingPayment.ReceivedWith.NewChannel
+            }
             queries.updateReceived(
-                received_at = paymentInDb?.received?.receivedAt,
+                received_at = paymentInDb.received?.receivedAt,
                 received_with_type = receivedWithType,
                 received_with_blob = receivedWithBlob,
+                received_with_new_channel = if (receivedWithNewChannel) 1 else 0,
                 payment_hash = paymentHash.toByteArray()
             )
-            if (queries.changes().executeAsOne() != 1L) {
-                throw IncomingPaymentNotFound(paymentHash)
-            }
             didCompleteWalletPayment(WalletPaymentId.IncomingPaymentId(paymentHash), database)
+        }
+    }
+
+    fun findNewChannelPayment(channelId: ByteVector32): ByteVector32? {
+        return database.transactionWithResult {
+            val query = queries.listNewChannel(mapper = ::mapListNewChannel)
+            var match: ListNewChannelRow? = null
+            query.execute { row ->
+                row.received?.receivedWith?.mapNotNull {
+                    it as? IncomingPayment.ReceivedWith.NewChannel
+                }?.first {
+                    it.channelId == channelId
+                }?.let {
+                    match = row
+                    QueryExecution.Stop
+                } ?: QueryExecution.Continue
+            }
+            match?.paymentHash
         }
     }
 
     fun updateNewChannelConfirmed(paymentHash: ByteVector32, receivedAt: Long) {
         database.transaction {
-            val paymentInDb: IncomingPayment? = queries.get(
+            val paymentInDb = queries.get(
                 payment_hash = paymentHash.toByteArray(),
                 mapper = ::mapIncomingPayment
-            ).executeAsOneOrNull()
-            val (receivedWithType, receivedWithBlob) = paymentInDb?.received?.receivedWith?.map {
+            ).executeAsOneOrNull() ?: throw IncomingPaymentNotFound(paymentHash)
+            val newReceivedWith = paymentInDb.received?.receivedWith?.map {
                 when (it) {
                     is IncomingPayment.ReceivedWith.NewChannel -> it.copy(confirmed = true)
                     else -> it
                 }
-            }?.toSet()?.mapToDb() ?: (null to null)
+            }?.toSet() ?: emptySet()
+            val (receivedWithType, receivedWithBlob) = newReceivedWith.mapToDb() ?: (null to null)
+            val receivedWithNewChannel = newReceivedWith.any {
+                it is IncomingPayment.ReceivedWith.NewChannel
+            }
             queries.updateReceived(
                 received_at = receivedAt,
                 received_with_type = receivedWithType,
                 received_with_blob = receivedWithBlob,
+                received_with_new_channel = if (receivedWithNewChannel) 1 else 0,
                 payment_hash = paymentHash.toByteArray()
             )
-            if (queries.changes().executeAsOne() != 1L) {
-                throw IncomingPaymentNotFound(paymentHash)
-            }
             didCompleteWalletPayment(WalletPaymentId.IncomingPaymentId(paymentHash), database)
         }
     }
@@ -142,7 +172,10 @@ class IncomingQueries(private val database: PaymentsDatabase) {
         database.transaction {
             val paymentHash = Crypto.sha256(preimage).toByteVector32()
             val (originType, originData) = origin.mapToDb()
-            val (receivedWithType, receivedWithBlob) = receivedWith.mapToDb() ?: null to null
+            val (receivedWithType, receivedWithBlob) = receivedWith.mapToDb() ?: (null to null)
+            val receivedWithNewChannel = receivedWith.any {
+                it is IncomingPayment.ReceivedWith.NewChannel
+            }
             queries.insertAndReceive(
                 payment_hash = paymentHash.toByteArray(),
                 preimage = preimage.toByteArray(),
@@ -151,6 +184,7 @@ class IncomingQueries(private val database: PaymentsDatabase) {
                 received_at = receivedAt,
                 received_with_type = receivedWithType,
                 received_with_blob = receivedWithBlob,
+                received_with_new_channel = if (receivedWithNewChannel) 1 else 0,
                 created_at = createdAt
             )
             didCompleteWalletPayment(WalletPaymentId.IncomingPaymentId(paymentHash), database)
@@ -206,28 +240,56 @@ class IncomingQueries(private val database: PaymentsDatabase) {
             return IncomingPayment(
                 preimage = ByteVector32(preimage),
                 origin = IncomingOriginData.deserialize(origin_type, origin_blob),
-                received = mapIncomingReceived(received_amount_msat?.msat, received_at, origin_type, received_with_type, received_with_blob),
+                received = mapIncomingReceived(received_amount_msat, received_at, received_with_type, received_with_blob, origin_type),
                 createdAt = created_at
             )
         }
 
         private fun mapIncomingReceived(
-            amount: MilliSatoshi?,
-            receivedAt: Long?,
-            originTypeVersion: IncomingOriginTypeVersion,
-            receivedWithTypeVersion: IncomingReceivedWithTypeVersion?,
-            receivedWithBlob: ByteArray?
+            received_amount_msat: Long?,
+            received_at: Long?,
+            received_with_type: IncomingReceivedWithTypeVersion?,
+            received_with_blob: ByteArray?,
+            origin_type: IncomingOriginTypeVersion
         ): IncomingPayment.Received? {
             return when {
-                receivedAt == null && receivedWithTypeVersion == null && receivedWithBlob == null -> null
-                receivedAt != null && receivedWithTypeVersion != null && receivedWithBlob != null -> {
-                    IncomingPayment.Received(IncomingReceivedWithData.deserialize(receivedWithTypeVersion, receivedWithBlob, amount, originTypeVersion), receivedAt)
+                received_at == null && received_with_type == null && received_with_blob == null -> null
+                received_at != null && received_with_type != null && received_with_blob != null -> {
+                    IncomingPayment.Received(
+                        receivedWith = IncomingReceivedWithData.deserialize(received_with_type, received_with_blob, received_amount_msat?.msat, origin_type),
+                        receivedAt = received_at
+                    )
                 }
-                else -> throw UnreadableIncomingReceivedWith(receivedAt, receivedWithTypeVersion, receivedWithBlob)
+                else -> throw UnreadableIncomingReceivedWith(received_at, received_with_type, received_with_blob)
             }
+        }
+
+        private fun mapListNewChannel(
+            payment_hash: ByteArray,
+            received_amount_msat: Long?,
+            received_at: Long?,
+            received_with_type: IncomingReceivedWithTypeVersion?,
+            received_with_blob: ByteArray?,
+            origin_type: IncomingOriginTypeVersion
+        ): ListNewChannelRow {
+            return ListNewChannelRow(
+                paymentHash = payment_hash.toByteVector32(),
+                received = mapIncomingReceived(
+                    received_amount_msat = received_amount_msat,
+                    received_at = received_at,
+                    received_with_type = received_with_type,
+                    received_with_blob = received_with_blob,
+                    origin_type = origin_type
+                )
+            )
         }
     }
 }
+
+data class ListNewChannelRow(
+    val paymentHash: ByteVector32,
+    val received: IncomingPayment.Received?
+)
 
 class UnreadableIncomingReceivedWith(receivedAt: Long?, receivedWithTypeVersion: IncomingReceivedWithTypeVersion?, receivedWithBlob: ByteArray?) :
     RuntimeException("unreadable received with data [ receivedAt=$receivedAt, receivedWithTypeVersion=$receivedWithTypeVersion, receivedWithBlob=$receivedWithBlob ]")

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/IncomingQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/IncomingQueries.kt
@@ -122,10 +122,8 @@ class IncomingQueries(private val database: PaymentsDatabase) {
             val query = queries.listNewChannel(mapper = ::mapListNewChannel)
             var match: ListNewChannelRow? = null
             query.execute { row ->
-                row.received?.receivedWith?.mapNotNull {
-                    it as? IncomingPayment.ReceivedWith.NewChannel
-                }?.first {
-                    it.channelId == channelId
+                row.received?.receivedWith?.first {
+                    it is IncomingPayment.ReceivedWith.NewChannel && it.channelId == channelId
                 }?.let {
                     match = row
                     QueryExecution.Stop

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataQueries.kt
@@ -1,5 +1,7 @@
 package fr.acinq.phoenix.db.payments
 
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.byteVector32
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.utils.currentTimestampMillis
 import fr.acinq.phoenix.data.*
@@ -110,6 +112,19 @@ class MetadataQueries(val database: PaymentsDatabase) {
             }
             didUpdateWalletPaymentMetadata(id, database)
         }
+    }
+
+    fun mapChannelId(channelId: ByteVector32, paymentHash: ByteVector32) {
+        queries.mapChannelId(
+            channel_id = channelId.toByteArray(),
+            payment_hash = paymentHash.toByteArray()
+        )
+    }
+
+    fun fetchPaymentHash(channelId: ByteVector32): ByteVector32? {
+        return queries.fetchPaymentHash(
+            channel_id = channelId.toByteArray()
+        ).executeAsOneOrNull()?.byteVector32()
     }
 
     companion object {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataQueries.kt
@@ -114,19 +114,6 @@ class MetadataQueries(val database: PaymentsDatabase) {
         }
     }
 
-    fun mapChannelId(channelId: ByteVector32, paymentHash: ByteVector32) {
-        queries.mapChannelId(
-            channel_id = channelId.toByteArray(),
-            payment_hash = paymentHash.toByteArray()
-        )
-    }
-
-    fun fetchPaymentHash(channelId: ByteVector32): ByteVector32? {
-        return queries.fetchPaymentHash(
-            channel_id = channelId.toByteArray()
-        ).executeAsOneOrNull()?.byteVector32()
-    }
-
     companion object {
         fun mapDescriptions(
             lnurl_description: String?,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/BalanceManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/BalanceManager.kt
@@ -1,0 +1,157 @@
+package fr.acinq.phoenix.managers
+
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.Satoshi
+import fr.acinq.lightning.ChannelEvents
+import fr.acinq.lightning.MilliSatoshi
+import fr.acinq.lightning.SwapInEvents
+import fr.acinq.lightning.blockchain.electrum.WalletState
+import fr.acinq.lightning.io.Peer
+import fr.acinq.lightning.utils.*
+import fr.acinq.phoenix.PhoenixBusiness
+import fr.acinq.phoenix.utils.extensions.calculateBalance
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import org.kodein.log.LoggerFactory
+import org.kodein.log.newLogger
+
+class BalanceManager(
+    loggerFactory: LoggerFactory,
+    private val peerManager: PeerManager,
+    private val databaseManager: DatabaseManager
+) : CoroutineScope by MainScope() {
+
+    constructor(business: PhoenixBusiness): this(
+        loggerFactory = business.loggerFactory,
+        peerManager = business.peerManager,
+        databaseManager = business.databaseManager
+    )
+
+    private val log = newLogger(loggerFactory)
+
+    private val _balance = MutableStateFlow<MilliSatoshi?>(null)
+    val balance: StateFlow<MilliSatoshi?> = _balance
+
+    private val _swapInWallet = MutableStateFlow<WalletState?>(null)
+    private val _pendingReservedUtxos = MutableStateFlow<Map<ByteVector32, List<WalletState.Utxo>>>(emptyMap())
+    private val _reservedUtxos = MutableStateFlow<Set<WalletState.Utxo>>(emptySet())
+
+    private val _swapInWalletBalance = MutableStateFlow(WalletBalance.empty())
+    val swapInWalletBalance: StateFlow<WalletBalance> = _swapInWalletBalance
+
+    /**
+     * Flow of map of (bitcoinAddress -> amount) swap-ins.
+     * DEPRECATED: Replace with swapInWalletBalance
+     */
+    private val _incomingSwaps = MutableStateFlow<Map<String, MilliSatoshi>>(HashMap())
+    val incomingSwaps: StateFlow<Map<String, MilliSatoshi>> = _incomingSwaps
+    private var _incomingSwapsMap by _incomingSwaps
+
+    init {
+        launch {
+            val peer = peerManager.peerState.filterNotNull().first()
+            monitorPeer(peer)
+        }
+    }
+
+    private fun monitorPeer(peer: Peer) {
+        launch {
+            peer.channelsFlow.collect { channels ->
+                _balance.value = calculateBalance(channels)
+            }
+        }
+
+        /**
+         * What is the swap-in wallet's balance ?
+         *
+         * At first glance, it looks like we should be able to use:
+         * `peer.swapInWallet.walletStateFlow`
+         *
+         * However, this is a reflection of the balance on the Electrum server.
+         * Which means, there's a *DELAY* between:
+         * - when we consider the channel opened (+ update balance, + create IncomingPayment)
+         * - when that updated balance is bounced back from the Electrum server
+         *
+         * Even on a fast connection, that takes several seconds.
+         * And during that time, the UI is in a bad state:
+         *
+         * - the (lightning) balance has been updated to reflect the new channel
+         * - the incoming payment is reflected in the payments list
+         * - but the wallet incorrectly says "+ X sat incoming"
+         *
+         * So we work around this shortcoming by taking advantage of:
+         * - ChannelEvents.Creating
+         * - ChannelEvents.Created
+         *
+         * Which gives us the `List<Utxo>` that we can manually ignore,
+         * while we wait for the Electrum wallet to catch up.
+         */
+
+        launch {
+            peer.swapInWallet.walletStateFlow.collect { wallet ->
+                _swapInWallet.value = wallet
+                _reservedUtxos.update { it.intersect(wallet.utxos) }
+            }
+        }
+        launch {
+            peer.nodeParams.nodeEvents.collect { event ->
+                when (event) {
+                    is SwapInEvents.Requested -> {
+                        // Using a placeholder address because it's not exposed by lightning-kmp.
+                        _incomingSwapsMap = _incomingSwapsMap + ("foobar" to event.req.localFundingAmount.toMilliSatoshi())
+                    }
+                    is SwapInEvents.Accepted -> {
+                        log.info { "swap-in request=${event.requestId} has been accepted for funding_fee=${event.fundingFee} service_fee=${event.serviceFee}" }
+                    }
+                    is SwapInEvents.Rejected -> {
+                        log.error { "rejected swap-in for required_fee=${event.requiredFees} with error=${event.failure}" }
+                        _incomingSwapsMap = _incomingSwapsMap - "foobar"
+                    }
+                    is ChannelEvents.Creating -> {
+                        log.info { "channel=${event.state.channelId} is being created" }
+                        val channelId = event.state.channelId
+                        val channelUtxos = event.state.wallet.confirmedUtxos
+                        _pendingReservedUtxos.update { it.plus(channelId to channelUtxos) }
+                    }
+                    is ChannelEvents.Created -> {
+                        log.info { "channel=${event.state.channelId} has been successfully created!" }
+                        val channelId = event.state.channelId
+                        _pendingReservedUtxos.value[channelId]?.let { channelUtxos ->
+                            _reservedUtxos.update { it.union(channelUtxos) }
+                            _pendingReservedUtxos.update { it.minus(channelId) }
+                        }
+                        _incomingSwapsMap = _incomingSwapsMap - "foobar"
+                    }
+                    is ChannelEvents.Confirmed -> {
+                        databaseManager.paymentsDb().updateNewChannelConfirmed(
+                            channelId = event.state.channelId,
+                            receivedAt = currentTimestampMillis()
+                        )
+                    }
+                }
+            }
+        }
+        launch {
+            combine(_swapInWallet.filterNotNull(), _reservedUtxos) { swapInWallet, reservedUtxos ->
+                swapInWallet.minus(reservedUtxos)
+            }.collect { availableWallet ->
+                _swapInWalletBalance.value = WalletBalance(
+                    confirmed = availableWallet.confirmedBalance,
+                    unconfirmed = availableWallet.unconfirmedBalance
+                )
+            }
+        }
+    }
+}
+data class WalletBalance(
+    val confirmed: Satoshi,
+    val unconfirmed: Satoshi
+) {
+    val total get() = confirmed + unconfirmed
+
+    companion object {
+        fun empty() = WalletBalance(0.sat, 0.sat)
+    }
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/DatabaseManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/DatabaseManager.kt
@@ -51,6 +51,7 @@ class DatabaseManager(
                     driver = createChannelsDbDriver(ctx, chain, nodeIdHash)
                 )
                 val paymentsDb = SqlitePaymentsDb(
+                    loggerFactory,
                     driver = createPaymentsDbDriver(ctx, chain, nodeIdHash),
                     currencyManager = currencyManager
                 )

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PeerManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PeerManager.kt
@@ -1,10 +1,16 @@
 package fr.acinq.phoenix.managers
 
+import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.bitcoin.Crypto
+import fr.acinq.bitcoin.Satoshi
+import fr.acinq.lightning.ChannelEvents
 import fr.acinq.lightning.blockchain.electrum.ElectrumWatcher
+import fr.acinq.lightning.blockchain.electrum.WalletState
+import fr.acinq.lightning.blockchain.electrum.WalletState.Utxo
 import fr.acinq.lightning.io.Peer
 import fr.acinq.lightning.io.TcpSocket
+import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.wire.InitTlv
 import fr.acinq.lightning.wire.TlvStream
 import fr.acinq.phoenix.PhoenixBusiness
@@ -42,6 +48,13 @@ class PeerManager(
     private val _balance = MutableStateFlow<MilliSatoshi?>(null)
     val balance: StateFlow<MilliSatoshi?> = _balance
 
+    private val _swapInWallet = MutableStateFlow<WalletState?>(null)
+    private val _pendingReservedUtxos = MutableStateFlow<Map<ByteVector32, List<Utxo>>>(emptyMap())
+    private val _reservedUtxos = MutableStateFlow<Set<Utxo>>(emptySet())
+
+    private val _swapInWalletBalance = MutableStateFlow(WalletBalance.empty())
+    val swapInWalletBalance: StateFlow<WalletBalance> = _swapInWalletBalance
+
     init {
         launch {
             val nodeParams = nodeParamsManager.nodeParams.filterNotNull().first()
@@ -62,19 +75,97 @@ class PeerManager(
 
             val peer = Peer(
                 initTlvStream = initTlvs,
-                nodeParams = nodeParamsManager.nodeParams.filterNotNull().first(),
-                walletParams = configurationManager.chainContext.filterNotNull().first().walletParams(),
+                nodeParams = nodeParams,
+                walletParams = walletParams,
                 watcher = electrumWatcher,
                 db = databaseManager.databases.filterNotNull().first(),
                 socketBuilder = tcpSocketBuilder,
                 scope = MainScope()
             )
             _peer.value = peer
+            monitorPeer(peer)
+        }
+    }
+
+    private fun monitorPeer(peer: Peer) {
+        launch {
             peer.channelsFlow.collect { channels ->
                 _balance.value = calculateBalance(channels)
+            }
+        }
+
+        /**
+         * What is the swap-in wallet's balance ?
+         *
+         * At first glance, it looks like we should be able to use:
+         * `peer.swapInWallet.walletStateFlow`
+         *
+         * However, this is a reflection of the balance on the Electrum server.
+         * Which means, there's a *DELAY* between:
+         * - when we consider the channel opened (+ update balance, + create IncomingPayment)
+         * - when that updated balance is bounced back from the Electrum server
+         *
+         * Even on a fast connection, that takes several seconds.
+         * And during that time, the UI is in a bad state:
+         *
+         * - the (lightning) balance has been updated to reflect the new channel
+         * - the incoming payment is reflected in the payments list
+         * - but the wallet incorrectly says "+ X sat incoming"
+         *
+         * So we work around this shortcoming by taking advantage of:
+         * - ChannelEvents.Creating
+         * - ChannelEvents.Created
+         *
+         * Which gives us the `List<Utxo>` that we can manually ignore,
+         * while we wait for the Electrum wallet to catch up.
+         */
+
+        launch {
+            peer.swapInWallet.walletStateFlow.collect { wallet ->
+                _swapInWallet.value = wallet
+                _reservedUtxos.update { it.intersect(wallet.utxos) }
+            }
+        }
+        launch {
+            peer.nodeParams.nodeEvents.collect { event ->
+                when (event) {
+                    is ChannelEvents.Creating -> {
+                        val channelId = event.state.channelId
+                        val channelUtxos = event.state.wallet.confirmedUtxos
+                        _pendingReservedUtxos.update { it.plus(channelId to channelUtxos) }
+                    }
+                    is ChannelEvents.Created -> {
+                        val channelId = event.state.channelId
+                        _pendingReservedUtxos.value[channelId]?.let { channelUtxos ->
+                            _reservedUtxos.update { it.union(channelUtxos) }
+                            _pendingReservedUtxos.update { it.minus(channelId) }
+                        }
+                    }
+                }
+            }
+        }
+        launch {
+            combine(_swapInWallet.filterNotNull(), _reservedUtxos) { swapInWallet, reservedUtxos ->
+                swapInWallet.minus(reservedUtxos)
+            }.collect { availableWallet ->
+                _swapInWalletBalance.value = WalletBalance(
+                    confirmed = availableWallet.confirmedBalance,
+                    unconfirmed = availableWallet.unconfirmedBalance
+                )
             }
         }
     }
 
     suspend fun getPeer() = peerState.filterNotNull().first()
+}
+
+data class WalletBalance(
+    val confirmed: Satoshi,
+    val unconfirmed: Satoshi
+) {
+    val total get() = confirmed + unconfirmed
+
+    companion object {
+        fun empty() = WalletBalance(0.sat, 0.sat)
+    }
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/extensions/ChannelExtensions.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/extensions/ChannelExtensions.kt
@@ -18,6 +18,7 @@ package fr.acinq.phoenix.utils.extensions
 
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.lightning.MilliSatoshi
+import fr.acinq.lightning.NodeParams
 import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.transactions.CommitmentSpec
 import fr.acinq.lightning.utils.sum
@@ -30,6 +31,13 @@ val ChannelState.localCommitmentSpec: CommitmentSpec? get() =
         is Syncing -> state.localCommitmentSpec
         else -> null
     }
+
+fun ChannelStateWithCommitments.minDepthForFunding(nodeParams: NodeParams): Int {
+    return Helpers.minDepthForFunding(
+        nodeParams = nodeParams,
+        fundingAmount = commitments.fundingAmount
+    )
+}
 
 fun calculateBalance(channels: Map<ByteVector32, ChannelState>): MilliSatoshi {
     return channels.values.map {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/extensions/ChannelExtensions.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/extensions/ChannelExtensions.kt
@@ -53,6 +53,10 @@ fun calculateBalance(channels: Map<ByteVector32, ChannelState>): MilliSatoshi {
             is Closed -> MilliSatoshi(0)
             is Aborted -> MilliSatoshi(0)
             is ErrorInformationLeak -> MilliSatoshi(0)
+            is WaitForChannelReady -> MilliSatoshi(0)
+            is LegacyWaitForFundingLocked -> MilliSatoshi(0)
+            is WaitForFundingConfirmed -> MilliSatoshi(0)
+            is LegacyWaitForFundingConfirmed -> MilliSatoshi(0)
             else -> channel?.localCommitmentSpec?.toLocal ?: MilliSatoshi(0)
         }
     }.sum()

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/extensions/QueryExtensions.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/extensions/QueryExtensions.kt
@@ -1,0 +1,20 @@
+package fr.acinq.phoenix.utils.extensions
+
+import com.squareup.sqldelight.Query
+import com.squareup.sqldelight.db.use
+
+enum class QueryExecution {
+    Continue,
+    Stop
+}
+
+fun <T : Any> Query<T>.execute(iterator: (T) -> QueryExecution) {
+    this.execute().use { cursor ->
+        while (cursor.next()) {
+            val row = this.mapper(cursor)
+            if (iterator(row) == QueryExecution.Stop) {
+                break
+            }
+        }
+    }
+}

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/IncomingPayments.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/IncomingPayments.sq
@@ -14,15 +14,20 @@ CREATE TABLE IF NOT EXISTS incoming_payments (
     received_at INTEGER DEFAULT NULL,
     -- received with
     received_with_type TEXT AS IncomingReceivedWithTypeVersion DEFAULT NULL,
-    received_with_blob BLOB DEFAULT NULL
+    received_with_blob BLOB DEFAULT NULL,
+    received_with_new_channel INTEGER DEFAULT 0
 );
 
--- The created_at column is used by AggregatedQueries.listAllPaymentsOrder for sorting.
--- And that query is used constantly by the app.
-CREATE INDEX IF NOT EXISTS incoming_payments_created_at_idx ON incoming_payments(created_at);
+-- These columns are used by AggregatedQueries for sorting.
+-- And those queriers are used constantly by the app.
+CREATE INDEX IF NOT EXISTS incoming_payments_sort_idx
+    ON incoming_payments(created_at, received_at);
 
--- The received_amount_msat column is used regularly as a filter within AggregatedQueries.
-CREATE INDEX IF NOT EXISTS received_amount_msat_idx ON incoming_payments(received_amount_msat);
+-- Used to find payments associated with new channels.
+-- That is, to assist in mapping from a channel_id to the associated initial payment.
+CREATE INDEX IF NOT EXISTS incoming_payments_new_channel_idx
+    ON incoming_payments(created_at)
+ WHERE received_with_new_channel = 1;
 
 -- queries
 
@@ -39,7 +44,8 @@ updateReceived:
 UPDATE incoming_payments
 SET    received_at=?,
        received_with_type=?,
-       received_with_blob=?
+       received_with_blob=?,
+       received_with_new_channel=?
 WHERE  payment_hash = ?;
 
 insertAndReceive:
@@ -50,8 +56,9 @@ INSERT INTO incoming_payments (
             origin_type, origin_blob,
             received_at,
             received_with_type,
-            received_with_blob)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+            received_with_blob,
+            received_with_new_channel)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 get:
 SELECT payment_hash, preimage, created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob
@@ -82,6 +89,12 @@ ORDER BY
        r.received_at DESC,
        payment_hash DESC
 LIMIT :limit OFFSET :offset;
+
+listNewChannel:
+SELECT   payment_hash, received_amount_msat, received_at, received_with_type, received_with_blob, origin_type
+FROM     incoming_payments
+WHERE    received_with_new_channel = 1
+ORDER BY created_at DESC;
 
 scanCompleted:
 SELECT payment_hash,

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/IncomingPayments.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/IncomingPayments.sq
@@ -18,10 +18,11 @@ CREATE TABLE IF NOT EXISTS incoming_payments (
     received_with_new_channel INTEGER DEFAULT 0
 );
 
--- These columns are used by AggregatedQueries for sorting.
--- And those queriers are used constantly by the app.
-CREATE INDEX IF NOT EXISTS incoming_payments_sort_idx
-    ON incoming_payments(created_at, received_at);
+-- Create indexes to optimize the queries in AggregatedQueries.
+-- Tip: Use "explain query plan" to ensure they're actually being used.
+CREATE INDEX IF NOT EXISTS incoming_payments_filter_idx
+    ON incoming_payments(received_at)
+ WHERE received_at IS NOT NULL;
 
 -- Used to find payments associated with new channels.
 -- That is, to assist in mapping from a channel_id to the associated initial payment.

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/OutgoingPayments.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/OutgoingPayments.sq
@@ -24,10 +24,10 @@ CREATE TABLE IF NOT EXISTS outgoing_payments (
     status_blob BLOB DEFAULT NULL
 );
 
--- These columns are used by AggregatedQueries for sorting.
--- And those queriers are used constantly by the app.
-CREATE INDEX IF NOT EXISTS outgoing_payments_sort_idx
-    ON outgoing_payments(created_at, completed_at);
+-- Create indexes to optimize the queries in AggregatedQueries.
+-- Tip: Use "explain query plan" to ensure they're actually being used.
+CREATE INDEX IF NOT EXISTS outgoing_payments_filter_idx
+    ON outgoing_payments(completed_at);
 
 -- Stores the lightning parts that make up a lightning payment
 CREATE TABLE IF NOT EXISTS outgoing_payment_parts (

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/OutgoingPayments.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/OutgoingPayments.sq
@@ -24,9 +24,10 @@ CREATE TABLE IF NOT EXISTS outgoing_payments (
     status_blob BLOB DEFAULT NULL
 );
 
--- The created_at column is used by AggregatedQueries.listAllPaymentsOrder for sorting.
--- And that query is used constantly by the app.
-CREATE INDEX IF NOT EXISTS outgoing_payments_created_at_idx ON outgoing_payments(created_at);
+-- These columns are used by AggregatedQueries for sorting.
+-- And those queriers are used constantly by the app.
+CREATE INDEX IF NOT EXISTS outgoing_payments_sort_idx
+    ON outgoing_payments(created_at, completed_at);
 
 -- Stores the lightning parts that make up a lightning payment
 CREATE TABLE IF NOT EXISTS outgoing_payment_parts (

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/PaymentsMetadata.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/PaymentsMetadata.sq
@@ -5,6 +5,13 @@ import fr.acinq.phoenix.db.payments.LNUrlSuccessAction;
 -- This table stores metadata corresponding to a payment.
 -- * type => enum indicating whether payment is incoming or outgoing
 -- * id => stores the primary key of the payment row
+-- * lnurl_base => serialized lnurl object (e.g. LNUrl.Pay), excluding metadata content
+-- * lnurl_metadata => serialized lnurl metadata (e.g. LNUrl.Pay.Metadata)
+-- * lnurl_successAction => serialized LUD-09 (e.g. LNUrl.PayInvoice.SuccessAction.Message)
+-- * user_description => user-customized short description
+-- * user_notes => user-customized notes (can be much longer than description)
+-- * modified_at => last time this DB entry was modified (i.e. within payments_metadata table)
+-- * original_fiat => stores original fiat price (via conversion rate) at time of transaction
 --
 CREATE TABLE IF NOT EXISTS payments_metadata (
     type INTEGER NOT NULL,
@@ -23,6 +30,14 @@ CREATE TABLE IF NOT EXISTS payments_metadata (
     original_fiat_rate REAL DEFAULT NULL,
     PRIMARY KEY (type, id)
 );
+
+-- Provides a mapping: `local_channels.channel_id` => `incoming_payments.payment_hash`.
+CREATE TABLE IF NOT EXISTS channel_id_map (
+    channel_id BLOB NOT NULL PRIMARY KEY,
+    payment_hash BLOB NOT NULL
+);
+
+-- queries for payments_metadata table
 
 hasMetadata:
 SELECT COUNT(*) FROM payments_metadata
@@ -58,6 +73,16 @@ WHERE  type = ? AND id = ?;
 fetchMetadata:
 SELECT * FROM payments_metadata
 WHERE type = ? AND id = ?;
+
+-- queries for channel_id_map table
+
+mapChannelId:
+INSERT INTO channel_id_map (channel_id, payment_hash)
+VALUES (?, ?);
+
+fetchPaymentHash:
+SELECT payment_hash FROM channel_id_map
+WHERE channel_id = ?;
 
 -- use this in a `transaction` block to know how many rows were changed after an UPDATE
 changes:

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/PaymentsMetadata.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/PaymentsMetadata.sq
@@ -31,12 +31,6 @@ CREATE TABLE IF NOT EXISTS payments_metadata (
     PRIMARY KEY (type, id)
 );
 
--- Provides a mapping: `local_channels.channel_id` => `incoming_payments.payment_hash`.
-CREATE TABLE IF NOT EXISTS channel_id_map (
-    channel_id BLOB NOT NULL PRIMARY KEY,
-    payment_hash BLOB NOT NULL
-);
-
 -- queries for payments_metadata table
 
 hasMetadata:
@@ -73,16 +67,6 @@ WHERE  type = ? AND id = ?;
 fetchMetadata:
 SELECT * FROM payments_metadata
 WHERE type = ? AND id = ?;
-
--- queries for channel_id_map table
-
-mapChannelId:
-INSERT INTO channel_id_map (channel_id, payment_hash)
-VALUES (?, ?);
-
-fetchPaymentHash:
-SELECT payment_hash FROM channel_id_map
-WHERE channel_id = ?;
 
 -- use this in a `transaction` block to know how many rows were changed after an UPDATE
 changes:

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/6.sqm
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/6.sqm
@@ -2,17 +2,20 @@
 --
 -- Changes:
 -- * Removed index: received_amount_msat_idx
--- * Replaced index: incoming_payments_created_at_idx -> incoming_payments_sort_idx
--- * Replaced index: outgoing_payments_created_at_idx -> outgoing_payments_sort_idx
+-- * Replaced index: incoming_payments_created_at_idx -> incoming_payments_filter_idx
+-- * Replaced index: outgoing_payments_created_at_idx -> outgoing_payments_filter_idx
 -- * Added column: incoming_payments.received_with_new_channel
 
 DROP INDEX IF EXISTS received_amount_msat_idx;
 
 DROP INDEX IF EXISTS incoming_payments_created_at_idx;
-CREATE INDEX IF NOT EXISTS incoming_payments_sort_idx ON incoming_payments(created_at, received_at);
+CREATE INDEX IF NOT EXISTS incoming_payments_filter_idx
+    ON incoming_payments(received_at)
+ WHERE received_at IS NOT NULL;
 
 DROP INDEX IF EXISTS outgoing_payments_created_at_idx;
-CREATE INDEX IF NOT EXISTS outgoing_payments_sort_idx ON outgoing_payments(created_at, completed_at);
+CREATE INDEX IF NOT EXISTS outgoing_payments_filter_idx
+    ON outgoing_payments(completed_at);
 
 ALTER TABLE incoming_payments ADD COLUMN received_with_new_channel INTEGER DEFAULT 0;
 

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/6.sqm
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/6.sqm
@@ -1,9 +1,21 @@
 -- Migration: v6 -> v7
 --
 -- Changes:
--- * Added table channel_id_map
+-- * Removed index: received_amount_msat_idx
+-- * Replaced index: incoming_payments_created_at_idx -> incoming_payments_sort_idx
+-- * Replaced index: outgoing_payments_created_at_idx -> outgoing_payments_sort_idx
+-- * Added column: incoming_payments.received_with_new_channel
 
-CREATE TABLE IF NOT EXISTS channel_id_map (
-    channel_id BLOB NOT NULL PRIMARY KEY,
-    payment_hash BLOB NOT NULL
-);
+DROP INDEX IF EXISTS received_amount_msat_idx;
+
+DROP INDEX IF EXISTS incoming_payments_created_at_idx;
+CREATE INDEX IF NOT EXISTS incoming_payments_sort_idx ON incoming_payments(created_at, received_at);
+
+DROP INDEX IF EXISTS outgoing_payments_created_at_idx;
+CREATE INDEX IF NOT EXISTS outgoing_payments_sort_idx ON outgoing_payments(created_at, completed_at);
+
+ALTER TABLE incoming_payments ADD COLUMN received_with_new_channel INTEGER DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS incoming_payments_new_channel_idx
+    ON incoming_payments(created_at)
+ WHERE received_with_new_channel = 1;

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/6.sqm
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/6.sqm
@@ -1,0 +1,9 @@
+-- Migration: v6 -> v7
+--
+-- Changes:
+-- * Added table channel_id_map
+
+CREATE TABLE IF NOT EXISTS channel_id_map (
+    channel_id BLOB NOT NULL PRIMARY KEY,
+    payment_hash BLOB NOT NULL
+);

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
@@ -32,6 +32,11 @@ fun IncomingPayment.Origin.asSwapIn(): IncomingPayment.Origin.SwapIn? = when (th
     else -> null
 }
 
+fun IncomingPayment.Origin.asDualSwapIn(): IncomingPayment.Origin.DualSwapIn? = when (this) {
+    is IncomingPayment.Origin.DualSwapIn -> this
+    else -> null
+}
+
 fun IncomingPayment.ReceivedWith.asLightningPayment(): IncomingPayment.ReceivedWith.LightningPayment? = when (this) {
     is IncomingPayment.ReceivedWith.LightningPayment -> this
     else -> null

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
@@ -1,11 +1,14 @@
 package fr.acinq.phoenix.utils
 
+import fr.acinq.lightning.blockchain.electrum.ElectrumMiniWallet
+import fr.acinq.lightning.blockchain.electrum.WalletState
 import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.io.NativeSocketException
 import fr.acinq.lightning.io.TcpSocket
 import fr.acinq.lightning.utils.Connection
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Class types from lightning-kmp & bitcoin-kmp are not exported to iOS unless we explicitly
@@ -150,3 +153,5 @@ fun NativeSocketException.asTLS(): NativeSocketException.TLS? = when (this) {
     is NativeSocketException.TLS -> this
     else -> null
 }
+
+fun ElectrumMiniWallet.currentWalletState(): WalletState = this.walletStateFlow.value


### PR DESCRIPTION
Here's what the UI looks like so far.

First, the "Receive" screen now explains that the swap-in address is owned by the user's own wallet:

<img height="450" src="https://user-images.githubusercontent.com/304604/203836526-90dd121b-9402-4601-9810-5312c0e1a251.png"/>

If we see an incoming payment that's too small we now flag it:

<img height="450" src="https://user-images.githubusercontent.com/304604/203836859-122e2936-aead-41b8-a5a2-c6a74d9f7dab.png"/>

Tapping on the text/button reveals a new popover window that explains the situation:

<img height="450" src="https://user-images.githubusercontent.com/304604/203837020-2b34f96c-6085-4c05-8e97-6d51d82c5c43.png"/>

If the incoming amount is acceptable, the UI looks as it did before:

<img height="450" src="https://user-images.githubusercontent.com/304604/203837380-8f73c377-cbcb-42f3-8d52-dfbde6048cc7.png"/>

And tapping on the text/button reveals a popover with helpful information:

<img height="450" src="https://user-images.githubusercontent.com/304604/203837958-ef50bbcb-a3b6-467c-80ec-31c12c2c662f.png"/>

The previous functionality is available via the "Explore" button:

<img height="450" src="https://user-images.githubusercontent.com/304604/203841855-0f4a126b-e4dc-43b9-b824-e11d02134c60.png"/>

Once the incoming payment receives 1 block confirmation, the payment channel is started, and the UI displays an incoming payment:

<img height="450" src="https://user-images.githubusercontent.com/304604/203842126-d0faa74b-1756-47be-a346-b80cba6ecb02.png"/>

The payment window now separates the services fees from miner fees:

<img height="450" src="https://user-images.githubusercontent.com/304604/203842328-32903b2c-e810-42a7-98f9-55b231122d85.png"/>

After a few block confirmations, the payment channel is opened, and everything looks normal again:

<img height="450" src="https://user-images.githubusercontent.com/304604/203851186-924a54ac-1f06-46bf-bc9f-a05d85d5a64f.png"/>
