### PR TITLE
Simple CSV export for transaction history

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/AppView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/AppView.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -32,10 +31,7 @@ import androidx.navigation.compose.composable
 import fr.acinq.phoenix.android.home.*
 import fr.acinq.phoenix.android.init.*
 import fr.acinq.phoenix.android.intro.IntroView
-import fr.acinq.phoenix.android.payments.PaymentDetailsView
-import fr.acinq.phoenix.android.payments.PaymentsHistoryView
-import fr.acinq.phoenix.android.payments.ReceiveView
-import fr.acinq.phoenix.android.payments.ScanDataView
+import fr.acinq.phoenix.android.payments.*
 import fr.acinq.phoenix.android.service.WalletState
 import fr.acinq.phoenix.android.settings.*
 import fr.acinq.phoenix.android.utils.appBackground
@@ -205,10 +201,14 @@ fun AppView(
                 }
                 composable(Screen.PaymentsHistory.route) {
                     PaymentsHistoryView(
-                        onBackClick = { navController.popBackStack() },
+                        onBackClick = { popToHome(navController) },
                         paymentsViewModel = paymentsViewModel,
-                        onPaymentClick = { navigateToPaymentDetails(navController, id = it, isFromEvent = false) }
+                        onPaymentClick = { navigateToPaymentDetails(navController, id = it, isFromEvent = false) },
+                        onCsvExportClick = { navController.navigate(Screen.PaymentsCsvExport) },
                     )
+                }
+                composable(Screen.PaymentsCsvExport.route) {
+                    CsvExportView(onBackClick = { navController.navigate(Screen.PaymentsHistory.route) })
                 }
                 composable(Screen.Settings.route) {
                     SettingsView()

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/Navigation.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/Navigation.kt
@@ -38,6 +38,7 @@ sealed class Screen(val route: String) {
     object ScanData : Screen("readdata")
     object PaymentDetails : Screen("payments")
     object PaymentsHistory : Screen("payments/all")
+    object PaymentsCsvExport : Screen("payments/export")
 
     // -- settings
     object Settings : Screen("settings")

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/CalendarView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/CalendarView.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android.components
+
+import android.widget.CalendarView
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import fr.acinq.lightning.utils.currentTimestampMillis
+import fr.acinq.phoenix.android.R
+import fr.acinq.phoenix.android.utils.Converter.toAbsoluteDateString
+import fr.acinq.phoenix.android.utils.mutedBgColor
+import kotlinx.datetime.*
+
+/**
+ * Calendar component to pick a day. [onDateSelected] returns the timestamp in millis at the
+ * **start** of day.
+ */
+@Composable
+fun CalendarView(
+    label: String,
+    buttonBackgroundColor: Color = mutedBgColor(),
+    initialTimestampMillis: Long = currentTimestampMillis(),
+    dialogTitle: String? = null,
+    onDateSelected: (Long) -> Unit,
+    enabled: Boolean,
+) {
+    var showCalendar by remember { mutableStateOf(false) }
+    var timestampMillis by remember { mutableStateOf(initialTimestampMillis) }
+
+    Row {
+        Text(
+            text = label,
+            modifier = Modifier.alignByBaseline()
+        )
+        Spacer(Modifier.width(2.dp))
+        Text(
+            text = stringResource(id = R.string.component_calendar_inclusive),
+            style = MaterialTheme.typography.caption.copy(fontSize = 14.sp),
+            modifier = Modifier.alignByBaseline()
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Button(
+            icon = R.drawable.ic_calendar,
+            text = timestampMillis.toAbsoluteDateString(),
+            onClick = { showCalendar = true },
+            backgroundColor = buttonBackgroundColor,
+            padding = PaddingValues(8.dp),
+            space = 8.dp,
+            enabled = enabled,
+            shape = RoundedCornerShape(8.dp),
+            modifier = Modifier.alignByBaseline()
+        )
+    }
+    if (showCalendar) {
+        Dialog(onDismiss = { showCalendar = false }, title = dialogTitle) {
+            AndroidView(
+                modifier = Modifier.wrapContentSize(),
+                factory = {
+                    CalendarView(it)
+                },
+                update = { view ->
+                    view.date = timestampMillis
+                    view.setOnDateChangeListener { _, year, month, dayOfMonth ->
+                        timestampMillis = LocalDate(year, month + 1, dayOfMonth).atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+                        onDateSelected(timestampMillis)
+                        showCalendar = false
+                    }
+                }
+            )
+        }
+    }
+}

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/ErrorMessage.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/ErrorMessage.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import fr.acinq.phoenix.android.R
+import fr.acinq.phoenix.android.utils.negativeColor
+
+@Composable
+fun ErrorMessage(
+    errorHeader: String,
+    errorDetails: String? = null,
+    padding: PaddingValues = PaddingValues(16.dp),
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier.padding(padding)) {
+        TextWithIcon(
+            text = errorHeader,
+            icon = R.drawable.ic_alert_triangle,
+            iconTint = negativeColor(),
+            maxLines = 1,
+            textOverflow = TextOverflow.Ellipsis
+        )
+        if (errorDetails != null) {
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = stringResource(id = R.string.component_error_message_details, errorDetails),
+                modifier = Modifier.padding(start = 24.dp),
+                style = MaterialTheme.typography.caption
+            )
+        }
+    }
+}

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Layout.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Layout.kt
@@ -86,6 +86,22 @@ fun DefaultScreenHeader(
     onBackClick: () -> Unit,
     backgroundColor: Color = MaterialTheme.colors.background,
 ) {
+    DefaultScreenHeader(
+        content = {
+            title?.let { Text(text = it) }
+        },
+        onBackClick = onBackClick,
+        backgroundColor = backgroundColor
+    )
+}
+
+/** The default header of a screen contains a back button and some content. */
+@Composable
+fun DefaultScreenHeader(
+    content: @Composable RowScope.() -> Unit,
+    onBackClick: () -> Unit,
+    backgroundColor: Color = MaterialTheme.colors.background,
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -94,9 +110,7 @@ fun DefaultScreenHeader(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         BackButton(onClick = onBackClick)
-        title?.let {
-            Text(text = it)
-        }
+        content()
     }
 }
 

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Switch.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Switch.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 ACINQ SAS
+ * Copyright 2023 ACINQ SAS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Checkbox
+import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.*
@@ -34,35 +34,35 @@ import fr.acinq.phoenix.android.utils.gray300
 import fr.acinq.phoenix.android.utils.gray600
 
 @Composable
-fun Checkbox(
-    text: String,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
+fun SwitchView(
     modifier: Modifier = Modifier,
+    text: String,
     enabled: Boolean = true,
-    padding: PaddingValues = PaddingValues(vertical = 16.dp, horizontal = 0.dp)
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit),
 ) {
     var internalChecked by rememberSaveable { mutableStateOf(checked) }
     val interactionSource = remember { MutableInteractionSource() }
     Row(
         modifier = modifier
-            .enableOrFade(enabled)
-            .clickable(interactionSource = interactionSource, indication = null, role = Role.Checkbox) {
+            .clickable(interactionSource = interactionSource, indication = null, role = Role.Checkbox, enabled = enabled) {
                 internalChecked = !internalChecked
                 onCheckedChange(internalChecked)
-            }
-            .padding(padding),
+            },
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Checkbox(
-            checked = internalChecked,
+        Text(text = text)
+        Spacer(Modifier.weight(1f))
+        Switch(
+            checked = checked,
             onCheckedChange = null,
-            modifier = Modifier.indication(
-                interactionSource = interactionSource,
-                indication = rememberRipple(bounded = false, color = if (isDarkTheme) gray300 else gray600, radius = 28.dp)
-            )
+            modifier = Modifier
+                .enableOrFade(enabled)
+                .padding(vertical = 6.dp)
+                .indication(
+                    interactionSource = interactionSource,
+                    indication = rememberRipple(bounded = false, color = if (isDarkTheme) gray300 else gray600, radius = 28.dp)
+                )
         )
-        Spacer(Modifier.width(12.dp))
-        Text(text)
     }
 }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/CsvExportView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/CsvExportView.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android.payments
+
+import android.text.format.DateUtils
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import fr.acinq.phoenix.android.R
+import fr.acinq.phoenix.android.business
+import fr.acinq.phoenix.android.components.*
+import fr.acinq.phoenix.android.utils.Converter.toBasicAbsoluteDateString
+import fr.acinq.phoenix.android.utils.logger
+import fr.acinq.phoenix.android.utils.positiveColor
+import fr.acinq.phoenix.android.utils.shareFile
+import fr.acinq.phoenix.db.SqlitePaymentsDb
+
+
+@Composable
+fun CsvExportView(
+    onBackClick: () -> Unit,
+) {
+    val log = logger("CsvExportView")
+    val context = LocalContext.current
+    val vm: CsvExportViewModel = viewModel(
+        factory = CsvExportViewModel.Factory(
+            peerManager = business.peerManager,
+            paymentsDb = business.databaseManager.databases.value!!.payments as SqlitePaymentsDb,
+            paymentsFetcher = business.paymentsManager.fetcher,
+        )
+    )
+    val startTimestamp = vm.startTimestampMillis
+    val endTimestamp = vm.endTimestampMillis
+    DefaultScreenLayout {
+        DefaultScreenHeader(onBackClick = onBackClick, title = stringResource(R.string.payments_export_title))
+        Card(internalPadding = PaddingValues(16.dp)) {
+            Text(text = stringResource(id = R.string.payments_export_instructions))
+            Spacer(Modifier.height(16.dp))
+            if (startTimestamp != null) {
+                CalendarView(
+                    label = stringResource(id = R.string.payments_export_start_label),
+                    initialTimestampMillis = startTimestamp,
+                    onDateSelected = {
+                        vm.reset()
+                        vm.startTimestampMillis = it
+                    },
+                    enabled = vm.state !is CsvExportState.Generating,
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            CalendarView(
+                label = stringResource(id = R.string.payments_export_end_label),
+                initialTimestampMillis = endTimestamp,
+                onDateSelected = {
+                    vm.reset()
+                    // timestamp returned by the calendar is at the start of day
+                    vm.endTimestampMillis = it + DateUtils.DAY_IN_MILLIS - 1_000
+                },
+                enabled = vm.state !is CsvExportState.Generating,
+            )
+            Spacer(Modifier.height(8.dp))
+            SwitchView(
+                text = stringResource(id = R.string.payments_export_context_label),
+                enabled = vm.state !is CsvExportState.Generating,
+                checked = vm.includesOriginDestination,
+                onCheckedChange = {
+                    vm.reset()
+                    vm.includesOriginDestination = it
+                },
+                modifier = Modifier.padding(vertical = 4.dp),
+            )
+            SwitchView(
+                text = stringResource(id = R.string.payments_export_description_label),
+                enabled = vm.state !is CsvExportState.Generating,
+                checked = vm.includesDescription && vm.includesNotes,
+                onCheckedChange = {
+                    vm.reset()
+                    vm.includesDescription = it
+                    vm.includesNotes = it
+                },
+                modifier = Modifier.padding(vertical = 4.dp)
+            )
+        }
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            when (val state = vm.state) {
+                CsvExportState.Init, is CsvExportState.Failed, is CsvExportState.NoData -> {
+                    if (startTimestamp == null) {
+                        TextWithIcon(
+                            text = stringResource(id = R.string.payments_export_initializing),
+                            icon = R.drawable.ic_info,
+                            padding = PaddingValues(16.dp),
+                        )
+                    } else if (startTimestamp > endTimestamp) {
+                        ErrorMessage(errorHeader = stringResource(id = R.string.payments_export_invalid_timestamps))
+                    } else {
+                        if (state is CsvExportState.Failed) {
+                            ErrorMessage(
+                                errorHeader = stringResource(id = R.string.payments_export_error),
+                                errorDetails = state.error.localizedMessage,
+                            )
+                        } else if (state is CsvExportState.NoData) {
+                            ErrorMessage(errorHeader = stringResource(id = R.string.payments_export_no_data))
+                        }
+                        Button(
+                            text = stringResource(id = R.string.payments_export_generate_button),
+                            icon = R.drawable.ic_build,
+                            onClick = { vm.generateCSV(context) },
+                            modifier = Modifier.fillMaxWidth(),
+                            padding = PaddingValues(16.dp)
+                        )
+                    }
+                }
+                is CsvExportState.Generating -> {
+                    ProgressView(text = stringResource(id = R.string.payments_export_in_progress, state.exportedCount))
+                }
+                is CsvExportState.Success -> {
+                    TextWithIcon(
+                        text = stringResource(id = R.string.payments_export_success, state.paymentsCount),
+                        icon = R.drawable.ic_check,
+                        iconTint = positiveColor(),
+                        modifier = Modifier.padding(16.dp)
+                    )
+                    Button(
+                        text = stringResource(R.string.payments_export_share_button),
+                        icon = R.drawable.ic_share,
+                        onClick = {
+                            shareFile(
+                                context, data = state.uri,
+                                subject = context.getString(
+                                    R.string.payments_export_share_subject,
+                                    startTimestamp?.toBasicAbsoluteDateString() ?: "N/A", endTimestamp.toBasicAbsoluteDateString()
+                                ),
+                                chooserTitle = context.getString(R.string.payments_export_share_title),
+                                mimeType = "text/csv"
+                            )
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+    }
+}

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/CsvExportViewModel.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/CsvExportViewModel.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android.payments
+
+
+import android.content.Context
+import android.net.Uri
+import androidx.compose.runtime.*
+import androidx.core.content.FileProvider
+import androidx.lifecycle.*
+import fr.acinq.lightning.utils.currentTimestampMillis
+import fr.acinq.phoenix.android.BuildConfig
+import fr.acinq.phoenix.android.utils.Converter.toAbsoluteDateTimeString
+import fr.acinq.phoenix.android.utils.smartDescription
+import fr.acinq.phoenix.data.*
+import fr.acinq.phoenix.db.*
+import fr.acinq.phoenix.managers.*
+import fr.acinq.phoenix.utils.*
+import kotlinx.coroutines.*
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.io.FileWriter
+
+sealed class CsvExportState {
+    object Init : CsvExportState()
+    data class Generating(val exportedCount: Int) : CsvExportState()
+    data class Success(val paymentsCount: Int, val uri: Uri) : CsvExportState()
+    object NoData : CsvExportState()
+    data class Failed(val error: Throwable) : CsvExportState()
+}
+
+class CsvExportViewModel(
+    private val peerManager: PeerManager,
+    private val paymentsDb: SqlitePaymentsDb,
+    private val paymentsFetcher: PaymentsFetcher,
+) : ViewModel() {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    /** Timestamp in millis of the oldest completed payment (incoming or outgoing) */
+    var oldestCompletedTimestamp by mutableStateOf<Long?>(null)
+        private set
+    var startTimestampMillis by mutableStateOf<Long?>(null)
+    var endTimestampMillis by mutableStateOf(currentTimestampMillis())
+    var includesFiat by mutableStateOf(true)
+    var includesDescription by mutableStateOf(true)
+    var includesNotes by mutableStateOf(true)
+    var includesOriginDestination by mutableStateOf(true)
+    var state by mutableStateOf<CsvExportState>(CsvExportState.Init)
+        private set
+
+    private val authority = "${BuildConfig.APPLICATION_ID}.provider"
+
+    init {
+        refreshOldestCompletedTimestamp()
+    }
+
+    fun reset() {
+        state = CsvExportState.Init
+    }
+
+    fun generateCSV(context: Context) {
+        viewModelScope.launch(Dispatchers.IO + CoroutineExceptionHandler { _, e ->
+            log.error("failed to generate CSV: ", e)
+            state = CsvExportState.Failed(e)
+        }) {
+            if (state is CsvExportState.Generating) return@launch
+            if (startTimestampMillis == null) throw IllegalArgumentException("start timestamp is undefined")
+            val swapInAddress = peerManager.getPeer().swapInAddress
+            state = CsvExportState.Generating(exportedCount = 0)
+            val csvConfig = CsvWriter.Configuration(
+                includesFiat = includesFiat,
+                includesDescription = includesDescription,
+                includesNotes = includesNotes,
+                includesOriginDestination = includesOriginDestination,
+                swapInAddress = swapInAddress
+            )
+            log.debug("exporting payments data between start=${startTimestampMillis?.toAbsoluteDateTimeString()} end=${endTimestampMillis.toAbsoluteDateTimeString()} config=$csvConfig")
+            val batchSize = 32
+            var batchOffset = 0
+            var fetching = true
+            val rows = mutableListOf<String>()
+            rows += CsvWriter.makeHeaderRow(csvConfig)
+            while (fetching) {
+                paymentsDb.listRangeSuccessfulPaymentsOrder(
+                    startDate = startTimestampMillis!!,
+                    endDate = endTimestampMillis,
+                    count = batchSize,
+                    skip = batchOffset
+                ).map { paymentRow ->
+                    paymentsFetcher.getPayment(paymentRow, WalletPaymentFetchOptions.All)?.let { info ->
+                        val descriptions = listOf(
+                            info.payment.smartDescription(context),
+                            info.metadata.userDescription,
+                            info.metadata.lnurl?.pay?.metadata?.longDesc
+                        ).mapNotNull { it.takeIf { !it.isNullOrBlank() } }
+                        val row = CsvWriter.makeRow(
+                            info = info,
+                            localizedDescription = descriptions.joinToString("\n"),
+                            config = csvConfig
+                        )
+                        state = CsvExportState.Generating(rows.size - 1)
+                        rows += row
+                    }
+                }.let { result ->
+                    if (result.isEmpty()) {
+                        fetching = false
+                    } else {
+                        batchOffset += result.size
+                    }
+                }
+            }
+            val paymentsCount = rows.size - 1 // offset header row
+            if (paymentsCount <= 1) {
+                log.info("no data found for this export attempt")
+                state = CsvExportState.NoData
+            } else {
+                // create file & write to disk
+                val exportDir = File(context.cacheDir, "payments")
+                if (!exportDir.exists()) exportDir.mkdir()
+                val file = File.createTempFile("phoenix-", ".csv", exportDir)
+                val writer = FileWriter(file, true)
+                rows.forEach {
+                    writer.write(it)
+                }
+                writer.close()
+                val uri = FileProvider.getUriForFile(context, authority, file)
+                log.info("processed $paymentsCount payments to export")
+                state = CsvExportState.Success(paymentsCount, uri)
+            }
+        }
+    }
+
+    private fun refreshOldestCompletedTimestamp() {
+        viewModelScope.launch(Dispatchers.Main + CoroutineExceptionHandler { _, e ->
+            log.error("failed to get oldest completed payment timestamp: ", e)
+            state = CsvExportState.Failed(e)
+        }) {
+            paymentsDb.getOldestCompletedDate().let {
+                oldestCompletedTimestamp = it
+                if (startTimestampMillis == null) startTimestampMillis = it
+            }
+        }
+    }
+
+    class Factory(
+        private val peerManager: PeerManager,
+        private val paymentsDb: SqlitePaymentsDb,
+        private val paymentsFetcher: PaymentsFetcher,
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return CsvExportViewModel(peerManager, paymentsDb, paymentsFetcher) as T
+        }
+    }
+}

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/PaymentDetailsSplashView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/PaymentDetailsSplashView.kt
@@ -48,12 +48,9 @@ import fr.acinq.phoenix.android.LocalBitcoinUnit
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.business
 import fr.acinq.phoenix.android.components.*
-import fr.acinq.phoenix.android.utils.Converter.toAbsoluteDateString
+import fr.acinq.phoenix.android.utils.*
+import fr.acinq.phoenix.android.utils.Converter.toAbsoluteDateTimeString
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
-import fr.acinq.phoenix.android.utils.MSatDisplayPolicy
-import fr.acinq.phoenix.android.utils.mutedTextColor
-import fr.acinq.phoenix.android.utils.negativeColor
-import fr.acinq.phoenix.android.utils.positiveColor
 import fr.acinq.phoenix.data.WalletPaymentId
 import fr.acinq.phoenix.data.WalletPaymentInfo
 import fr.acinq.phoenix.utils.extensions.errorMessage
@@ -96,22 +93,7 @@ fun PaymentDetailsSplashView(
             )
             Spacer(modifier = Modifier.height(36.dp))
 
-            val paymentDesc = remember(payment) {
-                when (payment) {
-                    is OutgoingPayment -> when (val details = payment.details) {
-                        is OutgoingPayment.Details.Normal -> details.paymentRequest.description ?: details.paymentRequest.descriptionHash?.toHex()
-                        is OutgoingPayment.Details.ChannelClosing -> context.getString(R.string.paymentdetails_desc_closing_channel)
-                        is OutgoingPayment.Details.KeySend -> context.getString(R.string.paymentdetails_desc_keysend)
-                        is OutgoingPayment.Details.SwapOut -> context.getString(R.string.paymentdetails_desc_swapout, details.address)
-                    }
-                    is IncomingPayment -> when (val origin = payment.origin) {
-                        is IncomingPayment.Origin.Invoice -> origin.paymentRequest.description ?: origin.paymentRequest.descriptionHash?.toHex()
-                        is IncomingPayment.Origin.KeySend -> context.getString(R.string.paymentdetails_desc_keysend)
-                        is IncomingPayment.Origin.SwapIn, is IncomingPayment.Origin.DualSwapIn -> context.getString(R.string.paymentdetails_desc_swapin)
-                    }
-                    else -> null
-                }?.takeIf { it.isNotBlank() }
-            }
+            val paymentDesc = remember(payment) { payment.smartDescription(context) }
             val customDesc = remember(data) { data.metadata.userDescription?.takeIf { it.isNotBlank() } }
             DetailsRow(
                 label = stringResource(id = R.string.paymentdetails_desc_label),
@@ -242,7 +224,7 @@ private fun PaymentStatus(
                 imageResId = if (fromEvent) R.drawable.ic_payment_details_success_animated else R.drawable.ic_payment_details_success_static,
                 isAnimated = fromEvent,
                 color = positiveColor(),
-                details = payment.completedAt().toAbsoluteDateString()
+                details = payment.completedAt().toAbsoluteDateTimeString()
             )
         }
         is IncomingPayment -> when {
@@ -267,7 +249,7 @@ private fun PaymentStatus(
                 imageResId = if (fromEvent) R.drawable.ic_payment_details_success_animated else R.drawable.ic_payment_details_success_static,
                 isAnimated = fromEvent,
                 color = positiveColor(),
-                details = payment.received?.receivedAt?.toAbsoluteDateString()
+                details = payment.received?.receivedAt?.toAbsoluteDateTimeString()
             )
         }
     }
@@ -381,3 +363,5 @@ private fun EditPaymentDetails(
         }
     }
 }
+
+

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/PaymentDetailsTechnicalView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/PaymentDetailsTechnicalView.kt
@@ -47,7 +47,7 @@ import fr.acinq.phoenix.android.components.Card
 import fr.acinq.phoenix.android.components.WebLink
 import fr.acinq.phoenix.android.components.txUrl
 import fr.acinq.phoenix.android.fiatRate
-import fr.acinq.phoenix.android.utils.Converter.toAbsoluteDateString
+import fr.acinq.phoenix.android.utils.Converter.toAbsoluteDateTimeString
 import fr.acinq.phoenix.android.utils.Converter.toFiat
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 import fr.acinq.phoenix.android.utils.MSatDisplayPolicy
@@ -183,14 +183,14 @@ private fun TimestampSection(
 ) {
     if (payment.completedAt() > 0) {
         TechnicalRow(label = stringResource(id = R.string.paymentdetails_completed_at_label)) {
-            Text(text = payment.completedAt().toAbsoluteDateString())
+            Text(text = payment.completedAt().toAbsoluteDateTimeString())
         }
     }
 
     // show time to completion for outgoing payments, when relevant
     if (payment is OutgoingPayment && (payment.details is OutgoingPayment.Details.Normal || payment.details is OutgoingPayment.Details.ChannelClosing)) {
         TechnicalRow(label = stringResource(id = R.string.paymentdetails_created_at_label)) {
-            Text(text = payment.createdAt.toAbsoluteDateString())
+            Text(text = payment.createdAt.toAbsoluteDateTimeString())
         }
 
         if (payment.completedAt() > 0) {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/PaymentDetailsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/PaymentDetailsView.kt
@@ -19,12 +19,14 @@ package fr.acinq.phoenix.android.payments
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -118,10 +120,16 @@ fun PaymentDetailsView(
         )
         when (state) {
             is PaymentDetailsState.Loading -> CenterContentView {
-                Text(stringResource(id = R.string.paymentdetails_loading))
+                Text(
+                    text = stringResource(id = R.string.paymentdetails_loading),
+                    modifier = Modifier.padding(16.dp)
+                )
             }
             is PaymentDetailsState.Failure -> CenterContentView {
-                Text(stringResource(id = R.string.paymentdetails_error, state.error.message ?: stringResource(id = R.string.utils_unknown)))
+                Text(
+                    text = stringResource(id = R.string.paymentdetails_error, state.error.message ?: stringResource(id = R.string.utils_unknown)),
+                    modifier = Modifier.padding(16.dp),
+                )
             }
             is PaymentDetailsState.Success.Splash -> {
                 PaymentDetailsSplashView(

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/PaymentsHistoryView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/PaymentsHistoryView.kt
@@ -23,9 +23,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Text
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.*
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.*
-import androidx.compose.ui.Modifier
+import androidx.compose.ui.*
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -54,6 +55,7 @@ fun PaymentsHistoryView(
     onBackClick: () -> Unit,
     paymentsViewModel: PaymentsViewModel,
     onPaymentClick: (WalletPaymentId) -> Unit,
+    onCsvExportClick: () -> Unit,
 ) {
     val log = logger("PaymentsHistory")
     val listState = rememberLazyListState()
@@ -63,10 +65,23 @@ fun PaymentsHistoryView(
         val date = Instant.fromEpochMilliseconds(it.orderRow.completedAt ?: it.orderRow.createdAt).toLocalDateTime(TimeZone.currentSystemDefault())
         date.month to date.year
     }
+
     DefaultScreenLayout(
         isScrollable = false
     ) {
-        DefaultScreenHeader(onBackClick = onBackClick, title = stringResource(id = R.string.payments_history_title, allPaymentsCount))
+        DefaultScreenHeader(
+            content = {
+                Text(text =  stringResource(id = R.string.payments_history_title, allPaymentsCount))
+                Spacer(Modifier.weight(1f))
+                Button(
+                    text = stringResource(id = R.string.payments_history_export_button),
+                    icon = R.drawable.ic_share,
+                    shape = CircleShape,
+                    onClick = onCsvExportClick
+                )
+            },
+            onBackClick = onBackClick,
+        )
         Card(modifier = Modifier.weight(1f, fill = false)) {
             LaunchedEffect(key1 = listState) {
                 snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull() }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/LogsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/LogsView.kt
@@ -33,6 +33,7 @@ import fr.acinq.phoenix.android.components.SettingButton
 import fr.acinq.phoenix.android.navController
 import fr.acinq.phoenix.android.utils.Logging
 import fr.acinq.phoenix.android.utils.logger
+import fr.acinq.phoenix.android.utils.shareFile
 
 @Composable
 fun LogsView() {
@@ -69,15 +70,12 @@ fun LogsView() {
                 icon = R.drawable.ic_share,
                 onClick = {
                     val logFile = Logging.getLastLogFile(context)
-                    val uri = FileProvider.getUriForFile(context, authority, logFile)
-                    val sendIntent: Intent = Intent().apply {
-                        action = Intent.ACTION_SEND
-                        type = "text/plain"
-                        putExtra(Intent.EXTRA_STREAM, uri)
-                        putExtra(Intent.EXTRA_SUBJECT, context.getString(R.string.logs_share_subject))
-                    }
-                    val shareIntent = Intent.createChooser(sendIntent, null)
-                    context.startActivity(shareIntent)
+                    shareFile(
+                        context = context,
+                        data = FileProvider.getUriForFile(context, authority, logFile),
+                        subject = context.getString(R.string.logs_share_subject),
+                        chooserTitle = context.getString(R.string.logs_share_title)
+                    )
                 }
             )
         }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/Clipboard.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/Clipboard.kt
@@ -20,6 +20,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.widget.Toast
 import fr.acinq.phoenix.android.R
 
@@ -40,6 +41,17 @@ fun share(context: Context, data: String, subject: String, chooserTitle: String?
         type = "text/plain"
         putExtra(Intent.EXTRA_TEXT, data)
         putExtra(Intent.EXTRA_SUBJECT, subject)
+    }
+    context.startActivity(Intent.createChooser(shareIntent, chooserTitle))
+}
+
+fun shareFile(context: Context, data: Uri, subject: String, chooserTitle: String? = null, mimeType: String = "text/plain") {
+    val shareIntent = Intent().apply {
+        action = Intent.ACTION_SEND
+        type = mimeType
+        putExtra(Intent.EXTRA_STREAM, data)
+        putExtra(Intent.EXTRA_SUBJECT, subject)
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
     }
     context.startActivity(Intent.createChooser(shareIntent, chooserTitle))
 }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/Converter.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/Converter.kt
@@ -35,6 +35,7 @@ import java.math.RoundingMode
 import java.text.DateFormat
 import java.text.DecimalFormat
 import java.text.NumberFormat
+import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.math.abs
 
@@ -142,8 +143,14 @@ object Converter {
         }
     }
 
-    /** Converts this millis timestamp into an absolute string date using the locale format. */
-    fun Long.toAbsoluteDateString(): String = DateFormat.getDateTimeInstance().format(Date(this))
+    /** Converts this millis timestamp into a pretty, absolute string date time using the locale format. */
+    fun Long.toAbsoluteDateTimeString(): String = DateFormat.getDateTimeInstance().format(Date(this))
+
+    /** Converts this millis timestamp into a pretty, absolute string date using the locale format. */
+    fun Long.toAbsoluteDateString(): String = DateFormat.getDateInstance().format(Date(this))
+
+    /** Converts this millis timestamp into an year-month-day string. */
+    fun Long.toBasicAbsoluteDateString(): String = SimpleDateFormat("yyyy-MM-dd").format(Date(this))
 
     @Composable
     public fun html(id: Int): Spanned {

--- a/phoenix-android/src/main/res/drawable/ic_calendar.xml
+++ b/phoenix-android/src/main/res/drawable/ic_calendar.xml
@@ -1,0 +1,50 @@
+<!--
+  ~ Copyright 2023 ACINQ SAS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="@dimen/icon_size"
+    android:height="@dimen/icon_size"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M5,4L19,4A2,2 0,0 1,21 6L21,20A2,2 0,0 1,19 22L5,22A2,2 0,0 1,3 20L3,6A2,2 0,0 1,5 4z"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M16,2L16,6"
+        android:strokeWidth="2"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M8,2L8,6"
+        android:strokeWidth="2"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M3,10L21,10"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -717,6 +717,23 @@
 
     <string name="payments_history_title">My payments (%1$d)</string>
     <string name="payments_history_backup_notavailable">Payments backup is not available yet.</string>
+    <string name="payments_history_export_button">Export</string>
+    <string name="payments_export_title">Export Payments</string>
+    <string name="payments_export_instructions">Export your payment history in CSV (comma separated value) format.</string>
+    <string name="payments_export_start_label">Start date</string>
+    <string name="payments_export_end_label">End date</string>
+    <string name="payments_export_context_label">Include origin/destination</string>
+    <string name="payments_export_description_label">Include description</string>
+    <string name="payments_export_generate_button">Export</string>
+    <string name="payments_export_initializing">Checking payments timestamp</string>
+    <string name="payments_export_invalid_timestamps">Please pick a valid start/end date</string>
+    <string name="payments_export_in_progress">Exporting payment #%1$d</string>
+    <string name="payments_export_success">%1$d payments successfully exported</string>
+    <string name="payments_export_share_subject">Phoenix - payments from %1$s to %2$s</string>
+    <string name="payments_export_share_title">Share Phoenix payments…</string>
+    <string name="payments_export_share_button">Share file</string>
+    <string name="payments_export_error">Export has failed.</string>
+    <string name="payments_export_no_data">No payments found.</string>
 
     <!-- ////////////// currencies ////////////// -->
 
@@ -733,5 +750,9 @@
     <string name="intro_selfcustody_sub1">Phoenix is self-custodial. A backup phrase is generated, containing all the information needed to restore your Bitcoin funds.</string>
     <string name="intro_selfcustody_sub2">Keep this phrase safe and secret!</string>
     <string name="intro_selfcustody_next_button">Get started</string>
+
+    <!-- components -->
+    <string name="component_calendar_inclusive">(inclusive)</string>
+    <string name="component_error_message_details">Cause: %1$s</string>
 
 </resources>

--- a/phoenix-android/src/main/res/xml/provider_paths.xml
+++ b/phoenix-android/src/main/res/xml/provider_paths.xml
@@ -17,4 +17,5 @@
 
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
   <files-path name="logs_dir" path="logs" />
+  <cache-path name="csv_export" path="payments/" />
 </paths>

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		DC48D2C42593DE30008D138C /* TextFieldCurrencyStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC48D2C32593DE30008D138C /* TextFieldCurrencyStyler.swift */; };
 		DC49DA8E258BB882005BC4BC /* ScaledButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC49DA8D258BB882005BC4BC /* ScaledButtonStyle.swift */; };
 		DC59377127516297003B4B53 /* Sequence+Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC59377027516296003B4B53 /* Sequence+Sum.swift */; };
+		DC5A934F297F2AE4004F19FD /* CodableCSV in Frameworks */ = {isa = PBXBuildFile; productRef = DC5A934E297F2AE4004F19FD /* CodableCSV */; };
 		DC5AF4542677BBF7003C911B /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = DC5AF4522677BBF7003C911B /* InfoPlist.strings */; };
 		DC5AF4572677BBF7003C911B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DC5AF4552677BBF7003C911B /* Localizable.strings */; };
 		DC5CA4ED28F83C3B0048A737 /* DrainWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5CA4EC28F83C3B0048A737 /* DrainWalletView.swift */; };
@@ -142,6 +143,7 @@
 		DC74174B270F332700F7E3E3 /* KotlinTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC74174A270F332700F7E3E3 /* KotlinTypes.swift */; };
 		DC74174D270F455D00F7E3E3 /* AES256.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC74174C270F455D00F7E3E3 /* AES256.swift */; };
 		DC81B79F25BF2AA200F5A52C /* MVI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC81B79E25BF2AA200F5A52C /* MVI.swift */; };
+		DC82EED629789853007A5853 /* TxHistoryExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC82EED529789853007A5853 /* TxHistoryExporter.swift */; };
 		DC87806F292D69C90061715B /* IncomingDepositPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC87806E292D69C90061715B /* IncomingDepositPopover.swift */; };
 		DC89857F25914747007B253F /* UIApplicationState+Phoenix.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC89857E25914747007B253F /* UIApplicationState+Phoenix.swift */; };
 		DC9473FA261270B4008D7242 /* MVI+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9473F9261270B4008D7242 /* MVI+Mock.swift */; };
