### PR TITLE
CoinDesk exchange rates no longer accurate

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
@@ -96,7 +96,8 @@ private fun getFlag(code: String): String {
         "CDF" -> "🇨🇩" // Congolese Franc
         "CHF" -> "🇨🇭" // Swiss Franc
         "CLP" -> "🇨🇱" // Chilean Peso
-        "CNY" -> "🇨🇳" // Chinese Yuan
+        "CNH" -> "🇨🇳" // Chinese Yuan (offshore)
+        "CNY" -> "🇨🇳" // Chinese Yuan (onshore)
         "COP" -> "🇨🇴" // Colombian Peso
         "CRC" -> "🇨🇷" // Costa Rican Colón
         "CUP" -> "🇨🇺" // Cuban Peso

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
@@ -157,7 +157,6 @@ private fun getFlag(code: String): String {
         "MMK" -> "🇲🇲" // Myanmar Kyat
         "MNT" -> "🇲🇳" // Mongolian Tugrik
         "MOP" -> "🇲🇴" // Macanese Pataca
-        "MTL" -> "🇲🇹" // Maltese Lira
         "MUR" -> "🇲🇺" // Mauritian Rupee
         "MVR" -> "🇲🇻" // Maldivian Rufiyaa
         "MWK" -> "🇲🇼" // Malawian Kwacha

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
@@ -56,8 +56,13 @@ fun FiatCurrency.labels(): Pair<String, String> {
     val context = LocalContext.current
     return remember(key1 = code) {
         val fullName = when {
-            code.length == 3 -> Currency.getInstance(code).displayName
+            code.length == 3 -> try {
+                Currency.getInstance(code).displayName
+            } catch (e: Exception) {
+                "N/A"
+            }
             code == "ARS_BM" -> context.getString(R.string.currency_ars_bm)
+            code == "CUP_FM" -> context.getString(R.string.currency_cup_fm)
             else -> "N/A"
         }
         val flag = getFlag(code)

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
@@ -101,6 +101,7 @@ private fun getFlag(code: String): String {
         "COP" -> "🇨🇴" // Colombian Peso
         "CRC" -> "🇨🇷" // Costa Rican Colón
         "CUP" -> "🇨🇺" // Cuban Peso
+        "CUP_FM" -> "🇨🇺" // Cuban Peso (free market)
         "CVE" -> "🇨🇻" // Cape Verdean Escudo
         "CZK" -> "🇨🇿" // Czech Koruna
         "DJF" -> "🇩🇯" // Djiboutian Franc

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -705,6 +705,7 @@
     <!-- ////////////// currencies ////////////// -->
 
     <string name="currency_ars_bm">Argentine Peso (Blue Market)</string>
+    <string name="currency_cup_fm">Cuban Peso (Free Market)</string>
 
     <!-- ////////////// payments history ////////////// -->
 

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -645,7 +645,7 @@
     <string name="about_seed_title">Safeguarding your key</string>
     <string name="about_seed_content">This wallet is self-custodial: <b>you have sole custody of the wallet\'s 12-words seed key</b>.\n\nThis key gives access to your money. Do not reveal it to anyone, and beware of phishing.</string>
     <string name="about_rates_title">Exchange rates</string>
-    <string name="about_rates_content">Bitcoin/fiat exchange rates are retrieved from various third-party APIs:\n- Blockchain.info\n- powered by Coindesk.com\n\nThose rates may not be accurate. Always check the actual Bitcoin amount before sending a payment.</string>
+    <string name="about_rates_content">Bitcoin/fiat exchange rates are retrieved from various third-party APIs:\n\n- Blockchain.info\n- powered by Coindesk.com\n- Coinbase.com\n- Bluelytics.com.ar\n- Yadio.io\n\nThose rates may not be accurate. Always check the actual Bitcoin amount before sending a payment.</string>
     <string name="about_version">Version</string>
     <string name="about_faq_link">Any questions? Check the FAQ</string>
     <string name="about_support_link">Support</string>

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Currency.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Currency.swift
@@ -59,6 +59,7 @@ extension FiatCurrency {
 		case .cop   : return "Colombian Peso"
 		case .crc   : return "Costa Rican Colón"
 		case .cup   : return "Cuban Peso"
+		case .cupFm : return "Cuban Peso (free market)"
 		case .cve   : return "Cape Verdean Escudo"
 		case .czk   : return "Czech Koruna"
 		case .djf   : return "Djiboutian Franc"
@@ -215,6 +216,7 @@ extension FiatCurrency {
 		case .cop   : return NSLocalizedString("COP", tableName: "Currencies", comment: "Colombian Peso")
 		case .crc   : return NSLocalizedString("CRC", tableName: "Currencies", comment: "Costa Rican Colón")
 		case .cup   : return NSLocalizedString("CUP", tableName: "Currencies", comment: "Cuban Peso")
+		case .cupFm : return NSLocalizedString("CUPfm", tableName: "Currencies", comment: "Cuban Peso (free market)")
 		case .cve   : return NSLocalizedString("CVE", tableName: "Currencies", comment: "Cape Verdean Escudo")
 		case .czk   : return NSLocalizedString("CZK", tableName: "Currencies", comment: "Czech Koruna")
 		case .djf   : return NSLocalizedString("DJF", tableName: "Currencies", comment: "Djiboutian Franc")
@@ -387,6 +389,7 @@ extension FiatCurrency {
 		case .cop   : return "🇨🇴" // Colombian Peso
 		case .crc   : return "🇨🇷" // Costa Rican Colón
 		case .cup   : return "🇨🇺" // Cuban Peso
+		case .cupFm : return "🇨🇺" // Cuban Peso (free market)
 		case .cve   : return "🇨🇻" // Cape Verdean Escudo
 		case .czk   : return "🇨🇿" // Czech Koruna
 		case .djf   : return "🇩🇯" // Djiboutian Franc

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Currency.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Currency.swift
@@ -115,7 +115,6 @@ extension FiatCurrency {
 		case .mmk   : return "Myanmar Kyat"
 		case .mnt   : return "Mongolian Tugrik"
 		case .mop   : return "Macanese Pataca"
-		case .mtl   : return "Maltese Lira"
 		case .mur   : return "Mauritian Rupee"
 		case .mvr   : return "Maldivian Rufiyaa"
 		case .mwk   : return "Malawian Kwacha"
@@ -271,7 +270,6 @@ extension FiatCurrency {
 		case .mmk   : return NSLocalizedString("MMK", tableName: "Currencies", comment: "Myanmar Kyat")
 		case .mnt   : return NSLocalizedString("MNT", tableName: "Currencies", comment: "Mongolian Tugrik")
 		case .mop   : return NSLocalizedString("MOP", tableName: "Currencies", comment: "Macanese Pataca")
-		case .mtl   : return NSLocalizedString("MTL", tableName: "Currencies", comment: "Maltese Lira")
 		case .mur   : return NSLocalizedString("MUR", tableName: "Currencies", comment: "Mauritian Rupee")
 		case .mvr   : return NSLocalizedString("MVR", tableName: "Currencies", comment: "Maldivian Rufiyaa")
 		case .mwk   : return NSLocalizedString("MWK", tableName: "Currencies", comment: "Malawian Kwacha")
@@ -443,7 +441,6 @@ extension FiatCurrency {
 		case .mmk   : return "🇲🇲" // Myanmar Kyat
 		case .mnt   : return "🇲🇳" // Mongolian Tugrik
 		case .mop   : return "🇲🇴" // Macanese Pataca
-		case .mtl   : return "🇲🇹" // Maltese Lira
 		case .mur   : return "🇲🇺" // Mauritian Rupee
 		case .mvr   : return "🇲🇻" // Maldivian Rufiyaa
 		case .mwk   : return "🇲🇼" // Malawian Kwacha

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Currency.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Currency.swift
@@ -54,6 +54,7 @@ extension FiatCurrency {
 		case .cdf   : return "Congolese Franc"
 		case .chf   : return "Swiss Franc"
 		case .clp   : return "Chilean Peso"
+		case .cnh   : return "Chinese Yuan (offshore)"
 		case .cny   : return "Chinese Yuan"
 		case .cop   : return "Colombian Peso"
 		case .crc   : return "Costa Rican Colón"
@@ -209,7 +210,8 @@ extension FiatCurrency {
 		case .cdf   : return NSLocalizedString("CDF", tableName: "Currencies", comment: "Congolese Franc")
 		case .chf   : return NSLocalizedString("CHF", tableName: "Currencies", comment: "Swiss Franc")
 		case .clp   : return NSLocalizedString("CLP", tableName: "Currencies", comment: "Chilean Peso")
-		case .cny   : return NSLocalizedString("CNY", tableName: "Currencies", comment: "Chinese Yuan")
+		case .cnh   : return NSLocalizedString("CNH", tableName: "Currencies", comment: "Chinese Yuan (offshore)")
+		case .cny   : return NSLocalizedString("CNY", tableName: "Currencies", comment: "Chinese Yuan (onshore)")
 		case .cop   : return NSLocalizedString("COP", tableName: "Currencies", comment: "Colombian Peso")
 		case .crc   : return NSLocalizedString("CRC", tableName: "Currencies", comment: "Costa Rican Colón")
 		case .cup   : return NSLocalizedString("CUP", tableName: "Currencies", comment: "Cuban Peso")
@@ -380,7 +382,8 @@ extension FiatCurrency {
 		case .cdf   : return "🇨🇩" // Congolese Franc
 		case .chf   : return "🇨🇭" // Swiss Franc
 		case .clp   : return "🇨🇱" // Chilean Peso
-		case .cny   : return "🇨🇳" // Chinese Yuan
+		case .cnh   : return "🇨🇳" // Chinese Yuan (offshore)
+		case .cny   : return "🇨🇳" // Chinese Yuan (onshore)
 		case .cop   : return "🇨🇴" // Colombian Peso
 		case .crc   : return "🇨🇷" // Costa Rican Colón
 		case .cup   : return "🇨🇺" // Cuban Peso

--- a/phoenix-ios/phoenix-ios/views/html/Base.lproj/about.html
+++ b/phoenix-ios/phoenix-ios/views/html/Base.lproj/about.html
@@ -29,8 +29,10 @@
 </p>
 <ul>
 	<li>Blockchain.info</li>
-	<li>Bitso</li>
+	<li>Coinbase</li>
 	<li><a href="https://coindesk.com/price/bitcoin">Powered by Coindesk</a></li>
+	<li><a href="https://bluelytics.com.ar/#!/">Bluelytics</a></li>
+	<li><a href="https://yadio.io/">Yadio</a></li>
 </ul>
 </body>
 </html>

--- a/phoenix-ios/phoenix-ios/views/html/ar.lproj/about.html
+++ b/phoenix-ios/phoenix-ios/views/html/ar.lproj/about.html
@@ -27,8 +27,10 @@
 </p>
 <ul>
 	<li>Blockchain.info</li>
-	<li>Bitso</li>
+	<li>Coinbase</li>
 	<li><a href="https://coindesk.com/price/bitcoin">مدعوم من Coindesk</a></li>
+	<li><a href="https://bluelytics.com.ar/#!/">Bluelytics</a></li>
+	<li><a href="https://yadio.io/">Yadio</a></li>
 </ul>
 </body>
 </html>

--- a/phoenix-ios/phoenix-ios/views/html/cs.lproj/about.html
+++ b/phoenix-ios/phoenix-ios/views/html/cs.lproj/about.html
@@ -28,8 +28,10 @@
 </p>
 <ul>
 	<li>Blockchain.info</li>
-	<li>Bitso</li>
+	<li>Coinbase</li>
 	<li><a href="https://coindesk.com/price/bitcoin">Powered by Coindesk</a></li>
+	<li><a href="https://bluelytics.com.ar/#!/">Bluelytics</a></li>
+	<li><a href="https://yadio.io/">Yadio</a></li>
 </ul>
 </body>
 </html>

--- a/phoenix-ios/phoenix-ios/views/html/es.lproj/about.html
+++ b/phoenix-ios/phoenix-ios/views/html/es.lproj/about.html
@@ -28,8 +28,10 @@
 </p>
 <ul>
 	<li>Blockchain.info</li>
-	<li>Bitso</li>
+	<li>Coinbase</li>
 	<li><a href="https://coindesk.com/price/bitcoin">Desarrollado por Coindesk</a></li>
+	<li><a href="https://bluelytics.com.ar/#!/">Bluelytics</a></li>
+	<li><a href="https://yadio.io/">Yadio</a></li>
 </ul>
 </body>
 </html>

--- a/phoenix-ios/phoenix-ios/views/html/fr.lproj/about.html
+++ b/phoenix-ios/phoenix-ios/views/html/fr.lproj/about.html
@@ -23,8 +23,10 @@
 </p>
 <ul>
 	<li>Blockchain.info</li>
-	<li>Bitso</li>
+	<li>Coinbase</li>
 	<li><a href="https://coindesk.com/price/bitcoin">Powered by Coindesk</a></li>
+	<li><a href="https://bluelytics.com.ar/#!/">Bluelytics</a></li>
+	<li><a href="https://yadio.io/">Yadio</a></li>
 </ul>
 </body>
 </html>

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
@@ -65,7 +65,8 @@ enum class FiatCurrency : CurrencyUnit {
     CDF, // Congolese Franc
     CHF, // Swiss Franc
     CLP, // Chilean Peso
-    CNY, // Chinese Yuan
+    CNH, // Chinese Yuan (offshore)
+    CNY, // Chinese Yuan (onshore)
     COP, // Colombian Peso
     CRC, // Costa Rican Colón
     CUP, // Cuban Peso

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
@@ -126,7 +126,6 @@ enum class FiatCurrency : CurrencyUnit {
     MMK, // Myanma Kyat
     MNT, // Mongolian Tugrik
     MOP, // Macanese Pataca
-    MTL, // Maltese Lira
     MUR, // Mauritian Rupee
     MVR, // Maldivian Rufiyaa
     MWK, // Malawian Kwacha

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
@@ -70,6 +70,7 @@ enum class FiatCurrency : CurrencyUnit {
     COP, // Colombian Peso
     CRC, // Costa Rican Colón
     CUP, // Cuban Peso
+    CUP_FM, // Cuban Peso (free market)
     CVE, // Cape Verdean Escudo
     CZK, // Czech Republic Koruna
     DJF, // Djiboutian Franc

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/ExchangeRates.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/ExchangeRates.kt
@@ -198,3 +198,23 @@ data class BluelyticsResponse(
         val value_buy: Double
     )
 }
+
+/**
+ * Yadio example:
+ * {
+ *   "BTC": 16640.86,
+ *   "USD": {
+ *     "CUP": 170,
+ *     "IRR": 4063500,
+ *     ...
+ *   },
+ *   "base": "USD",
+ *   "timestamp": 1672776301979
+ * }
+ */
+
+@Serializable
+data class YadioResponse(
+    @SerialName("USD")
+    val usdRates: Map<String, Double>
+)

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/ExchangeRates.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/ExchangeRates.kt
@@ -1,5 +1,7 @@
 package fr.acinq.phoenix.data
 
+import fr.acinq.phoenix.controllers.MVI
+import fr.acinq.phoenix.controllers.main.Home
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -62,7 +64,33 @@ sealed class ExchangeRate {
     }
 }
 
-@Serializable data class BlockchainInfoPriceObject(val last: Double)
+/**
+ * Blockchain.info example:
+ * {
+ *   "ARS": {
+ *     "15m": 5453151.01,
+ *     "last": 5453151.01,
+ *     "buy": 5453151.01,
+ *     "sell": 5453151.01,
+ *     "symbol": "ARS"
+ *   },
+ *   "AUD": {
+ *     "15m": 24869.41,
+ *     "last": 24869.41,
+ *     "buy": 24869.41,
+ *     "sell": 24869.41,
+ *     "symbol": "AUD"
+ *   },
+ *   ...
+ * }
+ */
+
+@Serializable
+data class BlockchainInfoPriceObject(
+    val last: Double
+)
+
+typealias BlockchainInfoResponse = Map<String, BlockchainInfoPriceObject>
 
 /**
  * Coinbase example:

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/ExchangeRates.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/ExchangeRates.kt
@@ -65,6 +65,30 @@ sealed class ExchangeRate {
 @Serializable data class BlockchainInfoPriceObject(val last: Double)
 
 /**
+ * Coinbase example:
+ * {
+ *   "data": {
+ *     "currency": "USD",
+ *     "rates": {
+ *       "AED": "3.6726399999999999",
+ *       "AFN": "89.2213",
+ *       ...
+ *     }
+ *   }
+ * }
+ */
+
+@Serializable
+data class CoinbaseResponse(
+    val data: Data,
+) {
+    @Serializable
+    data class Data(
+        val rates: Map<String, String>
+    )
+}
+
+/**
  * Coindesk example:
  * {
  *   "time":{

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/CurrencyManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/CurrencyManager.kt
@@ -105,7 +105,8 @@ class CurrencyManager(
     }
 
     /**
-     * The blockchain.info API is used to refresh the BitcoinPriceRates.
+     * The blockchain.info API is used to refresh the BitcoinPriceRates, using high liquidity markets
+     * currencies (i.e. USD/EUR).
      * Since bitcoin prices are volatile, we refresh them often.
      */
     private val blockchainInfoAPI = object : API {
@@ -131,7 +132,7 @@ class CurrencyManager(
     }
 
     /**
-     * The coindesk API is used to refresh select UsdPriceRates.
+     * The coindesk API is used to refresh select UsdPriceRates that are not available from Coinbase.
      * Since fiat prices are less volatile, we refresh them less often.
      * Also, the source only refreshes the values once per hour.
      */


### PR DESCRIPTION
We've had multiple reports of the CoinDesk exchange rates being inaccurate, most recently in issue #304.

I can attest to this personally, as I've noticed that the exchange rate for COP (Colombian Peso) has been very inaccurate recently. For example, the other day:

- coindesk: 1 USD = 4,219 COP
- actual rate: 1 USD = 4,757 COP

The raw JSON from the coindesk feed contains this disclaimer:

> "This data was produced from the CoinDesk Bitcoin Price Index (USD). Non-USD currency data converted using hourly conversion rate from openexchangerates.org"

However, if I pull directly from the source, I get very different exchange rates:

- direct from CoinDesk API: 1 USD = 4,218.99 COP
- direct from OpenExchangerRates API: 1 USD = 4,765.08 COP

So the OpenExchangeRates API has an accurate value, while CoinDesk does not. So if CoinDesk is indeed pulling from this source, then they're doing so poorly. It may be that they're no longer updating those rates...

Thus I went looking for alternative sources. The trouble is that most of the well-known sources for fiat exchange rates (e.g. OpenExchangeRates.org) are either not free, or their free service requires registration, and your account token is rate-limited (e.g. 1,000 API requests per month).

One possible solution to this would be to aggregate these exchange rates server-side, and provide an API to Phoenix clients. We can ponder the pros and cons of this approach later. For now, I've discovered an alternative solution: the Coinbase API

Coinbase's free & public API supports all the same currencies we were using Coindesk for... except certain countries that the USA is sanctioning:

- CUP: Cuban Peso
- ERN: Eritrean Nakfa
- IRR: Iranian Rial
- KPW: North Korean Won
- SDG: Sudanese Pound
- SOS: Somali Shilling
- SYP: Syrian Pound

So what I've done is replace coindesk with coinbase for all the other fiat currencies. That means 142 currencies that were previously using Coindesk, and getting stale exchange rates, are now using coinbase and getting accurate exchange rates.

For the 7 currencies listed above... well... we're still using coindesk for them :man_shrugging:

Other technical notes:

- I removed the "Maltese Lira", as they adopted the Euro back in January 2008
- I added CNH, which is the Chinese Yuan (offshore market) rate. We had a request for this on Jitbit awhile back.
- I also added CUP_FM, which is the Cuban Peso (free market) rate. From issue #298.
