### PR TITLE
Fixing mimalloc memory-limit crash

### DIFF
--- a/phoenix-shared/build.gradle.kts
+++ b/phoenix-shared/build.gradle.kts
@@ -29,6 +29,10 @@ kotlin {
             configureEach {
                 it.compilations.all {
                     kotlinOptions.freeCompilerArgs += "-Xoverride-konan-properties=osVersionMin.ios_x64=14.0;osVersionMin.ios_arm64=14.0"
+                    // The notification-service-extension is limited to 24 MB of memory.
+                    // With mimalloc we can easily hit the 24 MB limit, and the OS kills the process.
+                    // But with standard allocation, we're using less then half the limit.
+                    kotlinOptions.freeCompilerArgs += "-Xallocator=std"
                     kotlinOptions.freeCompilerArgs += listOf("-linker-options", "-application_extension")
                 }
             }


### PR DESCRIPTION
I was testing receiving payments when Phoenix was running in the background, and noticed that it had mysteriously stopped working in recent builds. I tracked down the issue and discovered the the notification-service-extension was crashing:

<img width="1267" alt="Screenshot 2022-12-14 at 10 25 02" src="https://user-images.githubusercontent.com/304604/207642737-3b2f6b91-39e6-4fee-b43d-6325dff6b527.png">

This issue is that Apple limits the amount of memory that a notification-service-extension is allowed to use. The memory is capped at 24 MB (for iOS 16).

In the Kotlin [docs](https://kotlinlang.org/docs/native-memory-manager.html#memory-consumption), they say:

> Another way to fix high memory consumption is related to [mimalloc](https://github.com/microsoft/mimalloc), the default memory allocator for many targets. It pre-allocates and holds onto the system memory to improve the allocation speed.
>
> To avoid that at the cost of performance, a couple of options are available:
> 
> * Switch the memory allocator from mimalloc to the system allocator. For that, set the -Xallocator=std compilation option in your Gradle build script.
> 
> * Since Kotlin 1.8.0-Beta, you can also instruct mimalloc to promptly release memory back to the system. It's a smaller performance cost, but it gives less definitive results.

The "-Xallocator=std" option seems to do the trick, as I wasn't able to reproduce the crash with that option set. In fact, the memory is significantly lowered:

<img width="350" alt="Screenshot 2022-12-14 at 10 36 42" src="https://user-images.githubusercontent.com/304604/207643444-7bea3004-2ee2-4505-b897-249288c67dcb.png">

I don't notice any performance degradation. In fact, fetching objects from the database actually seems faster. But I can appreciate how mimalloc theoretically increases performance. So I'd be happy to revisit this when we adopt Kotlin 1.8. Or if Apple raises the memory limits in future versions of iOS.