@@ -443,6 +445,7 @@
 		DC74174A270F332700F7E3E3 /* KotlinTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinTypes.swift; sourceTree = "<group>"; };
 		DC74174C270F455D00F7E3E3 /* AES256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AES256.swift; sourceTree = "<group>"; };
 		DC81B79E25BF2AA200F5A52C /* MVI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MVI.swift; sourceTree = "<group>"; };
+		DC82EED529789853007A5853 /* TxHistoryExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxHistoryExporter.swift; sourceTree = "<group>"; };
 		DC87806E292D69C90061715B /* IncomingDepositPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncomingDepositPopover.swift; sourceTree = "<group>"; };
 		DC89857E25914747007B253F /* UIApplicationState+Phoenix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplicationState+Phoenix.swift"; sourceTree = "<group>"; };
 		DC9473F9261270B4008D7242 /* MVI+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MVI+Mock.swift"; sourceTree = "<group>"; };
@@ -539,6 +542,7 @@
 			files = (
 				DCD71A79273987FE00B9A1EF /* Focuser in Frameworks */,
 				DC46BAE426C6FDD300E760A6 /* CircularCheckmarkProgress in Frameworks */,
+				DC5A934F297F2AE4004F19FD /* CodableCSV in Frameworks */,
 				DCC9D99C267BEB3D00EA36DD /* CloudKit.framework in Frameworks */,
 				DC39D4E5286B4A7E0030F18D /* Popovers in Frameworks */,
 				DCC46F1625C3521C005D32D9 /* FirebaseMessaging in Frameworks */,
