### PR TITLE
Check invoices' expiry in shared module

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/ScanDataView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/ScanDataView.kt
@@ -275,6 +275,7 @@ private fun ScanErrorView(
     onErrorDialogDismiss: () -> Unit,
 ) {
     val errorMessage = when (model.reason) {
+        is Scan.BadRequestReason.Expired -> stringResource(R.string.scan_error_expired)
         is Scan.BadRequestReason.ChainMismatch -> stringResource(R.string.scan_error_invalid_chain)
         is Scan.BadRequestReason.AlreadyPaidInvoice -> stringResource(R.string.scan_error_already_paid)
         is Scan.BadRequestReason.ServiceError -> stringResource(R.string.scan_error_lnurl_service_error)

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -156,8 +156,7 @@
     <string name="scan_request_camera_access">Grant camera permission</string>
     <string name="scan_instructions">Scan a QR code containing a payment request, a Bitcoin address or a LNURL</string>
 
-    <string name="scan_error_expired">Payment has expired.</string>
-    <string name="scan_error_pay_to_self">You cannot pay yourself.</string>
+    <string name="scan_error_expired">This invoice is expired.</string>
     <string name="scan_error_already_paid">This payment has already been paid.</string>
     <string name="scan_error_invalid_chain">This payment does not use the same blockchain as your wallet.</string>
     <string name="scan_error_lnurl_invalid">Failed to process this LNURL link. Make sure it is valid.</string>

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinTypes.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinTypes.swift
@@ -70,6 +70,7 @@ extension Scan {
 	typealias LnurlWithdraw_Error = LnurlWithdrawError
 	typealias LnurlWithdraw_Error_RemoteError = LnurlWithdrawErrorRemoteError
 
+	typealias BadRequestReason_Expired = BadRequestReasonExpired
 	typealias BadRequestReason_AlreadyPaidInvoice = BadRequestReasonAlreadyPaidInvoice
 	typealias BadRequestReason_ChainMismatch = BadRequestReasonChainMismatch
 	typealias BadRequestReason_InvalidLnurl = BadRequestReasonInvalidLnurl

--- a/phoenix-ios/phoenix-ios/views/send/PaymentSummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/PaymentSummaryView.swift
@@ -204,7 +204,6 @@ struct PaymentSummaryView: View {
 			switch problem {
 				case .emptyInput: shouldDisplay = false
 				case .invalidInput: shouldDisplay = false
-				case .expiredInvoice: shouldDisplay = false
 				case .amountOutOfRange: shouldDisplay = true // problem might be the tip
 				case .amountExceedsBalance: shouldDisplay = true // problem might be the tip
 				case .finalAmountExceedsBalance: shouldDisplay = true // problem is miner fee

--- a/phoenix-ios/phoenix-ios/views/send/SendView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/SendView.swift
@@ -133,7 +133,14 @@ struct SendView: MVIView {
 		log.trace("showErrorToast()")
 		
 		let msg: String
-		if let reason = model.reason as? Scan.BadRequestReason_ChainMismatch {
+		if model.reason is Scan.BadRequestReason_Expired {
+			
+			msg = NSLocalizedString(
+				"Invoice is expired",
+				comment: "Error message - scanning lightning invoice"
+			)
+			
+		} else if let reason = model.reason as? Scan.BadRequestReason_ChainMismatch {
 			
 			let requestChain = reason.requestChain?.name ?? "unknown"
 			msg = NSLocalizedString(

--- a/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
@@ -23,7 +23,6 @@ struct PaymentNumbers {
 enum Problem: Error {
 	case emptyInput
 	case invalidInput
-	case expiredInvoice
 	case amountExceedsBalance
 	case finalAmountExceedsBalance // including minerFee
 	case amountOutOfRange
@@ -489,7 +488,6 @@ struct ValidateView: View {
 				case .amountOutOfRange: return true
 				case .amountExceedsBalance: return true
 				case .finalAmountExceedsBalance: return false // problem isn't amount, it's the minerFee
-				case .expiredInvoice: return false // problem isn't amount, it's the invoice
 			}
 			
 		} else {
@@ -1057,16 +1055,6 @@ struct ValidateView: View {
 						problem = .finalAmountExceedsBalance
 						altAmount = NSLocalizedString("Total amount exceeds your balance", comment: "error message")
 					}
-				}
-			}
-			
-			if let paymentRequest = paymentRequest(),
-			   let expiryTimestampSeconds = paymentRequest.expiryTimestampSeconds()?.doubleValue,
-			   Date(timeIntervalSince1970: expiryTimestampSeconds) <= Date()
-			{
-				if problem == nil {
-					problem = .expiredInvoice
-					altAmount = NSLocalizedString("Invoice is expired", comment: "error message")
 				}
 			}
 			

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/Scan.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/Scan.kt
@@ -36,6 +36,7 @@ object Scan {
     sealed class BadRequestReason {
         object UnknownFormat : BadRequestReason()
         object AlreadyPaidInvoice : BadRequestReason()
+        data class Expired(val timestampSeconds: Long, val expirySeconds: Long) : BadRequestReason()
         data class ChainMismatch(val myChain: Chain, val requestChain: Chain?) : BadRequestReason()
         data class ServiceError(val url: Url, val error: LnurlError.RemoteFailure) : BadRequestReason()
         data class InvalidLnurl(val url: Url) : BadRequestReason()

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/ScanController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/ScanController.kt
@@ -27,10 +27,7 @@ import fr.acinq.lightning.blockchain.fee.FeeratePerKw
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.io.*
 import fr.acinq.lightning.payment.PaymentRequest
-import fr.acinq.lightning.utils.UUID
-import fr.acinq.lightning.utils.sat
-import fr.acinq.lightning.utils.secure
-import fr.acinq.lightning.utils.toMilliSatoshi
+import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.SwapOutRequest
 import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.controllers.AppController
@@ -581,6 +578,10 @@ class AppScanController(
         val requestChain = paymentRequest.chain()
         if (chain != requestChain) {
             return Scan.BadRequestReason.ChainMismatch(chain, requestChain)
+        }
+
+        if (paymentRequest.isExpired(currentTimestampSeconds())) {
+            return Scan.BadRequestReason.Expired(paymentRequest.timestampSeconds, paymentRequest.expirySeconds ?: PaymentRequest.DEFAULT_EXPIRY_SECONDS.toLong())
         }
 
         val db = databaseManager.databases.filterNotNull().first()


### PR DESCRIPTION
The scan controller is tasked with checking scanned payment requests, for example what chain is used, or if the payment has already been paid. It now also checks if the invoice is expired, using the `PaymentRequest.isExpired()` method from lightning-kmp.

@robbiehanson On iOS this check is done in [Swift](https://github.com/ACINQ/phoenix/blob/31e5061a648e365c8298a4a38623b1a0a7bb3f89/phoenix-ios/phoenix-ios/views/send/ValidateView.swift#L1063-L1071). I think it's better to do that in the shared controller.