### PR TITLE
Add "smart" channels flow in PeerManager

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Buttons.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Buttons.kt
@@ -235,6 +235,7 @@ fun Button(
     border: BorderStroke? = null,
     elevation: ButtonElevation? = null,
     backgroundColor: Color = Color.Unspecified, // transparent by default!
+    onClickLabel: String? = null,
 ) {
     val colors = ButtonDefaults.buttonColors(
         backgroundColor = backgroundColor,
@@ -250,6 +251,7 @@ fun Button(
         modifier = modifier
             .clickable(
                 onClick = onClick,
+                onClickLabel = onClickLabel,
                 enabled = enabled,
                 role = Role.Button,
                 interactionSource = interactionSource,
@@ -284,7 +286,7 @@ fun Button(
                     verticalAlignment = Alignment.CenterVertically,
                     content = {
                         if (text != null && icon != null) {
-                            TextWithIcon(text = text, icon = icon, iconTint = iconTint, space = space)
+                            TextWithIcon(text = text, icon = icon, iconTint = iconTint, space = space, alignBaseLine = true)
                         } else if (text != null) {
                             Text(text)
                         } else if (icon != null) {

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -97,7 +97,7 @@
     <string name="receive__qr_about">QR Code of the invoice</string>
     <string name="receive__qr_amount_label">Amount:</string>
     <string name="receive__qr_desc_label">Desc:</string>
-    <string name="receive__min_amount_pay_to_open">Your wallet is empty. The first payment you receive must be at least <b>%1$s</b>.</string>
+    <string name="receive__min_amount_pay_to_open">Your wallet is empty. First incoming payment must be at least <b>%1$s</b>.</string>
     <string name="receive__edit_button">Edit</string>
     <string name="receive__share_button">Share</string>
     <string name="receive__swapin_button">Show a Bitcoin address</string>
@@ -273,22 +273,15 @@
     <!-- //////////////// list all channels //////////////// -->
 
     <string name="listallchannels_title">Payment channels</string>
-    <string name="listallchannels_in_progress">Please hold…</string>
     <string name="listallchannels_node_id">Node id:</string>
     <string name="listallchannels_no_channels">You don\'t have any channels yet.\n\nPayments channels are created when you receive a payment and a new channel is needed. This is done automatically.</string>
-    <plurals name="listallchannels_channels_header">
-        <item quantity="one">You have %1$d channel.</item>
-        <item quantity="other">You have %1$d channels.</item>
-    </plurals>
-    <string name="listallchannels_copy">Copy</string>
-    <string name="listallchannels_share_all">Share all channels…</string>
     <string name="listallchannels_share">Share</string>
-    <string name="listallchannels_funding_tx">Tx</string>
+    <string name="listallchannels_channel_id">Channel id:</string>
+    <string name="listallchannels_funding_tx">Funding tx</string>
     <string name="listallchannels_funding_tx_desc">See funding transaction</string>
     <string name="listallchannels_close">Close</string>
     <string name="listallchannels_share_subject">Channels data</string>
     <string name="listallchannels_share_title">Share channel data</string>
-    <string name="listallchannels_serialization_error">Could not retrieve channel data</string>
 
     <!-- //////////////// channel details //////////////// -->
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/LocalChannelInfo.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/LocalChannelInfo.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.data
+
+import fr.acinq.lightning.channel.*
+import fr.acinq.lightning.transactions.*
+import fr.acinq.phoenix.utils.extensions.*
+
+data class LocalChannelInfo(
+    val channelId: String,
+    val state: ChannelState,
+    val isBooting: Boolean,
+) {
+    /** True if the channel is terminated and will never be usable again. */
+    val isTerminated by lazy { state is Closing || state is Closed || state is Aborted }
+    /** True if the channel can be used to forward payments. */
+    val isUsable by lazy { state is Normal && !isBooting }
+    /** Smart local balance after taking the state into account. For the raw balance, see [CommitmentSpec.toLocal]. */
+    val localBalance by lazy { state.localBalance() }
+    /** Raw balance of the peer */
+    val remoteBalance by lazy { state.localCommitmentSpec?.toRemote }
+    val fundingTx by lazy {
+        (state as? ChannelStateWithCommitments)?.commitments?.commitInput?.outPoint?.txid?.toString()
+    }
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/LocalChannelInfo.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/LocalChannelInfo.kt
@@ -20,6 +20,14 @@ import fr.acinq.lightning.channel.*
 import fr.acinq.lightning.transactions.*
 import fr.acinq.phoenix.utils.extensions.*
 
+/**
+ * @param channelId the channel's identifier as a hexadecimal string.
+ * @param state the channel's state that may contain commitments information.
+ * @param isBooting if true, this data comes from the local database and the channel has not yet been reestablished
+ *      with the peer. As such, the data may be obsolete (for example, if the peer actually force-closed the channel
+ *      while Phoenix was disconnected). If false, this data is the live view of the channel as negotiated with the
+ *      peer and can be considered up-to-date (but there's no guarantee, as the channel may actually be disconnected!).
+ */
 data class LocalChannelInfo(
     val channelId: String,
     val state: ChannelState,


### PR DESCRIPTION
The purpose of this PR is to help the UI have a more consistent view of the wallet's channels by providing a single source of truth.

## Problem

The `Peer` instance already exposes flow of the channels in `bootFlow` and `channelsFlow`, the first one being the channels in the database when starting up the node, and the second one being the actual, live channels that have been reestablished with the peer, and that second flow is empty while the node is starting (which can take a long time if the connection is bad). In any case this level of details is not useful to the user ; both flows must be combined into one flow. This is what the `BalanceManager` used to do. The `BalanceManager` also applied specific rules to compute the usable balance, by taking the channels' state into account.

However there are other places in the app where we need the list of channels: the channels list screen in the settings, the receive screen (to know if we need to display a liquidity disclaimer), the drain wallet screen...

## Proposed solution

We add a new `channelsFlow` in `PeerManager` that combines `Peer.bootFlow` and `Peer.channelsFlow` and publishes a map of `channelId -> LocalChannelInfo` which is a new object. 

```kotlin
data class LocalChannelInfo(
    val channelId: String,
    val state: ChannelState,
    val isBooting: Boolean,
) {
    val isUsable by lazy { state is Normal && !isBooting }
    val localBalance by lazy { state.localBalance() }
    ...
}
```

This object explicitly declares if the channel data comes from the DB (`isBooting: Boolean`), and also contains a few helpers methods (e.g. to get the usable balance). This flow is what should now be used, whether it is by other managers/MVI controllers in the shared module or directly by the UI code.

Only commit fda6c17104f40fc3c21eef0db0e9b5802ee876ca needs to be reviewed, the other one only affects Android.