@@ -1078,6 +1082,7 @@
 				DCD1208628663F4A00EB39C5 /* TransactionsView.swift */,
 				DCB410882902D5BF00CE4FF9 /* PaymentsSection.swift */,
 				DCEE8997288605FD00FE42DD /* PaymentCell.swift */,
+				DC82EED529789853007A5853 /* TxHistoryExporter.swift */,
 			);
 			path = transactions;
 			sourceTree = "<group>";
@@ -1141,6 +1146,7 @@
 				DC46BAE326C6FDD300E760A6 /* CircularCheckmarkProgress */,
 				DCD71A78273987FE00B9A1EF /* Focuser */,
 				DC39D4E4286B4A7E0030F18D /* Popovers */,
+				DC5A934E297F2AE4004F19FD /* CodableCSV */,
 			);
 			productName = "phoenix-ios";
 			productReference = 7555FF7B242A565900829871 /* Phoenix.app */;
@@ -1265,6 +1271,7 @@
 				DC46BAE226C6FDD300E760A6 /* XCRemoteSwiftPackageReference "CircularCheckmarkProgress" */,
 				DCD71A752739864400B9A1EF /* XCRemoteSwiftPackageReference "swift-focuser" */,
 				DC39D4E3286B4A7E0030F18D /* XCRemoteSwiftPackageReference "Popovers" */,
+				DC5A934D297F2AE4004F19FD /* XCRemoteSwiftPackageReference "CodableCSV" */,
 			);
 			productRefGroup = 7555FF7C242A565900829871 /* Products */;
 			projectDirPath = "";
@@ -1376,6 +1383,7 @@
 				DC33369826BAF721000E3F49 /* ShortSheet.swift in Sources */,
 				DC99E90925B78FA800FB20F7 /* EnabledSecurity.swift in Sources */,
 				DCB493CF269F859E001B0F09 /* SyncTxManager_State.swift in Sources */,
+				DC82EED629789853007A5853 /* TxHistoryExporter.swift in Sources */,
 				7555FF7F242A565900829871 /* AppDelegate.swift in Sources */,
 				DC74174B270F332700F7E3E3 /* KotlinTypes.swift in Sources */,
 				DC142135261E72320075857A /* AboutHTML.swift in Sources */,
@@ -2142,6 +2150,14 @@
 				version = 0.4.1;
 			};
 		};
+		DC5A934D297F2AE4004F19FD /* XCRemoteSwiftPackageReference "CodableCSV" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/dehesa/CodableCSV.git";
+			requirement = {
+				kind = exactVersion;
+				version = 0.6.7;
+			};
+		};
 		DC72C2EA25A3CADC008A927A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
@@ -2170,6 +2186,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = DC46BAE226C6FDD300E760A6 /* XCRemoteSwiftPackageReference "CircularCheckmarkProgress" */;
 			productName = CircularCheckmarkProgress;
