### PR TITLE
Show original fiat amount

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		DC67E40B27F3798600496C04 /* AnimatedMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC67E40A27F3798600496C04 /* AnimatedMenu.swift */; };
 		DC682FE8258175CE00CA1114 /* Popover.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC682FE7258175CE00CA1114 /* Popover.swift */; };
 		DC6CF35B2938F32E001837EE /* ListBackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6CF35A2938F32E001837EE /* ListBackgroundColor.swift */; };
+		DC6D26E329E76557006A7814 /* AnimatedClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6D26E229E76557006A7814 /* AnimatedClock.swift */; };
 		DC71E7302723240E0063613D /* KotlinObservables.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC71E72F2723240E0063613D /* KotlinObservables.swift */; };
 		DC71E7332728645B0063613D /* CurrencyConverterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC71E7322728645B0063613D /* CurrencyConverterView.swift */; };
 		DC71E7352728A5720063613D /* KotlinIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC71E7342728A5720063613D /* KotlinIdentifiable.swift */; };
@@ -444,6 +445,7 @@
 		DC67E40A27F3798600496C04 /* AnimatedMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedMenu.swift; sourceTree = "<group>"; };
 		DC682FE7258175CE00CA1114 /* Popover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Popover.swift; sourceTree = "<group>"; };
 		DC6CF35A2938F32E001837EE /* ListBackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListBackgroundColor.swift; sourceTree = "<group>"; };
+		DC6D26E229E76557006A7814 /* AnimatedClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedClock.swift; sourceTree = "<group>"; };
 		DC71E72F2723240E0063613D /* KotlinObservables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinObservables.swift; sourceTree = "<group>"; };
 		DC71E7322728645B0063613D /* CurrencyConverterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyConverterView.swift; sourceTree = "<group>"; };
 		DC71E7342728A5720063613D /* KotlinIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinIdentifiable.swift; sourceTree = "<group>"; };
@@ -608,6 +610,7 @@
 				DC08A51927FB6C5F0041603B /* TopTab.swift */,
 				DC39D4EE287497440030F18D /* SmartModal.swift */,
 				DC39D4F02874DDF40030F18D /* View+If.swift */,
+				DC6D26E229E76557006A7814 /* AnimatedClock.swift */,
 			);
 			path = widgets;
 			sourceTree = "<group>";
@@ -1561,6 +1564,7 @@
 				DC0D2EA72939273B00284608 /* KotlinExtensions+Payments.swift in Sources */,
 				DC72C33925A663CA008A927A /* QRCode.swift in Sources */,
 				DC5CA4ED28F83C3B0048A737 /* DrainWalletView.swift in Sources */,
