### PR TITLE
Fixing compiler warnings

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/ScanController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/ScanController.kt
@@ -109,6 +109,7 @@ class AppScanController(
                             )
                         }
                     }
+                    else -> {}
                 }
             }
         }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/OutgoingType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/OutgoingType.kt
@@ -111,6 +111,7 @@ data class OutgoingPaymentWrapper @OptIn(ExperimentalSerializationApi::class) co
 
         /** The status blob may contain closing transaction data, when type is [OutgoingStatusTypeVersion.SUCCEEDED_ONCHAIN_V0]. */
         fun getClosingPartsFromV0OnchainStatus(): List<OutgoingPayment.ClosingTxPart> {
+            @Suppress("DEPRECATION")
             return if (OutgoingStatusTypeVersion.valueOf(type) == OutgoingStatusTypeVersion.SUCCEEDED_ONCHAIN_V0) {
                 OutgoingStatusData.getClosingPartsFromV0Status(blob, ts)
             } else {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/DbTypesHelper.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/DbTypesHelper.kt
@@ -30,6 +30,7 @@ object DbTypesHelper {
     val module = SerializersModule {
         polymorphic(IncomingReceivedWithData.Part::class) {
             subclass(IncomingReceivedWithData.Part.Htlc.V0::class)
+            @Suppress("DEPRECATION")
             subclass(IncomingReceivedWithData.Part.NewChannel.V0::class)
             subclass(IncomingReceivedWithData.Part.NewChannel.V1::class)
         }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
@@ -17,7 +17,6 @@
 package fr.acinq.phoenix.db.payments
 
 import com.squareup.sqldelight.ColumnAdapter
-import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.PublicKey
 import fr.acinq.bitcoin.Satoshi
@@ -319,8 +318,14 @@ class OutgoingQueries(val database: PaymentsDatabase) {
                 )
             } else emptyList()
 
-            val closingTxParts = if (closingtx_part_id != null && closingtx_part_tx_id != null && closingtx_part_amount_sat != null
-                && closingtx_part_closing_info_type != null && closingtx_part_closing_info_blob != null && closingtx_part_created_at != null
+            @Suppress("DEPRECATION")
+            val closingTxParts = if (
+                closingtx_part_id != null &&
+                closingtx_part_tx_id != null &&
+                closingtx_part_amount_sat != null &&
+                closingtx_part_closing_info_type != null &&
+                closingtx_part_closing_info_blob != null &&
+                closingtx_part_created_at != null
             ) {
                 listOf(
                     mapClosingTxPart(
@@ -332,7 +337,11 @@ class OutgoingQueries(val database: PaymentsDatabase) {
                         createdAt = closingtx_part_created_at
                     )
                 )
-            } else if (status_type == OutgoingStatusTypeVersion.SUCCEEDED_ONCHAIN_V0 && status_blob != null && completed_at != null) {
+            } else if (
+                status_type == OutgoingStatusTypeVersion.SUCCEEDED_ONCHAIN_V0 &&
+                status_blob != null &&
+                completed_at != null
+            ) {
                 // we used to store closing txs data in the payment status blob
                 OutgoingStatusData.getClosingPartsFromV0Status(status_blob, completed_at)
             } else emptyList()

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingStatusType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingStatusType.kt
@@ -96,6 +96,7 @@ sealed class OutgoingStatusData {
         }
 
         fun deserialize(typeVersion: OutgoingStatusTypeVersion, blob: ByteArray, completedAt: Long): OutgoingPayment.Status = decodeBlob(blob) { json, format ->
+            @Suppress("DEPRECATION")
             when (typeVersion) {
                 OutgoingStatusTypeVersion.SUCCEEDED_OFFCHAIN_V0 -> format.decodeFromString<SucceededOffChain.V0>(json).let {
                     OutgoingPayment.Status.Completed.Succeeded.OffChain(it.preimage, completedAt)

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsManager.kt
@@ -86,7 +86,7 @@ class PaymentsManager(
         }
 
         launch {
-            var appLaunch: Long = currentTimestampMillis()
+            val appLaunch: Long = currentTimestampMillis()
             var isFirstCollection = true
 
             paymentsDb().listPaymentsOrderFlow(count = 25, skip = 0).collect { list ->
@@ -157,6 +157,7 @@ class PaymentsManager(
                         log.info { "channel=${it.state.channelId} has been successfully created!" }
                         _incomingSwapsMap = _incomingSwapsMap - "foobar"
                     }
+                    else -> {}
                 }
             }
         }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/LogMemory.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/LogMemory.kt
@@ -73,6 +73,7 @@ class LogMemory(val directory: Path) : LogFrontend, CoroutineScope by MainScope(
     }
 }
 
+@OptIn(DelicateCoroutinesApi::class)
 private fun writeLogs(lines: List<LogMemory.Line>, file: Path): Job = GlobalScope.launch(Dispatchers.Default) {
     val allLines = buildString {
         lines.forEach { line ->

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/Parser.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/Parser.kt
@@ -101,7 +101,7 @@ object Parser {
             }
         }
         val otherParams = ParametersBuilder().apply {
-            appendAll(url.parameters.filter { entry, value ->
+            appendAll(url.parameters.filter { entry, _ ->
                 !listOf("amount", "label", "message", "lightning").contains(entry)
             })
         }.build()


### PR DESCRIPTION
Fixes the following compiler warnings:

* Non exhaustive 'when' statements on sealed class/interface will be prohibited in 1.7, add X, Y, Z branches or 'else' branch instead
* X is deprecated (within deserialization routines)
* Parameter X is never used, could be renamed to _
* This is a delicate API and its use requires care. (for LogMemory.kt)