+		};
+		DC5A934E297F2AE4004F19FD /* CodableCSV */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DC5A934D297F2AE4004F19FD /* XCRemoteSwiftPackageReference "CodableCSV" */;
+			productName = CodableCSV;
 		};
 		DC72C31825A3CF87008A927A /* FirebaseMessaging */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -104,7 +104,7 @@
 		DC48D2C42593DE30008D138C /* TextFieldCurrencyStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC48D2C32593DE30008D138C /* TextFieldCurrencyStyler.swift */; };
 		DC49DA8E258BB882005BC4BC /* ScaledButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC49DA8D258BB882005BC4BC /* ScaledButtonStyle.swift */; };
 		DC59377127516297003B4B53 /* Sequence+Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC59377027516296003B4B53 /* Sequence+Sum.swift */; };
-		DC5A934F297F2AE4004F19FD /* CodableCSV in Frameworks */ = {isa = PBXBuildFile; productRef = DC5A934E297F2AE4004F19FD /* CodableCSV */; };
+		DC5A935329846044004F19FD /* FileHandle+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5A935229846043004F19FD /* FileHandle+Async.swift */; };
 		DC5AF4542677BBF7003C911B /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = DC5AF4522677BBF7003C911B /* InfoPlist.strings */; };
 		DC5AF4572677BBF7003C911B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DC5AF4552677BBF7003C911B /* Localizable.strings */; };
 		DC5CA4ED28F83C3B0048A737 /* DrainWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5CA4EC28F83C3B0048A737 /* DrainWalletView.swift */; };
@@ -415,6 +415,7 @@
 		DC48D2C32593DE30008D138C /* TextFieldCurrencyStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldCurrencyStyler.swift; sourceTree = "<group>"; };
 		DC49DA8D258BB882005BC4BC /* ScaledButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaledButtonStyle.swift; sourceTree = "<group>"; };
 		DC59377027516296003B4B53 /* Sequence+Sum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+Sum.swift"; sourceTree = "<group>"; };
+		DC5A935229846043004F19FD /* FileHandle+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileHandle+Async.swift"; sourceTree = "<group>"; };
 		DC5AF4532677BBF7003C911B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		DC5AF4562677BBF7003C911B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DC5CA4EC28F83C3B0048A737 /* DrainWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrainWalletView.swift; sourceTree = "<group>"; };
@@ -542,7 +543,6 @@
 			files = (
 				DCD71A79273987FE00B9A1EF /* Focuser in Frameworks */,
 				DC46BAE426C6FDD300E760A6 /* CircularCheckmarkProgress in Frameworks */,
-				DC5A934F297F2AE4004F19FD /* CodableCSV in Frameworks */,
 				DCC9D99C267BEB3D00EA36DD /* CloudKit.framework in Frameworks */,
 				DC39D4E5286B4A7E0030F18D /* Popovers in Frameworks */,
 				DCC46F1625C3521C005D32D9 /* FirebaseMessaging in Frameworks */,
@@ -1000,6 +1000,7 @@
 				DC09085725B5E43900A46136 /* String+VersionComparison.swift */,
 				DC384D82265C32F100131772 /* TextField+Verbatim.swift */,
 				DC89857E25914747007B253F /* UIApplicationState+Phoenix.swift */,
+				DC5A935229846043004F19FD /* FileHandle+Async.swift */,
 			);
 			path = extensions;
 			sourceTree = "<group>";
@@ -1146,7 +1147,6 @@
 				DC46BAE326C6FDD300E760A6 /* CircularCheckmarkProgress */,
 				DCD71A78273987FE00B9A1EF /* Focuser */,
 				DC39D4E4286B4A7E0030F18D /* Popovers */,
-				DC5A934E297F2AE4004F19FD /* CodableCSV */,
 			);
 			productName = "phoenix-ios";
 			productReference = 7555FF7B242A565900829871 /* Phoenix.app */;
@@ -1271,7 +1271,6 @@
 				DC46BAE226C6FDD300E760A6 /* XCRemoteSwiftPackageReference "CircularCheckmarkProgress" */,
 				DCD71A752739864400B9A1EF /* XCRemoteSwiftPackageReference "swift-focuser" */,
 				DC39D4E3286B4A7E0030F18D /* XCRemoteSwiftPackageReference "Popovers" */,
-				DC5A934D297F2AE4004F19FD /* XCRemoteSwiftPackageReference "CodableCSV" */,
 			);
 			productRefGroup = 7555FF7C242A565900829871 /* Products */;
 			projectDirPath = "";
@@ -1533,6 +1532,7 @@
 				DC5EE4C927679C6300A3035C /* RestoreView.swift in Sources */,
 				C8D7A70EFE0F071ACA0AE246 /* QRCodeScanner.swift in Sources */,
 				DC2CE55028A52AD90070A2E1 /* RecentPaymentsConfig.swift in Sources */,
+				DC5A935329846044004F19FD /* FileHandle+Async.swift in Sources */,
 				DC118C0A27B457F70080BBAC /* LnurlFlowErrorNotice.swift in Sources */,
 				53BEF2924096C8E7976D46E3 /* shapes.swift in Sources */,
 				DC0D2EA72939273B00284608 /* KotlinExtensions+Payments.swift in Sources */,
@@ -2150,14 +2150,6 @@
 				version = 0.4.1;
 			};
 		};
-		DC5A934D297F2AE4004F19FD /* XCRemoteSwiftPackageReference "CodableCSV" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/dehesa/CodableCSV.git";
-			requirement = {
-				kind = exactVersion;
-				version = 0.6.7;
-			};
-		};
 		DC72C2EA25A3CADC008A927A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
@@ -2186,11 +2178,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = DC46BAE226C6FDD300E760A6 /* XCRemoteSwiftPackageReference "CircularCheckmarkProgress" */;
 			productName = CircularCheckmarkProgress;
-		};
-		DC5A934E297F2AE4004F19FD /* CodableCSV */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = DC5A934D297F2AE4004F19FD /* XCRemoteSwiftPackageReference "CodableCSV" */;
-			productName = CodableCSV;
 		};
 		DC72C31825A3CF87008A927A /* FirebaseMessaging */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "codablecsv",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dehesa/CodableCSV.git",