+				DC6D26E329E76557006A7814 /* AnimatedClock.swift in Sources */,
 				DCAC9FC329675E1A0098D769 /* NavigationWrapper.swift in Sources */,
 				DC65D86428E2F7D700686355 /* ResetWalletView_Action.swift in Sources */,
 				DC71E7332728645B0063613D /* CurrencyConverterView.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/prefs/Prefs.swift
+++ b/phoenix-ios/phoenix-ios/prefs/Prefs.swift
@@ -21,6 +21,7 @@ fileprivate enum Key: String {
 	case invoiceExpirationDays
 	case maxFees
 	case hideAmounts = "hideAmountsOnHomeScreen"
+	case showOriginalFiatAmount
 	case recentPaymentsConfig
 }
 
@@ -40,7 +41,8 @@ class Prefs {
 	private init() {
 		UserDefaults.standard.register(defaults: [
 			Key.isNewWallet.rawValue: true,
-			Key.invoiceExpirationDays.rawValue: 7
+			Key.invoiceExpirationDays.rawValue: 7,
+			Key.showOriginalFiatAmount.rawValue: true
 		])
 	}
 	
@@ -104,6 +106,17 @@ class Prefs {
 	var hideAmounts: Bool {
 		get { defaults.hideAmounts }
 		set { defaults.hideAmounts = newValue }
+	}
+	
+	lazy private(set) var showOriginalFiatAmountPublisher: AnyPublisher<Bool, Never> = {
+		defaults.publisher(for: \.showOriginalFiatAmount, options: [.initial, .new])
+			.removeDuplicates()
+			.eraseToAnyPublisher()
+	}()
+	
+	var showOriginalFiatAmount: Bool {
+		get { defaults.showOriginalFiatAmount }
+		set { defaults.showOriginalFiatAmount = newValue }
 	}
 	
 	lazy private(set) var recentPaymentsConfigPublisher: AnyPublisher<RecentPaymentsConfig, Never> = {
@@ -228,6 +241,7 @@ class Prefs {
 		defaults.removeObject(forKey: Key.invoiceExpirationDays.rawValue)
 		defaults.removeObject(forKey: Key.maxFees.rawValue)
 		defaults.removeObject(forKey: Key.hideAmounts.rawValue)
+		defaults.removeObject(forKey: Key.showOriginalFiatAmount.rawValue)
 		defaults.removeObject(forKey: Key.recentPaymentsConfig.rawValue)
 		
 		self.backupTransactions.resetWallet(encryptedNodeId: encryptedNodeId)
@@ -265,6 +279,11 @@ extension UserDefaults {
 	@objc fileprivate var hideAmounts: Bool {
 		get { bool(forKey: Key.hideAmounts.rawValue) }
 		set { set(newValue, forKey: Key.hideAmounts.rawValue) }
+	}
+	
+	@objc fileprivate var showOriginalFiatAmount: Bool {
+		get { bool(forKey: Key.showOriginalFiatAmount.rawValue) }
+		set { set(newValue, forKey: Key.showOriginalFiatAmount.rawValue) }
 	}
 	
 	@objc fileprivate var recentPaymentsConfig: Data? {

--- a/phoenix-ios/phoenix-ios/utils/CurrencyPrefs.swift
+++ b/phoenix-ios/phoenix-ios/utils/CurrencyPrefs.swift
@@ -24,6 +24,7 @@ class CurrencyPrefs: ObservableObject {
 	@Published private(set) var fiatCurrency: FiatCurrency
 	@Published private(set) var bitcoinUnit: BitcoinUnit
 	@Published private(set) var hideAmounts: Bool
+	@Published private(set) var showOriginalFiatValue: Bool
 	
 	@Published var fiatExchangeRates: [ExchangeRate] = []
 	
@@ -44,6 +45,7 @@ class CurrencyPrefs: ObservableObject {
 		fiatCurrency = GroupPrefs.shared.fiatCurrency
 		bitcoinUnit = GroupPrefs.shared.bitcoinUnit
 		hideAmounts = Prefs.shared.hideAmounts
+		showOriginalFiatValue = Prefs.shared.showOriginalFiatAmount
 		
 		GroupPrefs.shared.fiatCurrencyPublisher.sink {[weak self](newValue: FiatCurrency) in
 			self?.fiatCurrency = newValue
@@ -51,6 +53,10 @@ class CurrencyPrefs: ObservableObject {
 		
 		GroupPrefs.shared.bitcoinUnitPublisher.sink {[weak self](newValue: BitcoinUnit) in
 			self?.bitcoinUnit = newValue
+		}.store(in: &cancellables)
+		
+		Prefs.shared.showOriginalFiatAmountPublisher.sink {[weak self](newValue: Bool) in
+			self?.showOriginalFiatValue = newValue
 		}.store(in: &cancellables)
 		
 		let business = Biz.business
@@ -63,13 +69,13 @@ class CurrencyPrefs: ObservableObject {
 		currencyType: CurrencyType,
 		fiatCurrency: FiatCurrency,
 		bitcoinUnit: BitcoinUnit,
-		exchangeRate: Double,
-		hideAmounts: Bool
+		exchangeRate: Double
 	) {
 		self.currencyType = currencyType
 		self.fiatCurrency = fiatCurrency
 		self.bitcoinUnit = bitcoinUnit
-		self.hideAmounts = hideAmounts
+		self.hideAmounts = false
+		self.showOriginalFiatValue = false
 		
 		let exchangeRate = ExchangeRate.BitcoinPriceRate(
 			fiatCurrency: fiatCurrency,
@@ -161,8 +167,7 @@ class CurrencyPrefs: ObservableObject {
 			currencyType: .bitcoin,
 			fiatCurrency: .usd,
 			bitcoinUnit: .sat,
-			exchangeRate: 20_000.00,
-			hideAmounts: false
+			exchangeRate: 20_000.00
 		)
 	}
 	
@@ -171,8 +176,7 @@ class CurrencyPrefs: ObservableObject {
 			currencyType: .bitcoin,
 			fiatCurrency: .eur,
 			bitcoinUnit: .sat,
-			exchangeRate: 17_000.00,
-			hideAmounts: false
+			exchangeRate: 17_000.00
 		)
 	}
 }

--- a/phoenix-ios/phoenix-ios/views/configuration/general/display configuration/DisplayConfigurationView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/general/display configuration/DisplayConfigurationView.swift
@@ -25,6 +25,7 @@ struct DisplayConfigurationView: View {
 	@State var fiatCurrency = GroupPrefs.shared.fiatCurrency
 	@State var bitcoinUnit = GroupPrefs.shared.bitcoinUnit
 	@State var theme = Prefs.shared.theme
+	@State var showOriginalFiatAmount = Prefs.shared.showOriginalFiatAmount
 	@State var recentPaymentsConfig = Prefs.shared.recentPaymentsConfig
 	@State var notificationSettings = NotificationsManager.shared.settings.value
 	
@@ -53,6 +54,7 @@ struct DisplayConfigurationView: View {
 		List {
 			section_currency()
 			section_theme()
+			section_paymentHistory()
 			section_home()
 			section_backgroundPayments()
 		}
@@ -136,6 +138,41 @@ struct DisplayConfigurationView: View {
 				}
 			}
 			.pickerStyle(SegmentedPickerStyle())
+			
+		} // </Section>
+	}
+	
+	@ViewBuilder
+	func section_paymentHistory() -> some View {
+		
+		Section(header: Text("Payment History")) {
+			
+			Toggle(isOn: $showOriginalFiatAmount) {
+				Text("Show original fiat amount")
+			}
+			.onChange(of: showOriginalFiatAmount) { newValue in
+				Prefs.shared.showOriginalFiatAmount = newValue
+			}
+			
+			Group {
+				if showOriginalFiatAmount {
+					Text(
+						"The displayed fiat value will be the price you paid at the time of the payment."
+					)
+				} else {
+					Text(
+						"""
+						The displayed fiat value will be the current price, \
+						based on the current fiat/bitcoin exchange rate.
+						"""
+					)
+				}
+			}
+			.font(.callout)
+			.fixedSize(horizontal: false, vertical: true) // SwiftUI truncation bugs
+			.foregroundColor(Color.secondary)
+			.padding(.top, 8)
+			.padding(.bottom, 4)
 			
 		} // </Section>
 	}

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
@@ -19,6 +19,11 @@ struct SummaryView: View {
 	@State var paymentInfo: WalletPaymentInfo
 	@State var paymentInfoIsStale: Bool
 	
+	let fetchOptions = WalletPaymentFetchOptions.companion.All
+	
+	@State var showOriginalFiatValue = GlobalEnvironment.currencyPrefs.showOriginalFiatValue
+	@State var showFiatValueExplanation = false
+	
 	@State var showDeletePaymentConfirmationDialog = false
 	
 	@State var didAppear = false
@@ -50,9 +55,7 @@ struct SummaryView: View {
 		if let row = paymentInfo.toOrderRow() {
 			
 			let fetcher = Biz.business.paymentsManager.fetcher
-			let options = WalletPaymentFetchOptions.companion.All
-			
-			if let result = fetcher.getCachedPayment(row: row, options: options) {
+			if let result = fetcher.getCachedPayment(row: row, options: fetchOptions) {
 				
 				self._paymentInfo = State(initialValue: result)
 				self._paymentInfoIsStale = State(initialValue: false)
@@ -138,208 +141,252 @@ struct SummaryView: View {
 	@ViewBuilder
 	func content() -> some View {
 		
-		let payment = paymentInfo.payment
-		
 		VStack {
 			Spacer(minLength: 25)
-			
-			switch payment.state() {
-			case .success:
-				Image("ic_payment_sent")
-					.renderingMode(.template)
-					.resizable()
-					.frame(width: 100, height: 100)
-					.aspectRatio(contentMode: .fit)
-					.foregroundColor(Color.appPositive)
-					.padding(.bottom, 16)
-					.accessibilityHidden(true)
-				VStack {
-					Group {
-						if payment is Lightning_kmpOutgoingPayment {
-							Text("SENT")
-								.accessibilityLabel("Payment sent")
-						} else {
-							Text("RECEIVED")
-								.accessibilityLabel("Payment received")
-						}
-					}
-					.font(Font.title2.bold())
-					.padding(.bottom, 2)
-					
-					if let completedAtDate = payment.completedAtDate() {
-						Text(completedAtDate.format())
-							.font(.subheadline)
-							.foregroundColor(.secondary)
-					}
-				}
-				.padding(.bottom, 30)
-				
-			case .pending:
-				if payment.isOnChain() {
-					Image(systemName: "hourglass.circle")
-						.renderingMode(.template)
-						.resizable()
-						.foregroundColor(Color.borderColor)
-						.frame(width: 100, height: 100)
-						.padding(.bottom, 16)
-						.accessibilityHidden(true)
-					VStack(alignment: HorizontalAlignment.center, spacing: 2) {
-						Text("WAITING FOR CONFIRMATIONS")
-							.font(.title2.uppercaseSmallCaps())
-							.multilineTextAlignment(.center)
-							.padding(.bottom, 6)
-							.accessibilityLabel("Pending payment")
-							.accessibilityHint("Waiting for confirmations")
-						if let depth = minFundingDepth() {
-							let minutes = depth * 10
-							Text("requires \(depth) confirmations")
-								.font(.footnote)
-								.multilineTextAlignment(.center)
-								.foregroundColor(.secondary)
-							Text("≈\(minutes) minutes")
-								.font(.footnote)
-								.multilineTextAlignment(.center)
-								.foregroundColor(.secondary)
-						}
-						if let broadcastDate = onChainBroadcastDate() {
-							Text(broadcastDate.format())
-								.font(.subheadline)
-								.foregroundColor(.secondary)
-								.padding(.top, 12)
-						}
-					} // </VStack>
-					.padding(.bottom, 30)
-				} else {
-					Image("ic_payment_sending")
-						.renderingMode(.template)
-						.resizable()
-						.foregroundColor(Color.borderColor)
-						.frame(width: 100, height: 100)
-						.padding(.bottom, 16)
-						.accessibilityHidden(true)
-					Text("PENDING")
-						.font(.title2.bold())
-						.padding(.bottom, 30)
-						.accessibilityLabel("Pending payment")
-				}
-				
-			case .failure:
-				Image(systemName: "xmark.circle")
-					.renderingMode(.template)
-					.resizable()
-					.frame(width: 100, height: 100)
-					.foregroundColor(.appNegative)
-					.padding(.bottom, 16)
-					.accessibilityHidden(true)
-				VStack {
-					Text("FAILED")
-						.font(.title2.bold())
-						.padding(.bottom, 2)
-						.accessibilityLabel("Failed payment")
-					
-					Text("NO FUNDS HAVE BEEN SENT")
-						.font(.title2.uppercaseSmallCaps())
-						.padding(.bottom, 6)
-					
-					if let completedAtDate = payment.completedAtDate() {
-						Text(completedAtDate.format())
-							.font(Font.subheadline)
-							.foregroundColor(.secondary)
-					}
-					
-				} // </VStack>
-				.padding(.bottom, 30)
-				
-			default:
-				EmptyView()
-			}
-
-			let isOutgoing = payment is Lightning_kmpOutgoingPayment
-			let amount = Utils.format(currencyPrefs, msat: payment.amount, policy: .showMsatsIfNonZero)
-			
-			HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
-				
-				if amount.hasSubFractionDigits {
-					
-					// We're showing sub-fractional values.
-					// For example, we're showing millisatoshis.
-					//
-					// It's helpful to downplay the sub-fractional part visually.
-					
-					let hasStdFractionDigits = amount.hasStdFractionDigits
-					
-					HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
-						Text(verbatim: isOutgoing ? "-" : "+")
-							.font(.largeTitle)
-							.foregroundColor(Color.secondary)
-						Text(verbatim: amount.integerDigits)
-							.font(.largeTitle)
-						Text(verbatim: amount.decimalSeparator)
-							.font(hasStdFractionDigits ? .largeTitle : .title)
-							.foregroundColor(hasStdFractionDigits ? Color.primary : Color.secondary)
-						if hasStdFractionDigits {
-							Text(verbatim: amount.stdFractionDigits)
-								.font(.largeTitle)
-								.foregroundColor(Color.primary)
-						}
-						Text(verbatim: amount.subFractionDigits)
-							.font(.title)
-							.foregroundColor(Color.secondary)
-					}
-					.environment(\.layoutDirection, .leftToRight) // Issue #237
-					
-				} else {
-					
-					HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
-						Text(verbatim: isOutgoing ? "-" : "+")
-							.font(.largeTitle)
-							.foregroundColor(Color.secondary)
-						Text(amount.digits)
-							.font(.largeTitle)
-					}
-					.environment(\.layoutDirection, .leftToRight) // Issue #237
-				}
-				
-				Text_CurrencyName(currency: amount.currency, fontTextStyle: .title3)
-					.foregroundColor(.appAccent)
-					.padding(.leading, 6)
-					.padding(.bottom, 4)
-			}
-			.lineLimit(1)              // SwiftUI truncation bugs
-			.minimumScaleFactor(0.5)   // SwiftUI truncation bugs
-			.onTapGesture { toggleCurrencyType() }
-			.padding([.top, .leading, .trailing], 8)
-			.padding(.bottom, 33)
-			.background(
-				VStack {
-					Spacer()
-					RoundedRectangle(cornerRadius: 10)
-						.frame(width: 70, height: 6, alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/)
-						.foregroundColor(Color.appAccent)
-				}
-			)
-			.padding(.bottom, 24)
-			.accessibilityElement()
-			.accessibilityLabel("\(isOutgoing ? "-" : "+")\(amount.string)")
-			
-			SummaryInfoGrid(paymentInfo: $paymentInfo)
-			
-			if #available(iOS 15.0, *) {
-				if payment.state() == WalletPaymentState.failure {
-					buttonList_withDeleteOption()
-				} else {
-					buttonList()
-				}
-			} else {
-				buttonList()
-			}
-			
+			header_status()
+			header_amount()
+			SummaryInfoGrid(paymentInfo: $paymentInfo, showOriginalFiatValue: $showOriginalFiatValue)
+			buttonList()
 			Spacer(minLength: 25)
 		}
 	}
 	
 	@ViewBuilder
+	func header_status() -> some View {
+		
+		let payment = paymentInfo.payment
+		
+		switch payment.state() {
+		case .success:
+			Image("ic_payment_sent")
+				.renderingMode(.template)
+				.resizable()
+				.frame(width: 100, height: 100)
+				.aspectRatio(contentMode: .fit)
+				.foregroundColor(Color.appPositive)
+				.padding(.bottom, 16)
+				.accessibilityHidden(true)
+			VStack {
+				Group {
+					if payment is Lightning_kmpOutgoingPayment {
+						Text("SENT")
+							.accessibilityLabel("Payment sent")
+					} else {
+						Text("RECEIVED")
+							.accessibilityLabel("Payment received")
+					}
+				}
+				.font(Font.title2.bold())
+				.padding(.bottom, 2)
+				
+				if let completedAtDate = payment.completedAtDate() {
+					Text(completedAtDate.format())
+						.font(.subheadline)
+						.foregroundColor(.secondary)
+				}
+			}
+			.padding(.bottom, 30)
+			
+		case .pending:
+			if payment.isOnChain() {
+				Image(systemName: "hourglass.circle")
+					.renderingMode(.template)
+					.resizable()
+					.foregroundColor(Color.borderColor)
+					.frame(width: 100, height: 100)
+					.padding(.bottom, 16)
+					.accessibilityHidden(true)
+				VStack(alignment: HorizontalAlignment.center, spacing: 2) {
+					Text("WAITING FOR CONFIRMATIONS")
+						.font(.title2.uppercaseSmallCaps())
+						.multilineTextAlignment(.center)
+						.padding(.bottom, 6)
+						.accessibilityLabel("Pending payment")
+						.accessibilityHint("Waiting for confirmations")
+					if let depth = minFundingDepth() {
+						let minutes = depth * 10
+						Text("requires \(depth) confirmations")
+							.font(.footnote)
+							.multilineTextAlignment(.center)
+							.foregroundColor(.secondary)
+						Text("≈\(minutes) minutes")
+							.font(.footnote)
+							.multilineTextAlignment(.center)
+							.foregroundColor(.secondary)
+					}
+					if let broadcastDate = onChainBroadcastDate() {
+						Text(broadcastDate.format())
+							.font(.subheadline)
+							.foregroundColor(.secondary)
+							.padding(.top, 12)
+					}
+				} // </VStack>
+				.padding(.bottom, 30)
+			} else {
+				Image("ic_payment_sending")
+					.renderingMode(.template)
+					.resizable()
+					.foregroundColor(Color.borderColor)
+					.frame(width: 100, height: 100)
+					.padding(.bottom, 16)
+					.accessibilityHidden(true)
+				Text("PENDING")
+					.font(.title2.bold())
+					.padding(.bottom, 30)
+					.accessibilityLabel("Pending payment")
+			}
+			
+		case .failure:
+			Image(systemName: "xmark.circle")
+				.renderingMode(.template)
+				.resizable()
+				.frame(width: 100, height: 100)
+				.foregroundColor(.appNegative)
+				.padding(.bottom, 16)
+				.accessibilityHidden(true)
+			VStack {
+				Text("FAILED")
+					.font(.title2.bold())
+					.padding(.bottom, 2)
+					.accessibilityLabel("Failed payment")
+				
+				Text("NO FUNDS HAVE BEEN SENT")
+					.font(.title2.uppercaseSmallCaps())
+					.padding(.bottom, 6)
+				
+				if let completedAtDate = payment.completedAtDate() {
+					Text(completedAtDate.format())
+						.font(Font.subheadline)
+						.foregroundColor(.secondary)
+				}
+				
+			} // </VStack>
+			.padding(.bottom, 30)
+			
+		default:
+			EmptyView()
+		}
+	}
+	
+	@ViewBuilder
+	func header_amount() -> some View {
+		
+		let isOutgoing = paymentInfo.payment is Lightning_kmpOutgoingPayment
+		let amount = formattedAmount()
+		
+		VStack(alignment: HorizontalAlignment.center, spacing: 10) {
+			
+			HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
+			
+				HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
+					
+					if amount.hasSubFractionDigits {
+						
+						// We're showing sub-fractional values.
+						// For example, we're showing millisatoshis.
+						//
+						// It's helpful to downplay the sub-fractional part visually.
+						
+						let hasStdFractionDigits = amount.hasStdFractionDigits
+						
+						HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
+							Text(verbatim: isOutgoing ? "-" : "+")
+								.font(.largeTitle)
+								.foregroundColor(Color.secondary)
+							Text(verbatim: amount.integerDigits)
+								.font(.largeTitle)
+							Text(verbatim: amount.decimalSeparator)
+								.font(hasStdFractionDigits ? .largeTitle : .title)
+								.foregroundColor(hasStdFractionDigits ? Color.primary : Color.secondary)
+							if hasStdFractionDigits {
+								Text(verbatim: amount.stdFractionDigits)
+									.font(.largeTitle)
+									.foregroundColor(Color.primary)
+							}
+							Text(verbatim: amount.subFractionDigits)
+								.font(.title)
+								.foregroundColor(Color.secondary)
+						}
+						.environment(\.layoutDirection, .leftToRight) // Issue #237
+						
+					} else {
+						
+						HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
+							Text(verbatim: isOutgoing ? "-" : "+")
+								.font(.largeTitle)
+								.foregroundColor(Color.secondary)
+							Text(amount.digits)
+								.font(.largeTitle)
+						}
+						.environment(\.layoutDirection, .leftToRight) // Issue #237
+					}
+					
+					Text_CurrencyName(currency: amount.currency, fontTextStyle: .title3)
+						.foregroundColor(.appAccent)
+						.padding(.leading, 6)
+						.padding(.bottom, 4)
+					
+				} // </HStack>
+				.onTapGesture { toggleCurrencyType() }
+				
+				if currencyPrefs.currencyType == .fiat {
+					
+					AnimatedClock(state: clockStateBinding(), size: 20, animationDuration: 1.25)
+						.padding(.leading, 8)
+				}
+				
+			} // </HStack>
+			.lineLimit(1)            // SwiftUI truncation bugs
+			.minimumScaleFactor(0.5) // SwiftUI truncation bugs
+			
+			Group {
+				if currencyPrefs.currencyType == .fiat && showFiatValueExplanation {
+					if showOriginalFiatValue {
+						Text("amount at time of payment")
+					} else {
+						Text("amount based on current exchange rate")
+					}
+				} else {
+					Text(verbatim: "sats are the standard")
+						.hidden()
+						.accessibilityHidden(true)
+				}
+			}
+			.font(.caption)
+			.foregroundColor(.secondary)
+			
+		} // </VStack>
+		.padding([.top, .leading, .trailing], 8)
+		.padding(.bottom, 13)
+		.background(
+			VStack {
+				Spacer()
+				RoundedRectangle(cornerRadius: 10)
+					.frame(width: 70, height: 6, alignment: .center)
+					.foregroundColor(Color.appAccent)
+			}
+		)
+		.padding(.bottom, 24)
+		.accessibilityElement()
+		.accessibilityLabel("\(isOutgoing ? "-" : "+")\(amount.string)")
+	}
+	
+	@ViewBuilder
 	func buttonList() -> some View {
+		
+		if #available(iOS 15.0, *) {
+			if paymentInfo.payment.state() == WalletPaymentState.failure {
+				buttonList_withDeleteOption()
+			} else {
+				buttonList_standardOptions()
+			}
+		} else {
+			buttonList_standardOptions()
+		}
+	}
+	
+	@ViewBuilder
+	func buttonList_standardOptions() -> some View {
 		
 		// Details | Edit
 		//         ^
@@ -473,6 +520,35 @@ struct SummaryView: View {
 		return nil
 	}
 	
+	func formattedAmount() -> FormattedAmount {
+		
+		let msat = paymentInfo.payment.amount
+		if showOriginalFiatValue && currencyPrefs.currencyType == .fiat {
+			
+			if let originalExchangeRate = paymentInfo.metadata.originalFiat {
+				return Utils.formatFiat(msat: msat, exchangeRate: originalExchangeRate)
+			} else {
+				return Utils.unknownFiatAmount(fiatCurrency: currencyPrefs.fiatCurrency)
+			}
+			
+		} else {
+			return Utils.format(currencyPrefs, msat: msat, policy: .showMsatsIfNonZero)
+		}
+	}
+	
+	func clockStateBinding() -> Binding<AnimatedClock.ClockState> {
+		
+		return Binding {
+			showOriginalFiatValue ? .past : .present
+		} set: { value in
+			switch value {
+				case .past    : showOriginalFiatValue = true
+				case .present : showOriginalFiatValue = false
+			}
+			showFiatValueExplanation = true
+		}
+	}
+	
 	// --------------------------------------------------
 	// MARK: Notifications
 	// --------------------------------------------------
@@ -481,7 +557,6 @@ struct SummaryView: View {
 		log.trace("onAppear()")
 		
 		let business = Biz.business
-		let options = WalletPaymentFetchOptions.companion.All
 		
 		if !didAppear {
 			didAppear = true
@@ -495,7 +570,7 @@ struct SummaryView: View {
 				
 				if let row = paymentInfo.toOrderRow() {
 
-					business.paymentsManager.fetcher.getPayment(row: row, options: options) { (result, _) in
+					business.paymentsManager.fetcher.getPayment(row: row, options: fetchOptions) { (result, _) in
 
 						if let result = result {
 							paymentInfo = result
@@ -504,7 +579,7 @@ struct SummaryView: View {
 
 				} else {
 				
-					business.paymentsManager.getPayment(id: paymentInfo.id(), options: options) { (result, _) in
+					business.paymentsManager.getPayment(id: paymentInfo.id(), options: fetchOptions) { (result, _) in
 						
 						if let result = result {
 							paymentInfo = result
@@ -519,7 +594,7 @@ struct SummaryView: View {
 			// The payment metadata may have changed (e.g. description/notes modified).
 			// So we need to refresh the payment info.
 			
-			business.paymentsManager.getPayment(id: paymentInfo.id(), options: options) { (result, _) in
+			business.paymentsManager.getPayment(id: paymentInfo.id(), options: fetchOptions) { (result, _) in
 				
 				if let result = result {
 					paymentInfo = result
@@ -563,6 +638,7 @@ struct SummaryView: View {
 fileprivate struct SummaryInfoGrid: InfoGridView {
 	
 	@Binding var paymentInfo: WalletPaymentInfo
+	@Binding var showOriginalFiatValue: Bool
 	
 	// <InfoGridView Protocol>
 	@State var keyColumnWidths: [InfoGridRow_KeyColumn_Width] = []
@@ -605,26 +681,26 @@ fileprivate struct SummaryInfoGrid: InfoGridView {
 			paymentTypeRow()
 			channelClosingRow()
 			
-			if let standardFees = paymentInfo.payment.standardFees(currencyPrefs: currencyPrefs) {
+			if let standardFees = paymentInfo.payment.standardFees() {
 				paymentFeesRow(
+					msat: standardFees.0,
 					title: standardFees.1,
-					amount: standardFees.0,
 					explanation: standardFees.2,
 					binding: $popoverPresent_standardFees
 				)
 			}
-			if let minerFees = paymentInfo.payment.minerFees(currencyPrefs: currencyPrefs) {
+			if let minerFees = paymentInfo.payment.minerFees() {
 				paymentFeesRow(
+					msat: minerFees.0,
 					title: minerFees.1,
-					amount: minerFees.0,
 					explanation: minerFees.2,
 					binding: $popoverPresent_minerFees
 				)
 			}
-			if let swapOutFees = paymentInfo.payment.swapOutFees(currencyPrefs: currencyPrefs) {
+			if let swapOutFees = paymentInfo.payment.swapOutFees() {
 				paymentFeesRow(
+					msat: swapOutFees.0,
 					title: swapOutFees.1,
-					amount: swapOutFees.0,
 					explanation: swapOutFees.2,
 					binding: $popoverPresent_swapFees
 				)
@@ -830,7 +906,7 @@ fileprivate struct SummaryInfoGrid: InfoGridView {
 	func paymentTypeRow() -> some View {
 		let identifier: String = #function
 		
-		if let pType = paymentInfo.payment.paymentType() {
+		if let paymentTypeTuple = paymentInfo.payment.paymentType() {
 			
 			InfoGridRow(
 				identifier: identifier,
@@ -844,8 +920,9 @@ fileprivate struct SummaryInfoGrid: InfoGridView {
 				
 				VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
 					
-					Text(pType.0)
-					+ Text(verbatim: " (\(pType.1))")
+					let (type, explanation) = paymentTypeTuple
+					Text(type)
+					+ Text(verbatim: " (\(explanation))")
 						.font(.footnote)
 						.foregroundColor(.secondary)
 					
@@ -904,8 +981,8 @@ fileprivate struct SummaryInfoGrid: InfoGridView {
 	
 	@ViewBuilder
 	func paymentFeesRow(
+		msat: Int64,
 		title: String,
-		amount: FormattedAmount,
 		explanation: String,
 		binding: Binding<Bool>
 	) -> some View {
@@ -923,6 +1000,7 @@ fileprivate struct SummaryInfoGrid: InfoGridView {
 				
 			HStack(alignment: VerticalAlignment.center, spacing: 6) {
 				
+				let amount = formattedAmount(msat: msat)
 				HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
 					
 					if amount.hasSubFractionDigits {
@@ -971,7 +1049,7 @@ fileprivate struct SummaryInfoGrid: InfoGridView {
 						}
 					}
 				}
-			}
+			} // </HStack>
 			
 		} // </InfoGridRow>
 	}
@@ -995,6 +1073,22 @@ fileprivate struct SummaryInfoGrid: InfoGridView {
 				Text(pError)
 				
 			} // </InfoGridRow>
+		}
+	}
+	
+	func formattedAmount(msat: Int64) -> FormattedAmount {
+		
+		if showOriginalFiatValue && currencyPrefs.currencyType == .fiat {
+			
+			if let originalExchangeRate = paymentInfo.metadata.originalFiat {
+				return Utils.formatFiat(msat: msat, exchangeRate: originalExchangeRate)
+			} else {
+				return Utils.unknownFiatAmount(fiatCurrency: currencyPrefs.fiatCurrency)
+			}
+			
+		} else {
+			
+			return Utils.format(currencyPrefs, msat: msat, policy: .showMsatsIfNonZero)
 		}
 	}
 

--- a/phoenix-ios/phoenix-ios/views/inspect/WalletPaymentExtensions.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/WalletPaymentExtensions.swift
@@ -87,7 +87,7 @@ extension Lightning_kmpWalletPayment {
 		return nil
 	}
 	
-	func standardFees(currencyPrefs: CurrencyPrefs) -> (FormattedAmount, String, String)? {
+	func standardFees() -> (Int64, String, String)? {
 		
 		if let incomingPayment = self as? Lightning_kmpIncomingPayment {
 		
@@ -104,7 +104,6 @@ extension Lightning_kmpWalletPayment {
 				
 				if msat > 0 {
 					
-					let formattedAmt = Utils.format(currencyPrefs, msat: msat, policy: .showMsatsIfNonZero)
 					let title = NSLocalizedString("Service Fees", comment: "Label in SummaryInfoGrid")
 					let exp = NSLocalizedString(
 						"""
@@ -114,16 +113,16 @@ extension Lightning_kmpWalletPayment {
 						comment: "Fees explanation"
 					)
 					
-					return (formattedAmt, title, exp)
+					return (msat, title, exp)
 				}
 				else {
 					// I think it's nice to see "Fees: 0 sat" :)
 					
-					let formattedAmt = Utils.format(currencyPrefs, msat: 0, policy: .hideMsats)
+					let msat = Int64(0)
 					let title = NSLocalizedString("Fees", comment: "Label in SummaryInfoGrid")
 					let exp = ""
 					
-					return (formattedAmt, title, exp)
+					return (msat, title, exp)
 				}
 			}
 			
@@ -135,8 +134,6 @@ extension Lightning_kmpWalletPayment {
 				if msat == 0 {
 					return nil
 				}
-				
-				let formattedAmt = Utils.format(currencyPrefs, msat: msat, policy: .showMsatsIfNonZero)
 				
 				var parts = 0
 				var hops = 0
@@ -171,14 +168,14 @@ extension Lightning_kmpWalletPayment {
 					)
 				}
 				
-				return (formattedAmt, title, exp)
+				return (msat, title, exp)
 			}
 		}
 		
 		return nil
 	}
 	
-	func minerFees(currencyPrefs: CurrencyPrefs) -> (FormattedAmount, String, String)? {
+	func minerFees() -> (Int64, String, String)? {
 		
 		if let incomingPayment = self as? Lightning_kmpIncomingPayment {
 			
@@ -196,14 +193,14 @@ extension Lightning_kmpWalletPayment {
 				
 				if sat > 0 {
 					
-					let formattedAmt = Utils.format(currencyPrefs, sat: sat)
+					let msat = Utils.toMsat(sat: sat)
 					let title = NSLocalizedString("Miner Fees", comment: "Label in SummaryInfoGrid")
 					let exp = NSLocalizedString(
 						"Bitcoin network fees paid for on-chain transaction.",
 						comment: "Fees explanation"
 					)
 					
-					return (formattedAmt, title, exp)
+					return (msat, title, exp)
 				}
 			}
 			
@@ -213,9 +210,7 @@ extension Lightning_kmpWalletPayment {
 				
 				// For on-chain payments, the fees are extracted from the mined transaction(s)
 				
-				let fees = outgoingPayment.fees
-				let formattedAmt = Utils.format(currencyPrefs, msat: fees, policy: .showMsatsIfNonZero)
-				
+				let msat = outgoingPayment.fees.msat
 				let title = NSLocalizedString("Miner Fees", comment: "Label in SummaryInfoGrid")
 				
 				let txCount = outgoingPayment.closingTxParts().count
@@ -232,20 +227,19 @@ extension Lightning_kmpWalletPayment {
 					)
 				}
 				
-				return (formattedAmt, title, exp)
+				return (msat, title, exp)
 			}
 		}
 		
 		return nil
 	}
 	
-	func swapOutFees(currencyPrefs: CurrencyPrefs) -> (FormattedAmount, String, String)? {
+	func swapOutFees() -> (Int64, String, String)? {
 		
 		if let outgoingPayment = self as? Lightning_kmpOutgoingPayment,
 		   let _ = outgoingPayment.details.asSwapOut() {
 			
 			let msat = outgoingPayment.fees.msat - outgoingPayment.routingFee.msat
-			let formattedAmt = Utils.format(currencyPrefs, msat: msat, policy: .showMsatsIfNonZero)
 			
 			let title = NSLocalizedString("Swap Fees", comment: "Label in SummaryInfoGrid")
 			let exp = NSLocalizedString(
@@ -253,7 +247,7 @@ extension Lightning_kmpWalletPayment {
 				comment: "Fees explanation"
 			)
 			
-			return (formattedAmt, title, exp)
+			return (msat, title, exp)
 		}
 		
 		return nil

--- a/phoenix-ios/phoenix-ios/views/main/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/main/HomeView.swift
@@ -901,7 +901,7 @@ struct HomeView : MVIView {
 		
 		// pretty much guaranteed to be in the cache
 		let fetcher = paymentsManager.fetcher
-		let options = WalletPaymentFetchOptions.companion.Descriptions
+		let options = PaymentCell.fetchOptions
 		fetcher.getPayment(row: row, options: options) { (result: WalletPaymentInfo?, _) in
 			
 			if let result = result {

--- a/phoenix-ios/phoenix-ios/views/style/Text_CurrencyName.swift
+++ b/phoenix-ios/phoenix-ios/views/style/Text_CurrencyName.swift
@@ -1,7 +1,15 @@
 import SwiftUI
 import PhoenixShared
 
-
+/// Standardized display of the currency name.
+///
+/// For most currencies, this is just simple text:
+/// - "EUR"
+///
+/// But some currencies have special handling:
+/// - "ARSbm"
+///       ^^ we want to display this part with a condensed font
+///
 struct Text_CurrencyName: View {
 	let currency: Currency
 	let fontTextStyle: Font.TextStyle

--- a/phoenix-ios/phoenix-ios/views/transactions/PaymentCell.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/PaymentCell.swift
@@ -14,6 +14,10 @@ fileprivate var log = Logger(OSLog.disabled)
 
 struct PaymentCell : View {
 	
+	static let fetchOptions = WalletPaymentFetchOptions.companion.Descriptions.plus(
+		other: WalletPaymentFetchOptions.companion.OriginalFiat
+	)
+	
 	private let paymentsManager = Biz.business.paymentsManager
 	
 	let row: WalletPaymentOrderRow
@@ -36,15 +40,14 @@ struct PaymentCell : View {
 		self.didAppearCallback = didAppearCallback
 		self.didDisappearCallback = didDisappearCallback
 		
-		let options = WalletPaymentFetchOptions.companion.Descriptions
-		var result = paymentsManager.fetcher.getCachedPayment(row: row, options: options)
+		var result = paymentsManager.fetcher.getCachedPayment(row: row, options: PaymentCell.fetchOptions)
 		if let _ = result {
 			
 			self._fetched = State(initialValue: result)
 			self._fetchedIsStale = State(initialValue: false)
 		} else {
 			
-			result = paymentsManager.fetcher.getCachedStalePayment(row: row, options: options)
+			result = paymentsManager.fetcher.getCachedStalePayment(row: row, options: PaymentCell.fetchOptions)
 			
 			self._fetched = State(initialValue: result)
 			self._fetchedIsStale = State(initialValue: true)
@@ -234,10 +237,11 @@ struct PaymentCell : View {
 		
 		if fetched == nil || fetchedIsStale {
 			
-			let options = WalletPaymentFetchOptions.companion.Descriptions.plus(
-				other: WalletPaymentFetchOptions.companion.OriginalFiat
-			)
-			paymentsManager.fetcher.getPayment(row: row, options: options) { (result: WalletPaymentInfo?, _) in
+			paymentsManager.fetcher.getPayment(
+				row: row,
+				options: PaymentCell.fetchOptions
+			) { (result: WalletPaymentInfo?, _) in
+				
 				self.fetched = result
 			}
 		}

--- a/phoenix-ios/phoenix-ios/views/transactions/TransactionsView.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/TransactionsView.swift
@@ -551,7 +551,7 @@ struct TransactionsView: View {
 		
 		// pretty much guaranteed to be in the cache
 		let fetcher = Biz.business.paymentsManager.fetcher
-		let options = WalletPaymentFetchOptions.companion.Descriptions
+		let options = PaymentCell.fetchOptions
 		fetcher.getPayment(row: row, options: options) { (result: WalletPaymentInfo?, _) in
 			
 			if let result = result {

--- a/phoenix-ios/phoenix-ios/views/widgets/AnimatedClock.swift
+++ b/phoenix-ios/phoenix-ios/views/widgets/AnimatedClock.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+
+struct AnimatedClock: View {
+	
+	enum ClockState {
+		case past
+		case present
+		
+		mutating func toggle() {
+			switch self {
+				case .past    : self = .present
+				case .present : self = .past
+			}
+		}
+	}
+	
+	@Binding var state: ClockState
+	
+	let size: CGFloat
+	let animationDuration: TimeInterval
+	
+	private let lineThickness: CGFloat
+	private let hourHandleLength: CGFloat
+	private let minuteHandleLength: CGFloat
+	private let centralPointSize: CGFloat
+	
+	init(state: Binding<ClockState>, size: CGFloat, animationDuration: TimeInterval) {
+		
+		self._state = state
+		self.size = size
+		self.animationDuration = animationDuration
+		
+		self.lineThickness = max(CGFloat(1.6), CGFloat(size * (8.0 / 300.0)))
+		self.hourHandleLength = CGFloat(size * (80.0 / 300.0))
+		self.minuteHandleLength = CGFloat(size * (120.0 / 300.0))
+		self.centralPointSize = CGFloat(size * (12.0 / 300.0))
+	}
+	
+	@ViewBuilder
+	var body: some View {
+		
+		ZStack {
+			Circle()
+				.frame(width: size, height: size)
+				.foregroundColor(Color(UIColor.systemGray6))
+			
+			Circle()
+				.stroke(lineWidth: lineThickness)
+				.frame(width: size, height: size)
+			
+			// Minutes handle
+			Rectangle()
+				.frame(width: lineThickness, height: minuteHandleLength)
+				.cornerRadius(.infinity)
+				.rotationEffect(
+					.degrees(state == .past ? -2160 : 0),
+					anchor: .bottom
+				)
+				.offset(y: (-minuteHandleLength / 2.0))
+				.animation(.linear(duration: animationDuration), value: state)
+			
+			// Hours handle
+			Rectangle()
+				.frame(width: lineThickness, height: hourHandleLength)
+				.cornerRadius(.infinity)
+				.rotationEffect(
+					.degrees(state == .past ? -270 : -90),
+					anchor: .top
+				)
+				.offset(y: (hourHandleLength / 2.0))
+				.animation(.linear(duration: animationDuration), value: state)
+			
+			// Central point (looks good for bigger sizes)
+			if size > 45 {
+
+				let overlayMedium = centralPointSize / 3.0 * 2.0
+				let overlaySmall = centralPointSize / 3.0 * 1.0
+				Circle()
+					.frame(width: centralPointSize, height: centralPointSize)
+					.overlay(
+						Circle()
+							.frame(width: overlayMedium, height: overlayMedium)
+							.foregroundColor(Color(UIColor.systemGray2))
+					)
+					.overlay(
+						Circle()
+							.frame(width: overlaySmall, height: overlaySmall)
+							.foregroundColor(Color(UIColor.systemGray4))
+					)
+			}
+		}
+		.onTapGesture {
+			state.toggle()
+		}
+	}
+}


### PR DESCRIPTION
For most people, their unit-of-account is the local fiat currency. Maybe someday in the future it will be in sats, but for now it's usually the local fiat currency.

For example if Alice lives in Madrid, then she thinks in Euros. She has a good idea of what things cost - in Euros. If she travels to Colombia and sees a "lunch special" for 30,000 COP ... she has no idea if that's cheap or expensive until she converts the Pesos to Euros. And it's the same if she's told the lunch special is 22,500 sats.

And when she remembers how much she paid for something, she remembers the value in Euros. "I had an amazing lunch for under 6 Euros !"

The problem is that Phoenix displays the payment history using the **current** fiat value. That is, by taking the original payment amount in Bitcoin, and then converting it to fiat using the **current** fiat/bitcoin exchange rate. This is incredibly frustrating because your memory of how much something cost doesn't match what is displayed in Phoenix:

<img width="325" src="https://user-images.githubusercontent.com/304604/229240492-31f66d7e-f36a-4a10-991a-56977f4de710.png"/>

"🤯 I **know** I paid less than 6 Euros for that meal ! 😡"

However, Phoenix knows what the original fiat amount was. (We've been storing that information since PR #259) 

This PR adds an option to display the original fiat amount in your payment history:

<img height="450" src="https://user-images.githubusercontent.com/304604/229240889-3f3108fe-fea2-4a77-ac01-8a873866dfd6.png"/>&nbsp;&nbsp;<img height="450" src="https://user-images.githubusercontent.com/304604/229240921-916ce046-c258-4764-b7cc-c2c6e7089460.png"/>


