### PR TITLE
Display warning if watchtower is disabled

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		DC46BAF826CACCF700E760A6 /* KotlinAssociatedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC46BAF226CACCF700E760A6 /* KotlinAssociatedObject.swift */; };
 		DC46CB1228D9AAB000C4EAC7 /* LockState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC46CB1128D9AAB000C4EAC7 /* LockState.swift */; };
 		DC46CB1628D9F30500C4EAC7 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC46CB1528D9F30500C4EAC7 /* LoadingView.swift */; };
+		DC4864DA29D4E52C00ACD539 /* BgRefreshDisabledPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4864D929D4E52C00ACD539 /* BgRefreshDisabledPopover.swift */; };
 		DC48D2C42593DE30008D138C /* TextFieldCurrencyStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC48D2C32593DE30008D138C /* TextFieldCurrencyStyler.swift */; };
 		DC49DA8E258BB882005BC4BC /* ScaledButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC49DA8D258BB882005BC4BC /* ScaledButtonStyle.swift */; };
 		DC59377127516297003B4B53 /* Sequence+Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC59377027516296003B4B53 /* Sequence+Sum.swift */; };
@@ -415,6 +416,7 @@
 		DC46BAF226CACCF700E760A6 /* KotlinAssociatedObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KotlinAssociatedObject.swift; sourceTree = "<group>"; };
 		DC46CB1128D9AAB000C4EAC7 /* LockState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockState.swift; sourceTree = "<group>"; };
 		DC46CB1528D9F30500C4EAC7 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		DC4864D929D4E52C00ACD539 /* BgRefreshDisabledPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BgRefreshDisabledPopover.swift; sourceTree = "<group>"; };
 		DC48D2C32593DE30008D138C /* TextFieldCurrencyStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldCurrencyStyler.swift; sourceTree = "<group>"; };
 		DC49DA8D258BB882005BC4BC /* ScaledButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaledButtonStyle.swift; sourceTree = "<group>"; };
 		DC59377027516296003B4B53 /* Sequence+Sum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+Sum.swift"; sourceTree = "<group>"; };
@@ -1114,6 +1116,7 @@
 				53BEFE171C182513A5762686 /* HomeView.swift */,
 				DCDD9ED528637FD7001800A3 /* AppStatusButton.swift */,
 				DCDD9ED328637EBB001800A3 /* ToolsButton.swift */,
+				DC4864D929D4E52C00ACD539 /* BgRefreshDisabledPopover.swift */,
 			);
 			path = main;
 			sourceTree = "<group>";
@@ -1437,6 +1440,7 @@
 				DC118C0627B4557D0080BBAC /* ValidateView.swift in Sources */,
 				DC118C0827B457520080BBAC /* FetchActivityNotice.swift in Sources */,
 				DCD7E0AC28EC32CB009C30E5 /* BusinessManager.swift in Sources */,
+				DC4864DA29D4E52C00ACD539 /* BgRefreshDisabledPopover.swift in Sources */,
 				DCE7233027B167240017CF56 /* SyncSeedManager_Actor.swift in Sources */,
 				DCBA371B2758076F00610EC8 /* SyncSeedManager.swift in Sources */,
 				DC39D4F12874DDF40030F18D /* View+If.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/views/main/BgRefreshDisabledPopover.swift
+++ b/phoenix-ios/phoenix-ios/views/main/BgRefreshDisabledPopover.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import os.log
+
+#if DEBUG && true
+fileprivate var log = Logger(
+	subsystem: Bundle.main.bundleIdentifier!,
+	category: "BgRefreshDisabledPopover"
+)
+#else
+fileprivate var log = Logger(OSLog.disabled)
+#endif
+
+
+struct BgRefreshDisabledPopover: View {
+	
+	@Environment(\.popoverState) var popoverState: PopoverState
+	
+	@ViewBuilder
+	var body: some View {
+		
+		VStack(alignment: .trailing) {
+			
+			VStack(alignment: .leading, spacing: 0) {
+				Text("Watchtower Disabled")
+					.font(.title3)
+					.padding(.bottom)
+				
+				Text(
+					"""
+					The watchtower occasionally runs in the background (every few days) \
+					and monitors your funds to ensure everything is safe.
+					"""
+				)
+				.lineLimit(nil)
+				.fixedSize(horizontal: false, vertical: true) // text truncation bugs
+				.padding(.bottom, 15)
+				
+				Text(
+					"""
+					You disabled "background app refresh" for Phoenix which prevents the watchtower \
+					from running. Please enable it to ensure your funds remain safe.
+					"""
+				)
+				.lineLimit(nil)
+				.fixedSize(horizontal: false, vertical: true) // text truncation bugs
+			}
+			.padding(.bottom)
+			
+			HStack {
+				Button {
+					popoverState.close()
+				} label : {
+					Text("Ignore").font(.title3)
+				}
+				.padding(.trailing)
+				Button {
+					openIosSettings()
+				} label: {
+					Text("Fix It").font(.title3)
+				}
+			}
+		}
+		.padding()
+	}
+	
+	func openIosSettings() {
+		log.trace("openIosSettings()")
+		
+		if let bundleIdentifier = Bundle.main.bundleIdentifier,
+			let url = URL(string: UIApplication.openSettingsURLString + bundleIdentifier)
+		{
+			if UIApplication.shared.canOpenURL(url) {
+				UIApplication.shared.open(url)
+			}
+		}
+		
+		popoverState.close()
+	}
+}


### PR DESCRIPTION
We recently improved the handling of iOS notification permissions (PR #345) because "background app refresh" is no longer a requirement for background payments. However "background app refresh" IS required for the watchtower task that runs every few days.

So this PR adds a warning about it, with information about how to fix it.

<img height="450" src="https://user-images.githubusercontent.com/304604/228873874-923dfb78-2b52-49c9-96d3-97e63bc4e13a.png"/>&nbsp;&nbsp;<img height="450" src="https://user-images.githubusercontent.com/304604/228873991-52cec18c-a737-46a0-948a-2d0cac2cc425.png"/>

If the user taps the "Fix it" button, they're taken directly to the settings screen in iOS where they can re-enable "background app refresh" for Phoenix.