+      "state" : {
+        "revision" : "99ace2cfdfbc19108b529c021005fb57a460e715",
+        "version" : "0.6.7"
+      }
+    },
+    {
       "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "codablecsv",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/dehesa/CodableCSV.git",
-      "state" : {
-        "revision" : "99ace2cfdfbc19108b529c021005fb57a460e715",
-        "version" : "0.6.7"
-      }
-    },
-    {
       "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",

--- a/phoenix-ios/phoenix-ios/extensions/FileHandle+Async.swift
+++ b/phoenix-ios/phoenix-ios/extensions/FileHandle+Async.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+extension FileHandle {
+	
+	func asyncWrite(
+		data: any DataProtocol,
+		qos: DispatchQoS.QoSClass = .userInitiated
+	) async throws {
+		
+		return try await withCheckedThrowingContinuation { continuation in
+			DispatchQueue.global(qos: qos).async {
+				do {
+					try self.write(contentsOf: data)
+					continuation.resume(with: .success)
+				} catch {
+					continuation.resume(with: .failure(error))
+				}
+			}
+		}
+	}
+	
+	func asyncSyncAndClose(
+		qos: DispatchQoS.QoSClass = .userInitiated
+	) async throws {
+		
+		try await withCheckedThrowingContinuation { continuation in
+			DispatchQueue.global(qos: qos).async {
+				do {
+					try self.synchronize()
+					try self.close()
+					continuation.resume(with: .success)
+				} catch {
+					continuation.resume(with: .failure(error))
+				}
+			}
+		}
+	}
+}

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Payments.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Payments.swift
@@ -95,6 +95,14 @@ extension WalletPaymentInfo {
 
 extension Lightning_kmpWalletPayment {
 
+	func inIncoming() -> Bool {
+		return self is Lightning_kmpIncomingPayment
+	}
+
+	func isOutgoing() -> Bool {
+		return self is Lightning_kmpOutgoingPayment
+	}
+	
 	func isOnChain() -> Bool {
 		
 		if let incomingPayment = self as? Lightning_kmpIncomingPayment {
@@ -132,6 +140,10 @@ extension WalletPaymentMetadata {
 }
 
 extension Lightning_kmpWalletPayment {
+	
+	func createdAtDate() -> Date {
+		return self.createdAt.toDate(from: .milliseconds)
+	}
 	
 	func completedAtDate() -> Date? {
 		

--- a/phoenix-ios/phoenix-ios/views/transactions/TxHistoryExporter.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/TxHistoryExporter.swift
@@ -255,7 +255,12 @@ struct TxHistoryExporter: View {
 	func datesChanged() {
 		log.trace("datesChanged()")
 		
-		if startDate > endDate {
+		// Remember: startDate and endDate can be the same day.
+		
+		let startMillis = sanitizeStartDate()
+		let endMillis = sanitizeEndDate()
+		
+		if startMillis > endMillis {
 			invalidDates = true
 			paymentCount = nil
 		} else {

--- a/phoenix-ios/phoenix-ios/views/transactions/TxHistoryExporter.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/TxHistoryExporter.swift
@@ -534,10 +534,10 @@ struct TxHistoryExporter: View {
 					}
 					
 					try writer.endRow()
+					exportedCount = (exportedCount ?? 0) + 1
 				}
 				
 				rowsOffset += rows.count
-				exportedCount = rowsOffset
 				
 				if rows.count < FETCH_ROWS_BATCH_COUNT {
 					done = true

--- a/phoenix-ios/phoenix-ios/views/transactions/TxHistoryExporter.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/TxHistoryExporter.swift
@@ -426,19 +426,22 @@ struct TxHistoryExporter: View {
 			return exportingFailed()
 		}
 		
-		let config = CsvWriter.Configuration(
-			includesFiat: includeFiat,
-			includesDescription: includeDescription,
-			includesNotes: includeNotes
-		)
-		
 		exportedCount = 0
 		
 		let databaseManager = Biz.business.databaseManager
+		let peerManager = Biz.business.peerManager
 		let fetcher = Biz.business.paymentsManager.fetcher
 		
 		do {
 			let paymentsDb = try await databaseManager.paymentsDb()
+			let peer = try await peerManager.getPeer()
+			
+			let config = CsvWriter.Configuration(
+				includesFiat: includeFiat,
+				includesDescription: includeDescription,
+				includesNotes: includeNotes,
+				swapInAddress: peer.swapInAddress
+			)
 			
 			var done = false
 			var rowsOffset = 0

--- a/phoenix-ios/phoenix-ios/views/transactions/TxHistoryExporter.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/TxHistoryExporter.swift
@@ -1,0 +1,570 @@
+import SwiftUI
+import PhoenixShared
+import CodableCSV
+import os.log
+
+#if DEBUG && true
+fileprivate var log = Logger(
+	subsystem: Bundle.main.bundleIdentifier!,
+	category: "TxHistoryExporter"
+)
+#else
+fileprivate var log = Logger(OSLog.disabled)
+#endif
+
+
+struct TxHistoryExporter: View {
+	
+	@State var startDate = Date()
+	@State var endDate = Date()
+	
+	@State var includeDescription = true
+	@State var includeNotes = true
+	@State var includeFiat = true
+	
+	@State var invalidDates = false
+	@State var isExporting = false
+	@State var shareUrl: URL? = nil
+	@State var paymentCount: Int? = nil
+	@State var exportedCount: Int? = nil
+	
+	@StateObject var toast = Toast()
+	
+	@Environment(\.colorScheme) var colorScheme
+	
+	let FETCH_ROWS_BATCH_COUNT = 32
+	
+	let FIELD_ID          = "ID"
+	let FIELD_DATE        = "Date"
+	let FIELD_AMOUNT_BTC  = "Amount BTC"
+	let FIELD_AMOUNT_FIAT = "Amount Fiat"
+	let FIELD_DESCRIPTION = "Description"
+	let FIELD_NOTES       = "Notes"
+	
+	// --------------------------------------------------
+	// MARK: View Builders
+	// --------------------------------------------------
+	
+	@ViewBuilder
+	var body: some View {
+		
+		layers()
+			.navigationTitle(NSLocalizedString("Export Payments", comment: "Navigation bar title"))
+			.navigationBarTitleDisplayMode(.inline)
+	}
+	
+	@ViewBuilder
+	func layers() -> some View {
+		
+		ZStack {
+			Color.primaryBackground
+				.ignoresSafeArea(.all, edges: .all)
+			
+			wrappedContent()
+			
+			toast.view()
+		}
+		.onAppear {
+			onAppear()
+		}
+		.onChange(of: startDate) { _ in
+			datesChanged()
+		}
+		.onChange(of: endDate) { _ in
+			datesChanged()
+		}
+	}
+	
+	@ViewBuilder
+	func wrappedContent() -> some View {
+		
+		VStack(alignment: HorizontalAlignment.center, spacing: 0) {
+			Color.primaryBackground.frame(height: 25)
+			ScrollView(.vertical) {
+				content()
+			}
+		}
+		.sheet(isPresented: shareUrlBinding()) {
+			let items: [Any] = [shareUrl!]
+			ActivityView(activityItems: items, applicationActivities: nil)
+		}
+	}
+	
+	@ViewBuilder
+	func content() -> some View {
+		
+		VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
+			
+			Text("Export your payment history in CSV (comma separated value) format.")
+				.padding(.bottom, 40)
+			
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				Text("Start date")
+					.padding(.trailing, 4)
+				Text("(inclusive)")
+					.foregroundColor(.secondary)
+				Spacer()
+				DatePicker("", selection: $startDate, displayedComponents: .date)
+					 .labelsHidden()
+			} // </HStack>
+			.padding(.bottom)
+			
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				Text("End date")
+					.padding(.trailing, 4)
+				Text("(inclusive)")
+					.foregroundColor(.secondary)
+				Spacer()
+				DatePicker("", selection: $endDate, displayedComponents: .date)
+					.labelsHidden()
+			} // </HStack>
+			.padding(.bottom, 40)
+			
+			Toggle(isOn: $includeDescription) {
+				Text("Include description")
+			}
+			.disabled(isExporting)
+			.padding(.trailing, 2)
+			.padding(.bottom)
+			
+			Toggle(isOn: $includeNotes) {
+				Text("Include notes")
+			}
+			.disabled(isExporting)
+			.padding(.trailing, 2)
+			.padding(.bottom)
+			
+			HStack(alignment: VerticalAlignment.centerTopLine) {
+				VStack(alignment: HorizontalAlignment.leading, spacing: 4) {
+					Text("Include original fiat value")
+						.alignmentGuide(VerticalAlignment.centerTopLine) { (d: ViewDimensions) in
+							d[VerticalAlignment.center]
+						}
+					Text("(at time of payment)")
+						.foregroundColor(.secondary)
+						.padding(.leading, 4)
+				}
+				Spacer()
+				Toggle("", isOn: $includeFiat)
+					.labelsHidden()
+					.disabled(isExporting)
+					.padding(.trailing, 2)
+					.alignmentGuide(VerticalAlignment.centerTopLine) { (d: ViewDimensions) in
+						d[VerticalAlignment.center]
+					}
+					
+			} // </HStack>
+			.padding(.bottom, 40)
+			
+			HStack {
+				Spacer()
+				VStack(alignment: HorizontalAlignment.center) {
+					exportButton()
+					exportFooter()
+				}
+				Spacer()
+			}
+			
+		} // </VStack>
+		.padding()
+	}
+	
+	@ViewBuilder
+	func exportButton() -> some View {
+		
+		if #available(iOS 15, *) {
+
+			Button {
+				performExport()
+			} label: {
+				Label("Export", systemImage: "square.and.arrow.up")
+					.font(.title3)
+			}
+			.buttonStyle(.borderedProminent)
+			.buttonBorderShape(.capsule)
+			.disabled(invalidDates || isExporting)
+
+		} else {
+			
+			Button {
+				performExport()
+			} label: {
+				Label("Export", systemImage: "square.and.arrow.up")
+					.font(.title3)
+					.foregroundColor(Color.white)
+					.padding([.top, .bottom], 8)
+					.padding([.leading, .trailing], 16)
+			}
+			.buttonStyle(
+				ScaleButtonStyle(
+					cornerRadius: 100,
+					backgroundFill: Color.appAccent,
+					disabledBackgroundFill: Color.appAccent.opacity(0.65),
+					pressedOpacity: 0.4,
+					disabledOpacity: 0.4
+				)
+			)
+			.disabled(invalidDates || isExporting)
+		}
+	}
+	
+	@ViewBuilder
+	func exportFooter() -> some View {
+		
+		if invalidDates {
+			
+			Text("Invalid date range")
+				.foregroundColor(.appNegative)
+				.padding(.top, 8)
+			
+		} else if isExporting {
+			
+			VStack(alignment: HorizontalAlignment.center, spacing: 10) {
+				ProgressView()
+					.progressViewStyle(CircularProgressViewStyle(tint: Color.appAccent))
+				if let exportedCount {
+					if let paymentCount, exportedCount <= paymentCount {
+						Text("\(exportedCount) of \(paymentCount)").font(.subheadline)
+					} else {
+						Text("\(exportedCount)").font(.subheadline)
+					}
+				}
+			}
+			
+		} else if let paymentCount {
+			
+			if paymentCount == 1 {
+				Text("1 payment")
+					.padding(.top, 8)
+			} else {
+				Text("\(paymentCount) payments")
+					.padding(.top, 8)
+			}
+		}
+	}
+	
+	// --------------------------------------------------
+	// MARK: Actions
+	// --------------------------------------------------
+	
+	func onAppear() {
+		log.trace("onAppear()")
+		
+		fetchOldestPaymentDate()
+	}
+	
+	func datesChanged() {
+		log.trace("datesChanged()")
+		
+		if startDate > endDate {
+			invalidDates = true
+			paymentCount = nil
+		} else {
+			invalidDates = false
+			paymentCount = nil
+			refreshPaymentCount()
+		}
+	}
+	
+	func performExport() {
+		log.trace("performExport()")
+		
+		isExporting = true
+		exportedCount = nil
+		Task {
+			await asyncExport()
+		}
+	}
+	
+	// --------------------------------------------------
+	// MARK: Utilities
+	// --------------------------------------------------
+	
+	private func shareUrlBinding() -> Binding<Bool> {
+		
+		return Binding(
+			get: {
+				return shareUrl != nil
+			},
+			set: {
+				if !$0 {
+					if let tmpFileUrl = shareUrl {
+						DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 5.0) {
+							do {
+								try FileManager.default.removeItem(at: tmpFileUrl)
+								log.debug("Deleted tmp file: \(tmpFileUrl)")
+							} catch {
+								log.error("Error deleting tmp file: \(error)")
+							}
+						}
+						shareUrl = nil
+					}
+				}
+			}
+		)
+	}
+	
+	private func fetchOldestPaymentDate() {
+		log.trace("fetchOldestPaymentDate()")
+		
+		let databaseManager = Biz.business.databaseManager
+		databaseManager.paymentsDb { (result: SqlitePaymentsDb?, _) in
+			
+			assertMainThread()
+			guard let paymentsDb = result else {
+				return
+			}
+			
+			paymentsDb.getOldestCompletedDate { (millis: KotlinLong?, _) in
+				
+				if let oldestDate = self.millisToDate(millis) {
+					log.debug("oldestDate = \(oldestDate)")
+					startDate = oldestDate
+				}
+			}
+		}
+	}
+	
+	private func sanitizeStartDate() -> Int64 {
+		
+		let startOfDay = Calendar.current.startOfDay(for: startDate)
+		return Int64(startOfDay.timeIntervalSince1970 * 1_000)
+	}
+	
+	private func sanitizeEndDate() -> Int64 {
+		
+		var components = DateComponents()
+		components.day = 1
+		components.second = -1
+		
+		let endOfDay = Calendar.current.date(byAdding: components, to: endDate)!
+		return Int64(endOfDay.timeIntervalSince1970 * 1_000)
+	}
+	
+	
+	private func refreshPaymentCount() {
+		log.trace("refreshPaymentCount()")
+		
+		let startMillis = sanitizeStartDate()
+		let endMillis = sanitizeEndDate()
+		
+		let databaseManager = Biz.business.databaseManager
+		databaseManager.paymentsDb { (result: SqlitePaymentsDb?, _) in
+			
+			assertMainThread()
+			guard let paymentsDb = result else {
+				return
+			}
+			
+			paymentsDb.listRangePaymentsCount(
+				startDate: startMillis,
+				endDate: endMillis
+			) { (result: KotlinLong?, _) in
+				
+				let count = result?.intValue ?? 0
+				if (startMillis == self.sanitizeStartDate()) && (endMillis == self.sanitizeEndDate()) {
+					paymentCount = count
+				} else {
+					// result no longer matches UI; user changed dates
+				}
+			}
+		}
+	}
+	
+	private func millisToDate(_ millis: KotlinLong?) -> Date? {
+			
+		if let millis = millis {
+			let seconds: TimeInterval = millis.doubleValue / Double(1_000)
+			return Date(timeIntervalSince1970: seconds)
+		} else {
+			return nil
+		}
+	}
+	
+	@MainActor
+	private func exportingFailed() {
+		log.trace("exportingFailed()")
+		
+		isExporting = false
+		toast.pop(
+			NSLocalizedString("Exporting Failed", comment: "TxHistoryExporter"),
+			colorScheme: colorScheme.opposite,
+			style: .chrome,
+			duration: 15.0,
+			alignment: .middle,
+			showCloseButton: true
+		)
+	}
+	
+	@MainActor
+	private func exportingFinished(_ tempFile: URL) {
+		log.trace("exportingFinished()")
+		
+		isExporting = false
+		shareUrl = tempFile
+	}
+	
+	// --------------------------------------------------
+	// MARK: Exporting
+	// --------------------------------------------------
+	
+	@MainActor
+	private func asyncExport() async {
+		log.trace("asyncExport()")
+		
+		let startMillis = sanitizeStartDate()
+		let endMillis = sanitizeEndDate()
+		
+		let tmpDir = FileManager.default.temporaryDirectory
+		let tmpFilename = "phoenix.csv"
+		let tmpFile = tmpDir.appendingPathComponent(tmpFilename, isDirectory: false)
+		
+		var headers = [
+			FIELD_ID,
+			FIELD_DATE,
+			FIELD_AMOUNT_BTC
+		]
+		if includeFiat {
+			headers.append(FIELD_AMOUNT_FIAT)
+		}
+		if includeDescription {
+			headers.append(FIELD_DESCRIPTION)
+		}
+		if includeNotes {
+			headers.append(FIELD_NOTES)
+		}
+		
+		var writerConfig = CSVWriter.Configuration()
+		writerConfig.encoding = .utf8
+		writerConfig.delimiters = (field: ",", row: "\n")
+		writerConfig.headers = headers
+		
+		let writer: CSVWriter
+		do {
+			writer = try CSVWriter(fileURL: tmpFile, append: false)
+			try writer.write(row: headers)
+		} catch {
+			log.error("Unable to create CSVWriter: \(error)")
+			return exportingFailed()
+		}
+		
+		exportedCount = 0
+		
+		let databaseManager = Biz.business.databaseManager
+		let fetcher = Biz.business.paymentsManager.fetcher
+		
+		do {
+			let paymentsDb = try await databaseManager.paymentsDb()
+			
+			var done = false
+			var rowsOffset = 0
+			
+			while !done {
+				
+				let rows: [WalletPaymentOrderRow] = try await paymentsDb.listRangePaymentsOrder(
+					startDate: startMillis,
+					endDate: endMillis,
+					count: Int32(FETCH_ROWS_BATCH_COUNT),
+					skip: Int32(rowsOffset)
+				)
+				
+				for row in rows {
+					
+					guard let info = try await fetcher.getPayment(
+						row: row,
+						options: WalletPaymentFetchOptions.companion.All
+					) else {
+						continue
+					}
+					
+					let id = info.payment.id()
+					let date = iso8601String(info)
+					
+					let amtMsat: Int64
+					if info.payment.isOutgoing() {
+						amtMsat = -info.payment.amount.msat
+					} else {
+						amtMsat = info.payment.amount.msat
+					}
+					
+					let amtBtc = "\(amtMsat) msat"
+					
+					try writer.write(field: id)     // FIELD_ID
+					try writer.write(field: date)   // FIELD_DATE
+					try writer.write(field: amtBtc) // FIELD_AMOUNT_BTC
+					
+					if includeFiat {
+						// Developer notes:
+						//
+						// - The fiat amount may not always be in the same currency.
+						//   That is, the user has the ability to set their preferred fiat currency in the app.
+						//   For example:
+						//   * user lives in USA, has currency set to USD
+						//     * payments will record USD/BTC exchange rate at time of payment
+						//     * exported payments will read "X.Y USD"
+						//   * user goes on vacation in Mexico, changes currency to MXN
+						//     * payments will record MXN/BTC exchange rate at time of payment
+						//     * exported payments will read "X.Y MXN"
+						//   * user moves to Spain, changes currency to EUR
+						//     * payments will record EUR/BTC exchange rate at time of payment
+						//     * exported payments will read "X.Y EUR"
+						//
+						// - Prior to v1.5.5, the exchange rates for fiat currencies other
+						//   than USD & EUR may have been unreliable. So if you're parsing,
+						//   for example COP (Colombian Pesos), and you have an alternative
+						//   source for fetching historical exchange rates, then you may
+						//   prefer that source over the CSV values.
+						//   v1.5.5 was released around Feb 1, 2023
+						
+						if let originalExchangeRate = info.metadata.originalFiat {
+							let amtFiat = Utils.formatFiat(msat: amtMsat, exchangeRate: originalExchangeRate)
+							try writer.write(field: amtFiat.string)
+						} else {
+							try writer.write(field: "") // unknown
+						}
+					}
+					
+					if includeDescription {
+						let description = info.paymentDescription() ?? info.defaultPaymentDescription()
+						try writer.write(field: description)
+					}
+					if includeNotes {
+						let notes = info.metadata.userNotes ?? ""
+						try writer.write(field: notes)
+					}
+					
+					try writer.endRow()
+				}
+				
+				rowsOffset += rows.count
+				exportedCount = rowsOffset
+				
+				if rows.count < FETCH_ROWS_BATCH_COUNT {
+					done = true
+				} else {
+					// there may be more; fetch another batch
+				}
+				
+			} // </while !done>
+			
+			try writer.endEncoding()
+			exportingFinished(tmpFile)
+			
+		} catch {
+			log.error("Error: \(error)")
+			exportingFailed()
+		}
+	}
+	
+	private func iso8601String(_ info: WalletPaymentInfo) -> String {
+		
+		let date = info.payment.completedAtDate() ?? info.payment.createdAtDate()
+		if #available(iOS 15, *) {
+			return date.ISO8601Format()
+			
+		} else {
+			let formatter = ISO8601DateFormatter()
+			return formatter.string(from: date)
+		}
+	}
+}

--- a/phoenix-ios/phoenix-ios/views/transactions/TxHistoryExporter.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/TxHistoryExporter.swift
@@ -20,6 +20,7 @@ struct TxHistoryExporter: View {
 	@State var includeDescription = true
 	@State var includeNotes = true
 	@State var includeFiat = true
+	@State var includeOriginDestination = true
 	
 	@State var invalidDates = false
 	@State var isExporting = false
@@ -145,6 +146,28 @@ struct TxHistoryExporter: View {
 				}
 				Spacer()
 				Toggle("", isOn: $includeFiat)
+					.labelsHidden()
+					.disabled(isExporting)
+					.padding(.trailing, 2)
+					.alignmentGuide(VerticalAlignment.centerTopLine) { (d: ViewDimensions) in
+						d[VerticalAlignment.center]
+					}
+					
+			} // </HStack>
+			.padding(.bottom)
+			
+			HStack(alignment: VerticalAlignment.centerTopLine) {
+				VStack(alignment: HorizontalAlignment.leading, spacing: 4) {
+					Text("Include origin & destination")
+						.alignmentGuide(VerticalAlignment.centerTopLine) { (d: ViewDimensions) in
+							d[VerticalAlignment.center]
+						}
+					Text("(e.g. btc address payment was sent to)")
+						.foregroundColor(.secondary)
+						.padding(.leading, 4)
+				}
+				Spacer()
+				Toggle("", isOn: $includeOriginDestination)
 					.labelsHidden()
 					.disabled(isExporting)
 					.padding(.trailing, 2)
@@ -445,6 +468,7 @@ struct TxHistoryExporter: View {
 				includesFiat: includeFiat,
 				includesDescription: includeDescription,
 				includesNotes: includeNotes,
+				includesOriginDestination: includeOriginDestination,
 				swapInAddress: peer.swapInAddress
 			)
 			

--- a/phoenix-ios/phoenix-ios/views/transactions/TxHistoryExporter.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/TxHistoryExporter.swift
@@ -383,7 +383,7 @@ struct TxHistoryExporter: View {
 				return
 			}
 			
-			paymentsDb.listRangePaymentsCount(
+			paymentsDb.listRangeSuccessfulPaymentsCount(
 				startDate: startMillis,
 				endDate: endMillis
 			) { (result: KotlinLong?, _) in
@@ -482,7 +482,7 @@ struct TxHistoryExporter: View {
 			
 			while !done {
 				
-				let rows: [WalletPaymentOrderRow] = try await paymentsDb.listRangePaymentsOrder(
+				let rows: [WalletPaymentOrderRow] = try await paymentsDb.listRangeSuccessfulPaymentsOrder(
 					startDate: startMillis,
 					endDate: endMillis,
 					count: Int32(FETCH_ROWS_BATCH_COUNT),

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
@@ -470,15 +470,22 @@ class SqlitePaymentsDb(
         }
     }
 
-    suspend fun listRangePaymentsOrder(
+    /**
+     * List payments successfully received or sent between [startDate] and [endDate], for page ([skip]->[skip+count]).
+     *
+     * @param startDate timestamp in millis
+     * @param endDate timestamp in millis
+     * @param count limit number of rows
+     * @param skip rows offset for paging
+     */
+    suspend fun listRangeSuccessfulPaymentsOrder(
         startDate: Long,
         endDate: Long,
         count: Int,
         skip: Int
     ): List<WalletPaymentOrderRow> {
-
         return withContext(Dispatchers.Default) {
-            aggrQueries.listRangePaymentsOrder(
+            aggrQueries.listRangeSuccessfulPaymentsOrder(
                 startDate = startDate,
                 endDate = endDate,
                 limit = count.toLong(),
@@ -488,13 +495,18 @@ class SqlitePaymentsDb(
         }
     }
 
-    suspend fun listRangePaymentsCount(
+    /**
+     * Count payments successfully received or sent between [startDate] and [endDate].
+     *
+     * @param startDate timestamp in millis
+     * @param endDate timestamp in millis
+     */
+    suspend fun listRangeSuccessfulPaymentsCount(
         startDate: Long,
         endDate: Long
     ): Long {
-
         return withContext(Dispatchers.Default) {
-            aggrQueries.listRangePaymentsCount(
+            aggrQueries.listRangeSuccessfulPaymentsCount(
                 startDate = startDate,
                 endDate = endDate,
                 mapper = ::allPaymentsCountMapper

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/IncomingQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/IncomingQueries.kt
@@ -193,6 +193,10 @@ class IncomingQueries(private val database: PaymentsDatabase) {
         return queries.get(payment_hash = paymentHash.toByteArray(), ::mapIncomingPayment).executeAsOneOrNull()
     }
 
+    fun getOldestReceivedDate(): Long? {
+        return queries.getOldestReceivedDate().executeAsOneOrNull()
+    }
+
     fun listExpiredPayments(fromCreatedAt: Long, toCreatedAt: Long): List<IncomingPayment> {
         return queries.listAllWithin(fromCreatedAt, toCreatedAt, ::mapIncomingPayment).executeAsList().filter {
             it.received == null

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
@@ -217,6 +217,10 @@ class OutgoingQueries(val database: PaymentsDatabase) {
         }
     }
 
+    fun getOldestCompletedDate(): Long? {
+        return queries.getOldestCompletedDate().executeAsOneOrNull()
+    }
+
     fun listPayments(paymentHash: ByteVector32): List<OutgoingPayment> {
         return queries.listPaymentsForPaymentHash(paymentHash.toByteArray(), ::mapOutgoingPayment).executeAsList()
             .run { groupByRawOutgoing(this) }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/CsvWriter.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/CsvWriter.kt
@@ -1,0 +1,147 @@
+package fr.acinq.phoenix.utils
+
+import fr.acinq.phoenix.data.WalletPaymentInfo
+import fr.acinq.phoenix.utils.extensions.createdAt
+import kotlinx.datetime.Instant
+
+class CsvWriter {
+    
+    data class Configuration(
+        val includesFiat: Boolean,
+        val includesDescription: Boolean,
+        val includesNotes: Boolean
+    )
+
+    companion object {
+        private const val FIELD_ID          = "ID"
+        private const val FIELD_DATE        = "Date"
+        private const val FIELD_AMOUNT_BTC  = "Amount BTC"
+        private const val FIELD_AMOUNT_FIAT = "Amount Fiat"
+        private const val FIELD_DESCRIPTION = "Description"
+        private const val FIELD_NOTES       = "Notes"
+
+        /**
+         * Creates and returns the header row for the CSV file.
+         * This includes the CRLF that terminates the row.
+         */
+        fun makeHeaderRow(config: Configuration): String {
+            var header = "$FIELD_ID,$FIELD_DATE,$FIELD_AMOUNT_BTC"
+            if (config.includesFiat) {
+                header += ",$FIELD_AMOUNT_FIAT"
+            }
+            if (config.includesDescription) {
+                header += ",$FIELD_DESCRIPTION"
+            }
+            if (config.includesNotes) {
+                header += ",$FIELD_NOTES"
+            }
+
+            header += "\r\n"
+            return header
+        }
+
+        /**
+         * Creates and returns the row for the given payment.
+         * This includes the CRLF that terminates the row.
+         *
+         * @param info Payment fetched via PaymentsFetcher
+         * @param localizedDescription As displayed in app (might be a localized default value)
+         * @param config The configuration for the CSV file
+         */
+        fun makeRow(
+            info: WalletPaymentInfo,
+            localizedDescription: String,
+            config: Configuration
+        ): String {
+
+            val id = info.id().dbId
+            var row = processField(id)
+
+            val completedAt = info.payment.completedAt()
+            val date = if (completedAt > 0) completedAt else info.payment.createdAt
+            val dateStr = Instant.fromEpochMilliseconds(date).toString() // ISO-8601 format
+            row += ",${processField(dateStr)}"
+
+            val amtBtc = "${info.payment.amount.msat} msat"
+            row += ",${processField(amtBtc)}"
+
+            if (config.includesFiat) {
+                /**
+                 * Developer notes:
+                 *
+                 * - The fiat amount may not always be in the same currency.
+                 *   That is, the user can configure their preferred fiat currency in the app.
+                 *   For example:
+                 *   * user lives in USA, has currency set to USD
+                 *     * payments will record USD/BTC exchange rate at time of payment
+                 *     * exported payments will read "X.Y USD"
+                 *   * user goes on vacation in Mexico, changes currency to MXN
+                 *     * payments will record MXN/BTC exchange rate at time of payment
+                 *     * exported payments will read "X.Y MXN"
+                 *   * user moves to Spain, changes currency to EUR
+                 *     * payments will record EUR/BTC exchange rate at time of payment
+                 *     * exported payments will read "X.Y EUR"
+                 *
+                 * - Prior to February 2023, the exchange rates for fiat currencies other
+                 *   than USD & EUR may have been unreliable. So if you're parsing,
+                 *   for example COP (Colombian Pesos), and you have an alternative
+                 *   source for fetching historical exchange rates, then you may
+                 *   prefer that source over the CSV values.
+                 */
+
+                info.metadata.originalFiat?.let { originalFiatExchangeRate ->
+                    val msatsPerBitcoin = 100_000_000_000
+                    val btc = info.payment.amount.msat.toDouble() / msatsPerBitcoin.toDouble()
+                    val fiat = btc * originalFiatExchangeRate.price
+
+                    // How do we display the fiat currency value ?
+                    // Some currencies use 2 decimal places, e.g. "4.26 EUR".
+                    // But there are also zero-decimal currencies, such as JPY.
+                    //
+                    // Since it's common to have micropayments on the lightning network,
+                    // we're simply going to always display 4 decimal places.
+                    //
+                    // The extra precision can be truncated / rounded / ignored
+                    // by the reader, who has more insight into how they wish
+                    // to use the exported information.
+                    //
+                    // Note: String.companion.format isn't available until Kotlin v1.7.2
+
+                    val components = fiat.toString().split(".")
+                    val comp0 = if (components.size > 0) components[0] else "0"
+                    val comp1 = if (components.size > 1) components[1] else "0"
+
+                    val fiatStr = "${comp0}.${comp1.take(4).padEnd(4, '0')}"
+
+                    row += ",${processField(fiatStr)} ${originalFiatExchangeRate.fiatCurrency.name}"
+                } ?: run {
+                    row += ","
+                }
+            }
+
+            if (config.includesDescription) {
+                row += ",${processField(localizedDescription)}"
+            }
+
+            if (config.includesNotes) {
+                info.metadata.userNotes?.let {
+                    row += ",${processField(it)}"
+                } ?: run {
+                    row += ","
+                }
+            }
+
+            row += "\r\n"
+            return row
+        }
+
+        private fun processField(str: String): String {
+            return str.findAnyOf(listOf(",", "\"", "\n"))?.let {
+                // - field must be enclosed in double-quotes
+                // - a double-quote appearing inside the field must be
+                //   escaped by preceding it with another double quote
+                "\"${str.replace("\"", "\"\"")}\""
+            } ?: str
+        }
+    }
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/CsvWriter.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/CsvWriter.kt
@@ -111,9 +111,11 @@ class CsvWriter {
                     val comp0 = if (components.size > 0) components[0] else "0"
                     val comp1 = if (components.size > 1) components[1] else "0"
 
-                    val fiatStr = "${comp0}.${comp1.take(4).padEnd(4, '0')}"
+                    val numStr = "${comp0}.${comp1.take(4).padEnd(4, '0')}"
+                    val currencyName = originalFiatExchangeRate.fiatCurrency.name
+                    val fiatStr = "$numStr $currencyName"
 
-                    row += ",${processField(fiatStr)} ${originalFiatExchangeRate.fiatCurrency.name}"
+                    row += ",${processField(fiatStr)}"
                 } ?: run {
                     row += ","
                 }

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/AggregatedQueries.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/AggregatedQueries.sq
@@ -97,3 +97,43 @@ LEFT OUTER JOIN payments_metadata ON
     payments_metadata.id = combined_payments.id
 ORDER BY COALESCE(combined_payments.completed_at, combined_payments.created_at) DESC
 LIMIT :limit OFFSET :offset;
+
+listRangePaymentsOrder:
+SELECT
+    combined_payments.type         AS type,
+    combined_payments.id           AS id,
+    combined_payments.created_at   AS created_at,
+    combined_payments.completed_at AS completed_at,
+    payments_metadata.modified_at  AS metadata_modified_at
+FROM (
+    SELECT
+        2            AS type,
+        id           AS id,
+        created_at   AS created_at,
+        completed_at AS completed_at
+    FROM outgoing_payments
+    WHERE completed_at BETWEEN :startDate AND :endDate
+UNION ALL
+    SELECT
+        1                        AS type,
+        lower(hex(payment_hash)) AS id,
+        created_at               AS created_at,
+        received_at              AS completed_at
+    FROM incoming_payments
+    WHERE incoming_payments.received_at BETWEEN :startDate AND :endDate
+) combined_payments
+LEFT OUTER JOIN payments_metadata ON
+    payments_metadata.type = combined_payments.type AND
+    payments_metadata.id = combined_payments.id
+ORDER BY COALESCE(combined_payments.completed_at, combined_payments.created_at) DESC
+LIMIT :limit OFFSET :offset;
+
+listRangePaymentsCount:
+SELECT SUM(result) AS result FROM (
+    SELECT COUNT(*) AS result
+    FROM outgoing_payments
+    WHERE completed_at BETWEEN :startDate AND :endDate
+UNION ALL
+    SELECT COUNT(*) AS result FROM incoming_payments
+    WHERE incoming_payments.received_at BETWEEN :startDate AND :endDate
+);

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/AggregatedQueries.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/AggregatedQueries.sq
@@ -98,7 +98,7 @@ LEFT OUTER JOIN payments_metadata ON
 ORDER BY COALESCE(combined_payments.completed_at, combined_payments.created_at) DESC
 LIMIT :limit OFFSET :offset;
 
-listRangePaymentsOrder:
+listRangeSuccessfulPaymentsOrder:
 SELECT
     combined_payments.type         AS type,
     combined_payments.id           AS id,
@@ -112,7 +112,8 @@ FROM (
         created_at   AS created_at,
         completed_at AS completed_at
     FROM outgoing_payments
-    WHERE completed_at BETWEEN :startDate AND :endDate
+    WHERE outgoing_payments.status_type LIKE 'SUCCEEDED_%'
+    AND   completed_at BETWEEN :startDate AND :endDate
 UNION ALL
     SELECT
         1                        AS type,
@@ -128,11 +129,12 @@ LEFT OUTER JOIN payments_metadata ON
 ORDER BY COALESCE(combined_payments.completed_at, combined_payments.created_at) DESC
 LIMIT :limit OFFSET :offset;
 
-listRangePaymentsCount:
+listRangeSuccessfulPaymentsCount:
 SELECT SUM(result) AS result FROM (
     SELECT COUNT(*) AS result
     FROM outgoing_payments
-    WHERE completed_at BETWEEN :startDate AND :endDate
+    WHERE outgoing_payments.status_type LIKE 'SUCCEEDED_%'
+    AND   completed_at BETWEEN :startDate AND :endDate
 UNION ALL
     SELECT COUNT(*) AS result FROM incoming_payments
     WHERE incoming_payments.received_at BETWEEN :startDate AND :endDate

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/IncomingPayments.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/IncomingPayments.sq
@@ -66,6 +66,13 @@ SELECT payment_hash, preimage, created_at, origin_type, origin_blob, received_am
 FROM   incoming_payments
 WHERE  payment_hash=?;
 
+getOldestReceivedDate:
+SELECT   received_at
+FROM     incoming_payments AS r
+WHERE    received_at IS NOT NULL
+ORDER BY r.received_at ASC
+LIMIT 1;
+
 listAll:
 SELECT payment_hash, preimage, created_at, origin_type, origin_blob, received_amount_msat, received_at, received_with_type, received_with_blob
 FROM   incoming_payments

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/OutgoingPayments.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/OutgoingPayments.sq
@@ -153,6 +153,13 @@ SELECT id,
 FROM outgoing_payments
 WHERE id=?;
 
+getOldestCompletedDate:
+SELECT   completed_at
+FROM     outgoing_payments AS o
+WHERE    completed_at IS NOT NULL
+ORDER BY o.completed_at ASC
+LIMIT 1;
+
 getPayment:
 SELECT parent.id,
        parent.recipient_amount_msat,

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/utils/CsvWriterTests.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/utils/CsvWriterTests.kt
@@ -7,6 +7,7 @@ import fr.acinq.bitcoin.PublicKey
 import fr.acinq.lightning.CltvExpiryDelta
 import fr.acinq.lightning.Lightning.randomBytes32
 import fr.acinq.lightning.MilliSatoshi
+import fr.acinq.lightning.db.ChannelClosingType
 import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.payment.PaymentRequest
@@ -56,12 +57,7 @@ class CsvWriterTests {
         val actual = CsvWriter.makeRow(
             info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
             localizedDescription = "L2 Top-up",
-            config = CsvWriter.Configuration(
-                includesFiat = true,
-                includesDescription = true,
-                includesNotes = true,
-                swapInAddress = swapInAddress
-            )
+            config = makeConfig()
         )
 
         assertEquals(expected, actual)
@@ -97,12 +93,7 @@ class CsvWriterTests {
         val actual = CsvWriter.makeRow(
             info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
             localizedDescription = "Cafécito",
-            config = CsvWriter.Configuration(
-                includesFiat = true,
-                includesDescription = true,
-                includesNotes = true,
-                swapInAddress = swapInAddress
-            )
+            config = makeConfig()
         )
 
         assertEquals(expected, actual)
@@ -134,12 +125,7 @@ class CsvWriterTests {
         val actual = CsvWriter.makeRow(
             info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
             localizedDescription = "Arepa de Choclo",
-            config = CsvWriter.Configuration(
-                includesFiat = true,
-                includesDescription = true,
-                includesNotes = true,
-                swapInAddress = swapInAddress
-            )
+            config = makeConfig()
         )
 
         assertEquals(expected, actual)
@@ -171,12 +157,7 @@ class CsvWriterTests {
         val actual = CsvWriter.makeRow(
             info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
             localizedDescription = "Test 1",
-            config = CsvWriter.Configuration(
-                includesFiat = true,
-                includesDescription = true,
-                includesNotes = true,
-                swapInAddress = swapInAddress
-            )
+            config = makeConfig()
         )
 
         assertEquals(expected, actual)
@@ -208,12 +189,7 @@ class CsvWriterTests {
         val actual = CsvWriter.makeRow(
             info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
             localizedDescription = "Test 2",
-            config = CsvWriter.Configuration(
-                includesFiat = true,
-                includesDescription = true,
-                includesNotes = true,
-                swapInAddress = swapInAddress
-            )
+            config = makeConfig()
         )
 
         assertEquals(expected, actual)
@@ -248,12 +224,7 @@ class CsvWriterTests {
         val actual = CsvWriter.makeRow(
             info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
             localizedDescription = "Test 3",
-            config = CsvWriter.Configuration(
-                includesFiat = true,
-                includesDescription = true,
-                includesNotes = true,
-                swapInAddress = swapInAddress
-            )
+            config = makeConfig()
         )
 
         assertEquals(expected, actual)
@@ -288,12 +259,7 @@ class CsvWriterTests {
         val actual = CsvWriter.makeRow(
             info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
             localizedDescription = "L1 Top-up",
-            config = CsvWriter.Configuration(
-                includesFiat = true,
-                includesDescription = true,
-                includesNotes = true,
-                swapInAddress = swapInAddress
-            )
+            config = makeConfig()
         )
 
         assertEquals(expected, actual)
@@ -330,18 +296,13 @@ class CsvWriterTests {
         val actual = CsvWriter.makeRow(
             info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
             localizedDescription = "Swap for cash",
-            config = CsvWriter.Configuration(
-                includesFiat = true,
-                includesDescription = true,
-                includesNotes = true,
-                swapInAddress = swapInAddress
-            )
+            config = makeConfig()
         )
 
         assertEquals(expected, actual)
     }
 
-/*  @Test
+    @Test
     fun testRow_Outgoing_ChannelClose() {
         val payment = OutgoingPayment(
             id = UUID.randomUUID(),
@@ -352,9 +313,17 @@ class CsvWriterTests {
                 closingAddress = "tb1qz5gxe2450uadavle8wwcc5ngquqfj5xp4dy0ja",
                 isSentToDefaultAddress = false
             ),
-            parts = listOf(),
+            parts = listOf(
+                OutgoingPayment.ClosingTxPart(
+                    id = UUID.randomUUID(),
+                    txId = randomBytes32(),
+                    claimed = 8_690.sat,
+                    closingType = ChannelClosingType.Mutual,
+                    createdAt = 0
+                )
+            ),
             status = OutgoingPayment.Status.Completed.Succeeded.OnChain(
-                completedAt = 1675289814498
+                completedAt = 1675353533694
             )
         )
         val metadata = makeMetadata(
@@ -362,21 +331,15 @@ class CsvWriterTests {
             userNotes = null
         )
 
-        val expected = "?\r\n"
+        val expected = "2023-02-02T15:58:53.694Z,-8690464,-464,,tb1qz5gxe2450uadavle8wwcc5ngquqfj5xp4dy0ja,-2.0563 USD,-0.0001 USD,Channel closing,\r\n"
         val actual = CsvWriter.makeRow(
             info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
             localizedDescription = "Channel closing",
-            config = CsvWriter.Configuration(
-                includesFiat = true,
-                includesDescription = true,
-                includesNotes = true,
-                swapInAddress = swapInAddress
-            )
+            config = makeConfig()
         )
 
         assertEquals(expected, actual)
     }
-    */
 
     /**
      * The only thing the CsvWriter reads from a PaymentRequest is the paymentHash.
@@ -422,5 +385,14 @@ class CsvWriterTests {
             userDescription = null,
             userNotes = userNotes,
             modifiedAt = null
+        )
+
+    private fun makeConfig() =
+        CsvWriter.Configuration(
+            includesFiat = true,
+            includesDescription = true,
+            includesNotes = true,
+            includesOriginDestination = true,
+            swapInAddress = swapInAddress
         )
 }

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/utils/CsvWriterTests.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/utils/CsvWriterTests.kt
@@ -1,0 +1,426 @@
+package fr.acinq.phoenix.utils
+
+import fr.acinq.bitcoin.Block
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.PrivateKey
+import fr.acinq.bitcoin.PublicKey
+import fr.acinq.lightning.CltvExpiryDelta
+import fr.acinq.lightning.Lightning.randomBytes32
+import fr.acinq.lightning.MilliSatoshi
+import fr.acinq.lightning.db.IncomingPayment
+import fr.acinq.lightning.db.OutgoingPayment
+import fr.acinq.lightning.payment.PaymentRequest
+import fr.acinq.lightning.utils.UUID
+import fr.acinq.lightning.utils.currentTimestampSeconds
+import fr.acinq.lightning.utils.msat
+import fr.acinq.lightning.utils.sat
+import fr.acinq.phoenix.TestConstants
+import fr.acinq.phoenix.data.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CsvWriterTests {
+
+    val swapInAddress = "tb1qf72v4qyczf7ymmqtr8z3vfqn6dapzl3e7l6tjv"
+
+    @Test
+    fun testRow_Incoming_NewChannel() {
+        val payment = IncomingPayment(
+            preimage = randomBytes32(),
+            origin = IncomingPayment.Origin.Invoice(
+                makePaymentRequest(
+                    "c76cef2e80fdf27841e28cfe0a8ed11db8fab346c6f2c609d616cd078f81eb65"
+                )
+            ),
+            received = IncomingPayment.Received(
+                receivedWith = setOf(
+                    IncomingPayment.ReceivedWith.NewChannel(
+                        id = UUID.randomUUID(),
+                        amount = 12_000_000.msat,
+                        serviceFee = 3_000_000.msat,
+                        fundingFee = 0.sat,
+                        channelId = randomBytes32(),
+                        confirmed = true
+                    )
+                ),
+                receivedAt = 1675270272445
+            ),
+            createdAt = 0
+        )
+        val metadata = makeMetadata(
+            exchangeRate = 22999.83,
+            userNotes = "Via Lightning network"
+        )
+
+        val expected = "2023-02-01T16:51:12.445Z,12000000,-3000000,c76cef2e80fdf27841e28cfe0a8ed11db8fab346c6f2c609d616cd078f81eb65,,2.7599 USD,-0.6899 USD,L2 Top-up,Via Lightning network\r\n"
+        val actual = CsvWriter.makeRow(
+            info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
+            localizedDescription = "L2 Top-up",
+            config = CsvWriter.Configuration(
+                includesFiat = true,
+                includesDescription = true,
+                includesNotes = true,
+                swapInAddress = swapInAddress
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testRow_Incoming_Payment() {
+        val payment = IncomingPayment(
+            preimage = randomBytes32(),
+            origin = IncomingPayment.Origin.Invoice(
+                makePaymentRequest(
+                    "9b57d81877451835a1511786e6b402b1e22c442f2070cee40eb1a3ff56c5ccd4"
+                )
+            ),
+            received = IncomingPayment.Received(
+                receivedWith = setOf(
+                    IncomingPayment.ReceivedWith.LightningPayment(
+                        amount = 2_173_929.msat,
+                        channelId = randomBytes32(),
+                        htlcId = 0
+                    )
+                ),
+                receivedAt = 1675270484965
+            ),
+            createdAt = 0
+        )
+        val metadata = makeMetadata(
+            exchangeRate = 22999.83,
+            userNotes = null
+        )
+
+        val expected = "2023-02-01T16:54:44.965Z,2173929,0,9b57d81877451835a1511786e6b402b1e22c442f2070cee40eb1a3ff56c5ccd4,,0.4999 USD,0.0000 USD,Cafécito,\r\n"
+        val actual = CsvWriter.makeRow(
+            info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
+            localizedDescription = "Cafécito",
+            config = CsvWriter.Configuration(
+                includesFiat = true,
+                includesDescription = true,
+                includesNotes = true,
+                swapInAddress = swapInAddress
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testRow_Outgoing_Payment() {
+        val payment = OutgoingPayment(
+            id = UUID.randomUUID(),
+            recipientAmount = 4351000.msat,
+            recipient = PublicKey.Generator,
+            details = OutgoingPayment.Details.Normal(
+                makePaymentRequest("8461bc951196177da41d43d9fb8d02c8a8af1f4d820dd464b573b8f5f122da3e")
+            ),
+            parts = listOf(
+                makeLightningPart(4_354_435.msat)
+            ),
+            status = OutgoingPayment.Status.Completed.Succeeded.OffChain(
+                preimage = randomBytes32(),
+                completedAt = 1675270582248
+            )
+        )
+        val metadata = makeMetadata(
+            exchangeRate = 22999.83,
+            userNotes = "Con quesito"
+        )
+
+        val expected = "2023-02-01T16:56:22.248Z,-4354435,-3435,,8461bc951196177da41d43d9fb8d02c8a8af1f4d820dd464b573b8f5f122da3e,-1.0015 USD,-0.0007 USD,Arepa de Choclo,Con quesito\r\n"
+        val actual = CsvWriter.makeRow(
+            info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
+            localizedDescription = "Arepa de Choclo",
+            config = CsvWriter.Configuration(
+                includesFiat = true,
+                includesDescription = true,
+                includesNotes = true,
+                swapInAddress = swapInAddress
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testRow_Outgoing_Payment_WithCommaInNote() {
+        val payment = OutgoingPayment(
+            id = UUID.randomUUID(),
+            recipientAmount = 100_000.msat,
+            recipient = PublicKey.Generator,
+            details = OutgoingPayment.Details.Normal(
+                makePaymentRequest("69d05498db73a22364e128cae30a73cc93ad3f96c2ae280a236ef740581ee2cb")
+            ),
+            parts = listOf(
+                makeLightningPart(103_010.msat)
+            ),
+            status = OutgoingPayment.Status.Completed.Succeeded.OffChain(
+                preimage = randomBytes32(),
+                completedAt = 1675270681099
+            )
+        )
+        val metadata = makeMetadata(
+            exchangeRate = 22999.83,
+            userNotes = "This note, um, has a comma"
+        )
+
+        val expected = "2023-02-01T16:58:01.099Z,-103010,-3010,,69d05498db73a22364e128cae30a73cc93ad3f96c2ae280a236ef740581ee2cb,-0.0236 USD,-0.0006 USD,Test 1,\"This note, um, has a comma\"\r\n"
+        val actual = CsvWriter.makeRow(
+            info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
+            localizedDescription = "Test 1",
+            config = CsvWriter.Configuration(
+                includesFiat = true,
+                includesDescription = true,
+                includesNotes = true,
+                swapInAddress = swapInAddress
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testRow_Outgoing_Payment_WithQuoteInNote() {
+        val payment = OutgoingPayment(
+            id = UUID.randomUUID(),
+            recipientAmount = 100_000.msat,
+            recipient = PublicKey.Generator,
+            details = OutgoingPayment.Details.Normal(
+                makePaymentRequest("f5548d0390ee1b8dee67c0b5d30e4ff9e54dbb700f9551cf48c5479771b42f63")
+            ),
+            parts = listOf(
+                makeLightningPart(103_010.msat)
+            ),
+            status = OutgoingPayment.Status.Completed.Succeeded.OffChain(
+                preimage = randomBytes32(),
+                completedAt = 1675270740742
+            )
+        )
+        val metadata = makeMetadata(
+            exchangeRate = 22999.83,
+            userNotes = "This \"note\" has quotes"
+        )
+
+        val expected = "2023-02-01T16:59:00.742Z,-103010,-3010,,f5548d0390ee1b8dee67c0b5d30e4ff9e54dbb700f9551cf48c5479771b42f63,-0.0236 USD,-0.0006 USD,Test 2,\"This \"\"note\"\" has quotes\"\r\n"
+        val actual = CsvWriter.makeRow(
+            info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
+            localizedDescription = "Test 2",
+            config = CsvWriter.Configuration(
+                includesFiat = true,
+                includesDescription = true,
+                includesNotes = true,
+                swapInAddress = swapInAddress
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testRow_Outgoing_Payment_WithNewlineInNote() {
+        val payment = OutgoingPayment(
+            id = UUID.randomUUID(),
+            recipientAmount = 100_000.msat,
+            recipient = PublicKey.Generator,
+            details = OutgoingPayment.Details.Normal(
+                makePaymentRequest("e4598076221f5b11012d769a40a9c73d8b152cdcac99d43591c7077564ce3784")
+            ),
+            parts = listOf(
+                makeLightningPart(103_010.msat)
+            ),
+            status = OutgoingPayment.Status.Completed.Succeeded.OffChain(
+                preimage = randomBytes32(),
+                completedAt = 1675270826945
+            )
+        )
+        val metadata = makeMetadata(
+            exchangeRate = 22999.83,
+            userNotes = "This note has multiple lines:\nBrie\nCheddar\nAsiago"
+        )
+
+        val expected = "2023-02-01T17:00:26.945Z,-103010,-3010,,e4598076221f5b11012d769a40a9c73d8b152cdcac99d43591c7077564ce3784,-0.0236 USD,-0.0006 USD,Test 3,\"This note has multiple lines:\n" +
+                "Brie\n" +
+                "Cheddar\n" +
+                "Asiago\"\r\n"
+        val actual = CsvWriter.makeRow(
+            info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
+            localizedDescription = "Test 3",
+            config = CsvWriter.Configuration(
+                includesFiat = true,
+                includesDescription = true,
+                includesNotes = true,
+                swapInAddress = swapInAddress
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testRow_Incoming_NewChannel_DualSwapIn() {
+        val payment = IncomingPayment(
+            preimage = randomBytes32(),
+            origin = IncomingPayment.Origin.DualSwapIn(localInputs = setOf()),
+            received = IncomingPayment.Received(
+                receivedWith = setOf(
+                    IncomingPayment.ReceivedWith.NewChannel(
+                        id = UUID.randomUUID(),
+                        amount = 12_000_000.msat,
+                        serviceFee = 2_931_000.msat,
+                        fundingFee = 69.sat,
+                        channelId = randomBytes32(),
+                        confirmed = true
+                    )
+                ),
+                receivedAt = 1675271683668
+            ),
+            createdAt = 0
+        )
+        val metadata = makeMetadata(
+            exchangeRate = 22999.83,
+            userNotes = "Via dual-funding flow"
+        )
+
+        val expected = "2023-02-01T17:14:43.668Z,12000000,-3000000,tb1qf72v4qyczf7ymmqtr8z3vfqn6dapzl3e7l6tjv,,2.7599 USD,-0.6899 USD,L1 Top-up,Via dual-funding flow\r\n"
+        val actual = CsvWriter.makeRow(
+            info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
+            localizedDescription = "L1 Top-up",
+            config = CsvWriter.Configuration(
+                includesFiat = true,
+                includesDescription = true,
+                includesNotes = true,
+                swapInAddress = swapInAddress
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testRow_Outgoing_SwapOut() {
+        val payment = OutgoingPayment(
+            id = UUID.randomUUID(),
+            recipientAmount = 12_820_000.msat,
+            recipient = PublicKey.Generator,
+            details = OutgoingPayment.Details.SwapOut(
+                address = "tb1qlywh0dk40k87gqphpfs8kghd96hmnvus7r8hhf",
+                paymentRequest = makePaymentRequest(
+                    "edaba30a13f364d660e2878ed537800dde0e8fbe9a28ebc70202c42a59ce90f3"
+                ),
+                swapOutFee = 2_820.sat
+            ),
+            parts = listOf(
+                makeLightningPart(12_000_000.msat),
+                makeLightningPart(820_000.msat)
+            ),
+            status = OutgoingPayment.Status.Completed.Succeeded.OffChain(
+                preimage = randomBytes32(),
+                completedAt = 1675289814498
+            )
+        )
+        val metadata = makeMetadata(
+            exchangeRate = 23686.60,
+            userNotes = null
+        )
+
+        val expected = "2023-02-01T22:16:54.498Z,-12820000,-2820000,,tb1qlywh0dk40k87gqphpfs8kghd96hmnvus7r8hhf,-3.0366 USD,-0.6679 USD,Swap for cash,\r\n"
+        val actual = CsvWriter.makeRow(
+            info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
+            localizedDescription = "Swap for cash",
+            config = CsvWriter.Configuration(
+                includesFiat = true,
+                includesDescription = true,
+                includesNotes = true,
+                swapInAddress = swapInAddress
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+
+/*  @Test
+    fun testRow_Outgoing_ChannelClose() {
+        val payment = OutgoingPayment(
+            id = UUID.randomUUID(),
+            recipientAmount = 8_690_464.msat,
+            recipient = PublicKey.Generator,
+            details = OutgoingPayment.Details.ChannelClosing(
+                channelId = randomBytes32(),
+                closingAddress = "tb1qz5gxe2450uadavle8wwcc5ngquqfj5xp4dy0ja",
+                isSentToDefaultAddress = false
+            ),
+            parts = listOf(),
+            status = OutgoingPayment.Status.Completed.Succeeded.OnChain(
+                completedAt = 1675289814498
+            )
+        )
+        val metadata = makeMetadata(
+            exchangeRate = 23662.59,
+            userNotes = null
+        )
+
+        val expected = "?\r\n"
+        val actual = CsvWriter.makeRow(
+            info = WalletPaymentInfo(payment, metadata, WalletPaymentFetchOptions.All),
+            localizedDescription = "Channel closing",
+            config = CsvWriter.Configuration(
+                includesFiat = true,
+                includesDescription = true,
+                includesNotes = true,
+                swapInAddress = swapInAddress
+            )
+        )
+
+        assertEquals(expected, actual)
+    }
+    */
+
+    /**
+     * The only thing the CsvWriter reads from a PaymentRequest is the paymentHash.
+     * So everything else can be fake.
+     */
+    private fun makePaymentRequest(paymentHash: String) =
+        PaymentRequest.create(
+            chainHash = Block.TestnetGenesisBlock.hash,
+            amount = 10_000.msat,
+            paymentHash = ByteVector32.fromValidHex(paymentHash),
+            privateKey = PrivateKey(value = randomBytes32()),
+            description = "fake invoice",
+            minFinalCltvExpiryDelta = CltvExpiryDelta(128),
+            features = TestConstants.Bob.nodeParams.features,
+            paymentSecret = randomBytes32(),
+            paymentMetadata = null,
+            expirySeconds = null,
+            extraHops = listOf(),
+            timestampSeconds = currentTimestampSeconds()
+        )
+
+    private fun makeLightningPart(amount: MilliSatoshi) =
+        OutgoingPayment.LightningPart(
+            id = UUID.randomUUID(),
+            amount = amount,
+            route = listOf(),
+            status = OutgoingPayment.LightningPart.Status.Succeeded(
+                preimage = randomBytes32(),
+                completedAt = 0
+            ),
+            createdAt = 0
+        )
+
+    private fun makeMetadata(exchangeRate: Double, userNotes: String?) =
+        WalletPaymentMetadata(
+            lnurl = null,
+            originalFiat = ExchangeRate.BitcoinPriceRate(
+                fiatCurrency = FiatCurrency.USD,
+                price = exchangeRate,
+                source = "originalFiat",
+                timestampMillis = 0
+            ),
+            userDescription = null,
+            userNotes = userNotes,
+            modifiedAt = null
+        )
+}


### PR DESCRIPTION
It's a pretty straight-forward process to export the transaction history in CSV format. The hardest part is probably the UI. And I think this meets most needs for now:

<img height="450" src="https://user-images.githubusercontent.com/304604/214429501-9257cf46-f15d-4e9f-8cb3-b4323ba25e55.png"/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img height="450" src="https://user-images.githubusercontent.com/304604/214429654-11291420-327e-447d-a10f-e880b9cc49e6.png"/>

<br/>

<details>
<summary>CSV Output Sample</summary>

```
ID,Date,Amount BTC,Amount Fiat,Description,Notes
36dfad8d0d7141a420329e083ab291c1b1de814fe83a5eabb4b5599eef98c0ba,2023-01-12T15:32:18Z,12000000 msat,2.17 USD,Top-up,
bd73dbcf-87b2-42ff-a64f-daff2f749ae3,2022-11-28T19:10:07Z,-13001 msat,-0.01 USD,Arepa de Choclo,

```
</details>


### Technical Notes:

* Since Kotlin Multiplatform is still lacking when it comes to file & disk IO, I did that stuff in Swift.

* The CSV [format](https://docs.fileformat.com/spreadsheet/csv/) is quite simple, and there are lots of open-source libraries available for every platform. I found a small & clean library I liked for Swift, and used it.

* When the view appears, we automatically fetch the user's oldest payment, and set the "Start Date" accordingly.

* When the user changes the start or end date, we automatically fetch the count, and update the UI accordingly. (*I found this very helpful when I was playing around with it.*)

* During the export process, the UI displays a little spinner and progress report ("32 of 96 payments...")

* Afterwards, the standard iOS export screen appears

* After exporting, the code deletes the CSV file from disk (which is stored in a temp directory, which the OS also cleans automatically)

Fixes issue #179 