### PR TITLE
(android) Handle dust migration and show notification when success

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/MainActivity.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/MainActivity.kt
@@ -55,19 +55,19 @@ class MainActivity : AppCompatActivity() {
 
         // reset required status to expected if needed
         lifecycleScope.launch {
-            if (PrefsDatastore.getLegacyAppStatus(applicationContext).filterNotNull().first() is LegacyAppStatus.Required) {
-                PrefsDatastore.saveStartLegacyApp(applicationContext, LegacyAppStatus.Required.Expected)
+            if (LegacyPrefsDatastore.getLegacyAppStatus(applicationContext).filterNotNull().first() is LegacyAppStatus.Required) {
+                LegacyPrefsDatastore.saveStartLegacyApp(applicationContext, LegacyAppStatus.Required.Expected)
             }
         }
 
         // migrate legacy data if needed
         lifecycleScope.launch {
-            val doDataMigration = PrefsDatastore.getDataMigrationExpected(applicationContext).filterNotNull().first()
+            val doDataMigration = LegacyPrefsDatastore.getDataMigrationExpected(applicationContext).filterNotNull().first()
             if (doDataMigration) {
                 LegacyMigrationHelper.migrateLegacyPreferences(applicationContext)
                 LegacyMigrationHelper.migrateLegacyPayments(applicationContext)
                 delay(5_000)
-                PrefsDatastore.saveDataMigrationExpected(applicationContext, false)
+                LegacyPrefsDatastore.saveDataMigrationExpected(applicationContext, false)
             }
         }
 
@@ -78,11 +78,11 @@ class MainActivity : AppCompatActivity() {
                 if (it is PhoenixAndroidLegacyInfoEvent) {
                     if (it.info.hasChannels) {
                         log.info("legacy channels have been found")
-                        PrefsDatastore.saveStartLegacyApp(applicationContext, LegacyAppStatus.Required.Expected)
+                        LegacyPrefsDatastore.saveStartLegacyApp(applicationContext, LegacyAppStatus.Required.Expected)
                     } else {
                         log.info("no legacy channels were found")
-                        PrefsDatastore.saveDataMigrationExpected(applicationContext, false)
-                        PrefsDatastore.saveStartLegacyApp(applicationContext, LegacyAppStatus.NotRequired)
+                        LegacyPrefsDatastore.saveDataMigrationExpected(applicationContext, false)
+                        LegacyPrefsDatastore.saveStartLegacyApp(applicationContext, LegacyAppStatus.NotRequired)
                     }
                 }
             }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/NoticesViewModel.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/NoticesViewModel.kt
@@ -24,17 +24,19 @@ import fr.acinq.phoenix.managers.AppConfigurationManager
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 
-sealed class Notice {
-    sealed class ShowInHome: Notice()
-    sealed class DoNotShowInHome: Notice()
+sealed class Notice() {
+    abstract val priority: Int
+    sealed class ShowInHome(override val priority: Int) : Notice()
 
-    object NotificationPermission : ShowInHome()
-    object BackupSeedReminder : ShowInHome()
-    object UpdateAvailable : ShowInHome()
-    object CriticalUpdateAvailable : ShowInHome()
-    object MempoolFull : ShowInHome()
+    object MigrationFromLegacy : ShowInHome(1)
+    object CriticalUpdateAvailable : ShowInHome(2)
+    object BackupSeedReminder : ShowInHome(3)
+    object MempoolFull : ShowInHome(10)
+    object UpdateAvailable : ShowInHome(20)
+    object NotificationPermission : ShowInHome(30)
 
     // less important notices
+    sealed class DoNotShowInHome(override val priority: Int = 999) : Notice()
     object WatchTowerLate : DoNotShowInHome()
 }
 

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
@@ -18,7 +18,6 @@ package fr.acinq.phoenix.android.home
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,26 +27,19 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.Dimension
 import androidx.constraintlayout.compose.MotionLayout
 import androidx.constraintlayout.compose.MotionScene
 import androidx.constraintlayout.compose.layoutId
 import fr.acinq.phoenix.android.*
-import fr.acinq.phoenix.android.R
-import fr.acinq.phoenix.android.components.Dialog
 import fr.acinq.phoenix.android.components.PrimarySeparator
 import fr.acinq.phoenix.android.components.mvi.MVIView
 import fr.acinq.phoenix.android.utils.datastore.HomeAmountDisplayMode
-import fr.acinq.phoenix.android.utils.datastore.InternalData
 import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.android.utils.findActivity
 import fr.acinq.phoenix.android.utils.logger
 import fr.acinq.phoenix.data.WalletPaymentId
-import fr.acinq.phoenix.legacy.utils.MigrationResult
-import fr.acinq.phoenix.legacy.utils.PrefsDatastore
-import kotlinx.coroutines.launch
 
 
 @Composable
@@ -81,10 +73,6 @@ fun HomeView(
     val payments by paymentsViewModel.latestPaymentsFlow.collectAsState()
     val swapInBalance = business.balanceManager.swapInWalletBalance.collectAsState()
     val pendingChannelsBalance = business.balanceManager.pendingChannelsBalance.collectAsState()
-
-    // controls for the migration dialog
-    val migrationResult = PrefsDatastore.getMigrationResult(context).collectAsState(initial = null).value
-    val migrationResultShown = InternalData.getMigrationResultShown(context).collectAsState(initial = null).value
 
     BackHandler {
         // force the back button to minimize the app
@@ -231,23 +219,5 @@ fun HomeView(
             )
             BottomBar(Modifier, onSettingsClick, onReceiveClick, onSendClick)
         }
-    }
-
-    if (migrationResultShown == false && migrationResult != null) {
-        MigrationResultDialog(migrationResult) {
-            scope.launch { InternalData.saveMigrationResultShown(context, true) }
-        }
-    }
-}
-
-
-
-@Composable
-private fun MigrationResultDialog(
-    migrationResult: MigrationResult,
-    onClose: () -> Unit
-) {
-    Dialog(title = stringResource(id = R.string.migration_dialog_title), onDismiss = onClose) {
-        Text(text = stringResource(id = R.string.migration_dialog_message), Modifier.padding(horizontal = 24.dp))
     }
 }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/init/CreateWalletView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/init/CreateWalletView.kt
@@ -40,7 +40,8 @@ import fr.acinq.phoenix.android.security.KeyState
 import fr.acinq.phoenix.android.security.SeedManager
 import fr.acinq.phoenix.android.utils.logger
 import fr.acinq.phoenix.controllers.init.Initialization
-import fr.acinq.phoenix.legacy.utils.PrefsDatastore
+import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
+import kotlinx.coroutines.flow.first
 
 
 @Composable
@@ -86,7 +87,7 @@ fun CreateWalletView(
                             }
                             LaunchedEffect(true) {
                                 vm.writeSeed(context, model.mnemonics, true, onSeedWritten)
-                                PrefsDatastore.saveDataMigrationExpected(context, false)
+                                LegacyPrefsDatastore.saveDataMigrationExpected(context, false)
                             }
                         }
                     }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/init/InitView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/init/InitView.kt
@@ -38,7 +38,7 @@ import fr.acinq.phoenix.controllers.ControllerFactory
 import fr.acinq.phoenix.controllers.InitializationController
 import fr.acinq.phoenix.controllers.init.Initialization
 import fr.acinq.phoenix.legacy.utils.LegacyAppStatus
-import fr.acinq.phoenix.legacy.utils.PrefsDatastore
+import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -127,7 +127,7 @@ internal class InitViewModel(controller: InitializationController) : MVIControll
                     val encrypted = EncryptedSeed.V2.NoAuth.encrypt(EncryptedSeed.fromMnemonics(mnemonics))
                     SeedManager.writeSeedToDisk(context, encrypted)
                     writingState = WritingSeedState.WrittenToDisk(encrypted)
-                    PrefsDatastore.saveStartLegacyApp(context, if (isNewWallet) LegacyAppStatus.NotRequired else LegacyAppStatus.Unknown)
+                    LegacyPrefsDatastore.saveStartLegacyApp(context, if (isNewWallet) LegacyAppStatus.NotRequired else LegacyAppStatus.Unknown)
                     log.info("mnemonics has been written to disk")
                 } else {
                     log.warn("cannot overwrite existing seed=${existing.name()}")

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/history/CsvExportView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/history/CsvExportView.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package fr.acinq.phoenix.android.payments
+package fr.acinq.phoenix.android.payments.history
 
 import android.text.format.DateUtils
 import androidx.compose.foundation.layout.*
@@ -30,8 +30,6 @@ import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.business
 import fr.acinq.phoenix.android.components.*
 import fr.acinq.phoenix.android.components.feedback.ErrorMessage
-import fr.acinq.phoenix.android.payments.history.CsvExportState
-import fr.acinq.phoenix.android.payments.history.CsvExportViewModel
 import fr.acinq.phoenix.android.utils.Converter.toBasicAbsoluteDateString
 import fr.acinq.phoenix.android.utils.logger
 import fr.acinq.phoenix.android.utils.positiveColor

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/history/PaymentsHistoryView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/history/PaymentsHistoryView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 ACINQ SAS
+ * Copyright 2023 ACINQ SAS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/service/ChannelsWatcher.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/service/ChannelsWatcher.kt
@@ -27,7 +27,7 @@ import fr.acinq.phoenix.android.utils.SystemNotificationHelper
 import fr.acinq.phoenix.android.utils.datastore.InternalData
 import fr.acinq.phoenix.data.WatchTowerOutcome
 import fr.acinq.phoenix.legacy.utils.LegacyAppStatus
-import fr.acinq.phoenix.legacy.utils.PrefsDatastore
+import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
 import fr.acinq.phoenix.managers.AppConnectionsDaemon
 import fr.acinq.phoenix.managers.NotificationsManager
 import kotlinx.coroutines.flow.filterNotNull
@@ -45,7 +45,7 @@ class ChannelsWatcher(context: Context, workerParams: WorkerParameters) : Corout
         var notificationsManager: NotificationsManager? = null
         try {
 
-            val legacyAppStatus = PrefsDatastore.getLegacyAppStatus(applicationContext).filterNotNull().first()
+            val legacyAppStatus = LegacyPrefsDatastore.getLegacyAppStatus(applicationContext).filterNotNull().first()
             if (legacyAppStatus !is LegacyAppStatus.NotRequired) {
                 log.info("abort channels-watcher service in state=${legacyAppStatus.name()}")
                 InternalData.saveChannelsWatcherOutcome(applicationContext, Outcome.Nominal(currentTimestampMillis()))

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/service/NodeService.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/service/NodeService.kt
@@ -26,7 +26,7 @@ import fr.acinq.phoenix.android.utils.SystemNotificationHelper
 import fr.acinq.phoenix.android.utils.datastore.InternalData
 import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.data.StartupParams
-import fr.acinq.phoenix.legacy.utils.PrefsDatastore
+import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
 import fr.acinq.phoenix.managers.AppConfigurationManager
 import fr.acinq.phoenix.managers.CurrencyManager
 import fr.acinq.phoenix.managers.NodeParamsManager
@@ -221,7 +221,7 @@ class NodeService : Service() {
         val electrumServer = UserPrefs.getElectrumServer(applicationContext).first()
         val isTorEnabled = UserPrefs.getIsTorEnabled(applicationContext).first()
         val liquidityPolicy = UserPrefs.getLiquidityPolicy(applicationContext).first()
-        val trustedSwapInTxs = PrefsDatastore.getMigrationTrustedSwapInTxs(applicationContext).first()
+        val trustedSwapInTxs = LegacyPrefsDatastore.getMigrationTrustedSwapInTxs(applicationContext).first()
         val preferredFiatCurrency = UserPrefs.getFiatCurrency(applicationContext).first()
         val seed = business.walletManager.mnemonicsToSeed(EncryptedSeed.toMnemonics(decryptedPayload))
 

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/NotificationsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/NotificationsView.kt
@@ -67,7 +67,7 @@ fun NotificationsView(
     val log = logger("NotificationsView")
     val notificationsManager = business.notificationsManager
     // TODO: filter rejected payments where the fee policy was X, but the fee policy is now Y
-    val notices = noticesViewModel.notices.values.toList()
+    val notices = noticesViewModel.notices.values.toList().sortedBy { it.priority }
     val notifications by notificationsManager.notifications.collectAsState(emptyList())
 
     DefaultScreenLayout(isScrollable = false) {
@@ -122,7 +122,22 @@ private fun PermamentNotice(
 ) {
     val context = LocalContext.current
     val nc = LocalNavController.current
+    val scope = rememberCoroutineScope()
+
     when (notice) {
+        Notice.MigrationFromLegacy -> {
+            ImportantNotification(
+                icon = R.drawable.ic_party_popper,
+                message = stringResource(id = R.string.inappnotif_migration_from_legacy),
+                actionText = stringResource(id = R.string.inappnotif_migration_from_legacy_action),
+                onActionClick = {
+                    openLink(context, "https://acinq.co/blog/phoenix-splicing-update")
+                    scope.launch {
+                        InternalData.saveLegacyMigrationMessageShown(context, true)
+                    }
+                }
+            )
+        }
         Notice.BackupSeedReminder -> {
             ImportantNotification(
                 icon = R.drawable.ic_key,
@@ -284,7 +299,7 @@ private fun ImportantNotification(
         Row(modifier = Modifier.padding(top = 12.dp, start = 16.dp, end = 16.dp)) {
             PhoenixIcon(resourceId = icon, tint = MaterialTheme.colors.primary, modifier = Modifier
                 .size(18.dp)
-                .offset(y = 1.dp))
+                .offset(y = 2.dp))
             Spacer(modifier = Modifier.width(10.dp))
             Column(modifier = Modifier.alignByBaseline()) {
                 Text(text = message, style = MaterialTheme.typography.body1.copy(fontSize = 16.sp))

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/NotificationsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/NotificationsView.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
@@ -66,41 +67,51 @@ fun NotificationsView(
     val log = logger("NotificationsView")
     val notificationsManager = business.notificationsManager
     // TODO: filter rejected payments where the fee policy was X, but the fee policy is now Y
+    val notices = noticesViewModel.notices.values.toList()
     val notifications by notificationsManager.notifications.collectAsState(emptyList())
 
     DefaultScreenLayout(isScrollable = false) {
         DefaultScreenHeader(onBackClick = onBackClick, title = stringResource(id = R.string.inappnotif_title))
-        LazyColumn {
-            // -- notices
-            val notices = noticesViewModel.notices.values.toList()
-            if (notices.isNotEmpty()) {
-                item {
-                    CardHeader(text = stringResource(id = R.string.inappnotif_notices_title))
+        if (notices.isEmpty() && notifications.isEmpty()) {
+            Spacer(modifier = Modifier.height(12.dp))
+            TextWithIcon(
+                text = stringResource(id = R.string.inappnotif_empty),
+                textStyle = MaterialTheme.typography.caption,
+                icon = R.drawable.ic_sleep,
+                iconTint = MaterialTheme.typography.caption.color,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            )
+        } else {
+            LazyColumn {
+                // -- notices
+                if (notices.isNotEmpty()) {
+                    item {
+                        CardHeader(text = stringResource(id = R.string.inappnotif_notices_title))
+                    }
                 }
-            }
-            items(notices) {
-                PermamentNotice(it)
-            }
+                items(notices) {
+                    PermamentNotice(it)
+                }
 
-            // -- some vertical space if needed
-            if (notices.isNotEmpty() && notifications.isNotEmpty()) {
-                item {
-                    Spacer(modifier = Modifier.height(16.dp))
+                // -- some vertical space if needed
+                if (notices.isNotEmpty() && notifications.isNotEmpty()) {
+                    item {
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
                 }
-            }
 
-            // -- payments notifications
-            if (notifications.isNotEmpty()) {
-                item {
-                    CardHeader(text = stringResource(id = R.string.inappnotif_payments_title))
+                // -- payments notifications
+                if (notifications.isNotEmpty()) {
+                    item {
+                        CardHeader(text = stringResource(id = R.string.inappnotif_payments_title))
+                    }
                 }
-            }
-            items(notifications) {
-                val relatedNotifications = it.first
-                PaymentNotification(it.second, onNotificationRead = { notificationsManager.dismissNotifications(relatedNotifications) })
+                items(notifications) {
+                    val relatedNotifications = it.first
+                    PaymentNotification(it.second, onNotificationRead = { notificationsManager.dismissNotifications(relatedNotifications) })
+                }
             }
         }
-
     }
 }
 
@@ -327,7 +338,9 @@ private fun DimissibleNotification(
                 bottomText?.let {
                     Text(text = it, style = MaterialTheme.typography.caption.copy(fontSize = 14.sp), modifier = Modifier.alignByBaseline())
                 }
-                Spacer(modifier = Modifier.weight(1f).widthIn(min = 8.dp))
+                Spacer(modifier = Modifier
+                    .weight(1f)
+                    .widthIn(min = 8.dp))
                 Text(
                     text = timestamp.toRelativeDateString(),
                     style = MaterialTheme.typography.caption.copy(fontSize = 12.sp),

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/SettingsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/SettingsView.kt
@@ -20,16 +20,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import fr.acinq.lightning.NodeParams
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.Screen
@@ -39,7 +36,7 @@ import fr.acinq.phoenix.android.navController
 import fr.acinq.phoenix.android.navigate
 import fr.acinq.phoenix.android.utils.negativeColor
 import fr.acinq.phoenix.legacy.utils.LegacyAppStatus
-import fr.acinq.phoenix.legacy.utils.PrefsDatastore
+import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
 import kotlinx.coroutines.launch
 
 
@@ -59,7 +56,7 @@ fun SettingsView() {
             Card {
                 Button(text = "Switch to Legacy app", icon = R.drawable.ic_user, onClick = {
                     scope.launch {
-                        PrefsDatastore.saveStartLegacyApp(context, LegacyAppStatus.Required.Expected)
+                        LegacyPrefsDatastore.saveStartLegacyApp(context, LegacyAppStatus.Required.Expected)
                     }
                 }, modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start)
             }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/SettingsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/SettingsView.kt
@@ -46,11 +46,12 @@ import kotlinx.coroutines.launch
 @Composable
 fun SettingsView() {
     val nc = navController
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val chain = business.chain
+
     DefaultScreenLayout {
         DefaultScreenHeader(title = stringResource(id = R.string.menu_settings), onBackClick = { nc.popBackStack() })
-        val scope = rememberCoroutineScope()
-        val context = LocalContext.current
-        val chain = business.chain
 
         // -- debug
         if (chain is NodeParams.Chain.Testnet) {
@@ -71,6 +72,7 @@ fun SettingsView() {
             SettingButton(text = R.string.settings_display_prefs, icon = R.drawable.ic_brush, onClick = { nc.navigate(Screen.Preferences) })
             SettingButton(text = R.string.settings_payment_settings, icon = R.drawable.ic_tool, onClick = { nc.navigate(Screen.PaymentSettings)})
             SettingButton(text = R.string.settings_liquidity_policy, icon = R.drawable.ic_settings, onClick = { nc.navigate(Screen.LiquidityPolicy) })
+            SettingButton(text = R.string.settings_payment_history, icon = R.drawable.ic_list, onClick = { nc.navigate(Screen.PaymentsHistory)})
             SettingButton(text = R.string.settings_notifications, icon = R.drawable.ic_notification, onClick = { nc.navigate(Screen.Notifications)})
         }
 

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/WalletInfoView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/WalletInfoView.kt
@@ -45,7 +45,7 @@ import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 import fr.acinq.phoenix.android.utils.copyToClipboard
 import fr.acinq.phoenix.android.utils.monoTypo
 import fr.acinq.phoenix.android.utils.mutedTextColor
-import fr.acinq.phoenix.legacy.utils.PrefsDatastore
+import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
 import fr.acinq.phoenix.managers.finalOnChainWalletPath
 
 @Composable
@@ -71,7 +71,7 @@ private fun OffChainWalletView(onLightningWalletClick: () -> Unit) {
     Card {
         LightningNodeIdView(nodeId = nodeParams?.nodeId?.toString(), onLightningWalletClick)
 
-        val isDataMigrationExpected by PrefsDatastore.getDataMigrationExpected(context).collectAsState(initial = null)
+        val isDataMigrationExpected by LegacyPrefsDatastore.getDataMigrationExpected(context).collectAsState(initial = null)
         if (isDataMigrationExpected != null) {
             val keyManager by business.walletManager.keyManager.collectAsState()
             keyManager?.let {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/startup/LegacySwitcherView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/startup/LegacySwitcherView.kt
@@ -34,7 +34,7 @@ import fr.acinq.phoenix.android.components.BorderButton
 import fr.acinq.phoenix.android.utils.logger
 import fr.acinq.phoenix.legacy.MainActivity
 import fr.acinq.phoenix.legacy.utils.LegacyAppStatus
-import fr.acinq.phoenix.legacy.utils.PrefsDatastore
+import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -45,7 +45,7 @@ fun LegacySwitcherView(
     val log = logger("LegacySwitcherView")
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val legacyAppStatus by PrefsDatastore.getLegacyAppStatus(context).collectAsState(initial = null)
+    val legacyAppStatus by LegacyPrefsDatastore.getLegacyAppStatus(context).collectAsState(initial = null)
     log.debug { "legacy switcher with legacyAppStatus=${legacyAppStatus}" }
 
     Column(
@@ -63,7 +63,7 @@ fun LegacySwitcherView(
             LegacyAppStatus.Required.Expected -> {
                 LaunchedEffect(key1 = true) {
                     scope.launch {
-                        PrefsDatastore.saveStartLegacyApp(context, LegacyAppStatus.Required.InitStart)
+                        LegacyPrefsDatastore.saveStartLegacyApp(context, LegacyAppStatus.Required.InitStart)
                     }
                 }
             }
@@ -71,7 +71,7 @@ fun LegacySwitcherView(
                 LaunchedEffect(key1 = true) {
                     scope.launch {
                         if (legacyAppStatus == LegacyAppStatus.Required.InitStart) {
-                            PrefsDatastore.saveStartLegacyApp(context, LegacyAppStatus.Required.Running)
+                            LegacyPrefsDatastore.saveStartLegacyApp(context, LegacyAppStatus.Required.Running)
                             log.info { "switching to legacy app" }
                             context.startActivity(Intent(context, MainActivity::class.java).apply {
                                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
@@ -88,7 +88,7 @@ fun LegacySwitcherView(
             LegacyAppStatus.Required.Interrupted -> {
                 BorderButton(text = stringResource(id = R.string.legacyswitch_restart), onClick = {
                     scope.launch {
-                        PrefsDatastore.saveStartLegacyApp(context, LegacyAppStatus.Required.Expected)
+                        LegacyPrefsDatastore.saveStartLegacyApp(context, LegacyAppStatus.Required.Expected)
                     }
                 })
             }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/startup/StartupView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/startup/StartupView.kt
@@ -41,7 +41,7 @@ import fr.acinq.phoenix.android.utils.*
 import fr.acinq.phoenix.android.utils.datastore.InternalData
 import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.legacy.utils.LegacyAppStatus
-import fr.acinq.phoenix.legacy.utils.PrefsDatastore
+import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
 import fr.acinq.phoenix.legacy.utils.Wallet
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -153,7 +153,7 @@ private fun LoadingView(
 ) {
     val log = logger("StartupView")
     val scope = rememberCoroutineScope()
-    val legacyAppStatus = PrefsDatastore.getLegacyAppStatus(context).collectAsState(null).value
+    val legacyAppStatus = LegacyPrefsDatastore.getLegacyAppStatus(context).collectAsState(null).value
     when (walletState) {
         is WalletState.Off -> {
             val keyState = produceState<KeyState>(initialValue = KeyState.Unknown, true) {
@@ -173,7 +173,7 @@ private fun LoadingView(
                                 Text(stringResource(id = R.string.startup_wait_legacy_check))
                                 log.info { "found legacy database file while in unknown legacy status; switching to legacy app" }
                                 LaunchedEffect(true) {
-                                    PrefsDatastore.saveStartLegacyApp(context, LegacyAppStatus.Required.Expected)
+                                    LegacyPrefsDatastore.saveStartLegacyApp(context, LegacyAppStatus.Required.Expected)
                                 }
                             } else {
                                 Text(stringResource(id = R.string.startup_checking_seed))

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/datastore/InternalData.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/datastore/InternalData.kt
@@ -24,7 +24,6 @@ import fr.acinq.phoenix.legacy.utils.Prefs as LegacyPrefs
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
@@ -57,10 +56,10 @@ object InternalData {
     // -- Whether a seed backup warning should be displayed - computed from SEED_MANUAL_BACKUP_DONE & SEED_LOSS_DISCLAIMER_READ
     fun showSeedBackupNotice(context: Context) = prefs(context).map { it[SEED_MANUAL_BACKUP_DONE] != true || it[SEED_LOSS_DISCLAIMER_READ] != true }
 
-    // -- Show a message summing up the migration result.
-    private val MIGRATION_RESULT_SHOWN = booleanPreferencesKey("MIGRATION_RESULT_SHOWN")
-    fun getMigrationResultShown(context: Context): Flow<Boolean> = prefs(context).map { it[MIGRATION_RESULT_SHOWN] ?: false }
-    suspend fun saveMigrationResultShown(context: Context, isShown: Boolean) = context.internalData.edit { it[MIGRATION_RESULT_SHOWN] = isShown }
+    // -- Show a message when the migration has been done.
+    private val LEGACY_MIGRATION_MESSSAGE_SHOWN = booleanPreferencesKey("LEGACY_MIGRATION_MESSSAGE_SHOWN")
+    fun getLegacyMigrationMessageShown(context: Context): Flow<Boolean> = prefs(context).map { it[LEGACY_MIGRATION_MESSSAGE_SHOWN] ?: false }
+    suspend fun saveLegacyMigrationMessageShown(context: Context, isShown: Boolean) = context.internalData.edit { it[LEGACY_MIGRATION_MESSSAGE_SHOWN] = isShown }
 
     // -- Show introduction screen at startup. True by default.
     private val SHOW_INTRO = booleanPreferencesKey("SHOW_INTRO")

--- a/phoenix-android/src/main/res/drawable/ic_list.xml
+++ b/phoenix-android/src/main/res/drawable/ic_list.xml
@@ -1,64 +1,48 @@
-<!--
-  ~ Copyright 2022 ACINQ SAS
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="@dimen/icon_size"
     android:height="@dimen/icon_size"
     android:viewportWidth="24"
     android:viewportHeight="24">
-  <path
-      android:pathData="M8,6L21,6"
-      android:strokeLineJoin="round"
-      android:strokeWidth="1.5"
-      android:fillColor="#00000000"
-      android:strokeColor="?attr/colorPrimary"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M8,12L21,12"
-      android:strokeLineJoin="round"
-      android:strokeWidth="1.5"
-      android:fillColor="#00000000"
-      android:strokeColor="?attr/colorPrimary"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M8,18L21,18"
-      android:strokeLineJoin="round"
-      android:strokeWidth="1.5"
-      android:fillColor="#00000000"
-      android:strokeColor="?attr/colorPrimary"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M3,6L3.01,6"
-      android:strokeLineJoin="round"
-      android:strokeWidth="1.5"
-      android:fillColor="#00000000"
-      android:strokeColor="?attr/colorPrimary"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M3,12L3.01,12"
-      android:strokeLineJoin="round"
-      android:strokeWidth="1.5"
-      android:fillColor="#00000000"
-      android:strokeColor="?attr/colorPrimary"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M3,18L3.01,18"
-      android:strokeLineJoin="round"
-      android:strokeWidth="1.5"
-      android:fillColor="#00000000"
-      android:strokeColor="?attr/colorPrimary"
-      android:strokeLineCap="round"/>
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M8,6L21,6"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M8,12L21,12"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M8,18L21,18"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M3,6L3.01,6"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M3,12L3.01,12"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M3,18L3.01,18"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
 </vector>

--- a/phoenix-android/src/main/res/drawable/ic_notification.xml
+++ b/phoenix-android/src/main/res/drawable/ic_notification.xml
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright 2021 ACINQ SAS
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="@dimen/icon_size"
     android:height="@dimen/icon_size"
@@ -22,14 +6,14 @@
     <path
         android:fillColor="#00000000"
         android:pathData="M18,8A6,6 0,0 0,6 8c0,7 -3,9 -3,9h18s-3,-2 -3,-9"
-        android:strokeWidth="1.5"
+        android:strokeWidth="1.7"
         android:strokeColor="?attr/colorPrimary"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />
     <path
         android:fillColor="#00000000"
         android:pathData="M13.73,21a2,2 0,0 1,-3.46 0"
-        android:strokeWidth="1.5"
+        android:strokeWidth="1.7"
         android:strokeColor="?attr/colorPrimary"
         android:strokeLineCap="round"
         android:strokeLineJoin="round" />

--- a/phoenix-android/src/main/res/drawable/ic_party_popper.xml
+++ b/phoenix-android/src/main/res/drawable/ic_party_popper.xml
@@ -1,0 +1,69 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="@dimen/icon_size"
+    android:height="@dimen/icon_size"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M5.8,11.3 L2,22l10.7,-3.79"
+        android:strokeWidth="2"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M4,3h0.01"
+        android:strokeWidth="2"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M22,8h0.01"
+        android:strokeWidth="2"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M15,2h0.01"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M22,20h0.01"
+        android:strokeWidth="2"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="m22,2 l-2.24,0.75a2.9,2.9 0,0 0,-1.96 3.12v0c0.1,0.86 -0.57,1.63 -1.45,1.63h-0.38c-0.86,0 -1.6,0.6 -1.76,1.44L14,10"
+        android:strokeWidth="1.75"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="m22,13 l-0.82,-0.33c-0.86,-0.34 -1.82,0.2 -1.98,1.11v0c-0.11,0.7 -0.72,1.22 -1.43,1.22H17"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="m11,2 l0.33,0.82c0.34,0.86 -0.2,1.82 -1.11,1.98v0C9.52,4.9 9,5.52 9,6.23V7"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M11,13c1.93,1.93 2.83,4.17 2,5 -0.83,0.83 -3.07,-0.07 -5,-2 -1.93,-1.93 -2.83,-4.17 -2,-5 0.83,-0.83 3.07,0.07 5,2Z"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/phoenix-android/src/main/res/values/important_strings.xml
+++ b/phoenix-android/src/main/res/values/important_strings.xml
@@ -109,6 +109,9 @@
 
     <!-- in-app notifications -->
 
+    <string name="inappnotif_migration_from_legacy">Congratulations! Your wallet has been updated.</string>
+    <string name="inappnotif_migration_from_legacy_action">See what\'s changed</string>
+
     <string name="inappnotif_backup_seed_message">Backup your wallet to prevent losing your bitcoins.</string>
     <string name="inappnotif_backup_seed_action">Backup my wallet</string>
 

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -223,6 +223,7 @@
     <string name="settings_tor">Tor</string>
     <string name="settings_about">About</string>
     <string name="settings_payment_settings">Payment options</string>
+    <string name="settings_payment_history">Payment history</string>
     <string name="settings_notifications">Notifications</string>
 
     <!-- mutual close -->
@@ -296,6 +297,7 @@
     <string name="inappnotif_title">Notifications</string>
     <string name="inappnotif_notices_title">Important messages</string>
     <string name="inappnotif_payments_title">Recent activity</string>
+    <string name="inappnotif_empty">No notifications yet</string>
 
     <!-- settings: display seed -->
 

--- a/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/AppContext.kt
+++ b/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/AppContext.kt
@@ -51,6 +51,8 @@ import kotlin.collections.ArrayList
 val Context.userPrefs: DataStore<Preferences> by preferencesDataStore(name = "userprefs")
 /** This datastore persists miscellaneous internal data representing various states of the app. */
 val Context.internalData: DataStore<Preferences> by preferencesDataStore(name = "internaldata")
+/** This datastore persists data for the legacy-to-kmp migration process. */
+val Context.legacyPrefs: DataStore<Preferences> by preferencesDataStore(name = "legacyprefs")
 
 abstract class AppContext : Application() {
 

--- a/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/MainActivity.kt
+++ b/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/MainActivity.kt
@@ -42,9 +42,8 @@ import fr.acinq.phoenix.legacy.paymentdetails.PaymentDetailsFragment
 import fr.acinq.phoenix.legacy.send.ReadInputFragmentDirections
 import fr.acinq.phoenix.legacy.utils.LegacyAppStatus
 import fr.acinq.phoenix.legacy.utils.Prefs
-import fr.acinq.phoenix.legacy.utils.PrefsDatastore
+import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collect
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -121,7 +120,7 @@ class MainActivity : AppCompatActivity() {
     intent?.let { saveURIIntent(intent) }
 
     lifecycleScope.launchWhenResumed {
-      PrefsDatastore.getLegacyAppStatus(applicationContext).collect {
+      LegacyPrefsDatastore.getLegacyAppStatus(applicationContext).collect {
         delay(500)
         if (it is LegacyAppStatus.NotRequired) {
           log.info("finishing legacy activity in state=${it.name()}")

--- a/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/background/LegacyChannelsWatcher.kt
+++ b/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/background/LegacyChannelsWatcher.kt
@@ -69,7 +69,7 @@ class LegacyChannelsWatcher(context: Context, workerParams: WorkerParameters) : 
   override suspend fun doWork(): Result {
     log.info("channels watcher has started")
     try {
-      val legacyAppStatus = PrefsDatastore.getLegacyAppStatus(applicationContext).filterNotNull().first()
+      val legacyAppStatus = LegacyPrefsDatastore.getLegacyAppStatus(applicationContext).filterNotNull().first()
       if (legacyAppStatus !is LegacyAppStatus.Required) {
         log.info("abort legacy channels-watcher service in state=${legacyAppStatus.name()}")
         Prefs.saveWatcherAttemptOutcome(applicationContext, WatchListener.`Ok$`.`MODULE$`)

--- a/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/background/LegacyFCMService.kt
+++ b/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/background/LegacyFCMService.kt
@@ -42,7 +42,7 @@ class LegacyFCMService : FirebaseMessagingService() {
   /** When receiving a message over FCM, starts the eclair node service (in foreground). */
   override fun onMessageReceived(remoteMessage: RemoteMessage) {
     serviceScope.launch {
-      val legacyAppStatus = PrefsDatastore.getLegacyAppStatus(applicationContext).filterNotNull().first()
+      val legacyAppStatus = LegacyPrefsDatastore.getLegacyAppStatus(applicationContext).filterNotNull().first()
       if (legacyAppStatus !is LegacyAppStatus.Required) {
         log.debug("cancel legacy fcm service in state=${legacyAppStatus.name()}")
         return@launch

--- a/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/main/MigrationFragmentDialog.kt
+++ b/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/main/MigrationFragmentDialog.kt
@@ -25,7 +25,6 @@ import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewModelScope
 import fr.acinq.bitcoin.scala.ByteVector32
 import fr.acinq.eclair.channel.*
@@ -35,18 +34,13 @@ import fr.acinq.phoenix.legacy.background.EclairNodeService
 import fr.acinq.phoenix.legacy.background.KitState.Bootstrap.Init.getKmpSwapInAddress
 import fr.acinq.phoenix.legacy.databinding.FragmentMigrationBinding
 import fr.acinq.phoenix.legacy.utils.LegacyAppStatus
-import fr.acinq.phoenix.legacy.utils.MigrationResult
-import fr.acinq.phoenix.legacy.utils.PrefsDatastore
+import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.bouncycastle.util.encoders.Hex
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import scala.collection.JavaConverters
-import scala.util.Either
-import scala.util.Left
-import scodec.bits.ByteVector
 
 class MigrationFragmentDialog : DialogFragment() {
   val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -273,16 +267,10 @@ class MigrationDialogViewModel : ViewModel() {
 
           // pause then update preferences to switch to the new app
           delay(3_000)
-          PrefsDatastore.saveDataMigrationExpected(context, true)
-          PrefsDatastore.saveMigrationResult(
-            context, MigrationResult(
-              legacyNodeId = legacyNodeId,
-              newNodeId = kmpNodeId,
-              address = swapInAddress
-            )
-          )
-          PrefsDatastore.saveMigrationTrustedSwapInTxs(context, mutualClosePublishedTxs)
-          PrefsDatastore.saveStartLegacyApp(context, LegacyAppStatus.NotRequired)
+          LegacyPrefsDatastore.saveDataMigrationExpected(context, true)
+          LegacyPrefsDatastore.saveHasMigratedFromLegacy(context, true)
+          LegacyPrefsDatastore.saveMigrationTrustedSwapInTxs(context, mutualClosePublishedTxs)
+          LegacyPrefsDatastore.saveStartLegacyApp(context, LegacyAppStatus.NotRequired)
         }
       }
     }

--- a/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/send/SendFragment.kt
+++ b/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/send/SendFragment.kt
@@ -35,6 +35,7 @@ import fr.acinq.eclair.wire.SwapOutResponse
 import fr.acinq.phoenix.legacy.BaseFragment
 import fr.acinq.phoenix.legacy.NavGraphMainDirections
 import fr.acinq.phoenix.legacy.R
+import fr.acinq.phoenix.legacy.ServiceStatus
 import fr.acinq.phoenix.legacy.databinding.FragmentSendBinding
 import fr.acinq.phoenix.legacy.db.AppDb
 import fr.acinq.phoenix.legacy.paymentdetails.PaymentDetailsFragment
@@ -86,7 +87,7 @@ class SendFragment : BaseFragment() {
       mBinding.unit.setSelection(unitList.indexOf(unit.code()))
     }
 
-    model.state.observe(viewLifecycleOwner, { state ->
+    model.state.observe(viewLifecycleOwner) { state ->
       context?.let { ctx ->
         model.isAmountFieldPristine.value = true
         when {
@@ -123,9 +124,9 @@ class SendFragment : BaseFragment() {
           else -> Unit
         }
       }
-    })
+    }
 
-    model.amountError.observe(viewLifecycleOwner, { error ->
+    model.amountError.observe(viewLifecycleOwner) { error ->
       if (model.isAmountFieldPristine.value != true) {
         if (error != null) {
           mBinding.amountConverted.text = ""
@@ -149,9 +150,9 @@ class SendFragment : BaseFragment() {
           mBinding.amountError.visibility = View.GONE
         }
       }
-    })
+    }
 
-    app.networkInfo.observe(viewLifecycleOwner, {
+    app.networkInfo.observe(viewLifecycleOwner) {
       if (!it.lightningConnected) {
         mBinding.sendButton.setIsPaused(true)
         mBinding.sendButton.setText(getString(R.string.legacy_btn_pause_connecting))
@@ -162,9 +163,9 @@ class SendFragment : BaseFragment() {
         mBinding.sendButton.setIsPaused(false)
         mBinding.sendButton.setText(getString(R.string.legacy_send_pay_button))
       }
-    })
+    }
 
-    model.checkAndSetPaymentRequest(app.service, args.payload)
+    model.checkAndSetPaymentRequest(app.service, args.payload, swapOutSettings)
 
     mBinding.amount.addTextChangedListener(object : TextWatcher {
       override fun afterTextChanged(s: Editable?) {
@@ -237,6 +238,10 @@ class SendFragment : BaseFragment() {
       if (state is SendState.InvalidInvoice.AlreadyPaid) {
         findNavController().navigate(NavGraphMainDirections.globalActionAnyToPaymentDetails(PaymentDetailsFragment.OUTGOING, state.parentId.toString(), false))
       }
+    }
+
+    mBinding.swapoutServiceDisabledButton.setOnClickListener {
+      findNavController().popBackStack()
     }
   }
 

--- a/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/settings/SettingsFragment.kt
+++ b/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/settings/SettingsFragment.kt
@@ -27,7 +27,7 @@ import fr.acinq.phoenix.legacy.R
 import fr.acinq.phoenix.legacy.background.KitState
 import fr.acinq.phoenix.legacy.databinding.FragmentSettingsBinding
 import fr.acinq.phoenix.legacy.utils.LegacyAppStatus
-import fr.acinq.phoenix.legacy.utils.PrefsDatastore
+import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
 import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -74,7 +74,7 @@ class SettingsFragment : BaseFragment(stayIfNotStarted = true) {
     mBinding.paymentSettingsButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_payment_settings) }
     mBinding.switchModernButton.setOnClickListener {
       lifecycleScope.launch {
-        PrefsDatastore.saveStartLegacyApp(requireContext(), LegacyAppStatus.NotRequired)
+        LegacyPrefsDatastore.saveStartLegacyApp(requireContext(), LegacyAppStatus.NotRequired)
       }
     }
   }

--- a/phoenix-legacy/src/main/res/layout/fragment_migration.xml
+++ b/phoenix-legacy/src/main/res/layout/fragment_migration.xml
@@ -141,6 +141,56 @@
       </androidx.constraintlayout.widget.ConstraintLayout>
 
       <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/confirm_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="@dimen/space_md_p"
+        android:paddingVertical="@dimen/space_md_p"
+        android:visibility="@{model.state instanceof MigrationScreenState.ConfirmMigration}"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+          android:id="@+id/confirm_title"
+          style="@style/dialog_title"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="@string/legacy_migration_confirm_title"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+          android:id="@+id/confirm_details"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="8dp"
+          android:text=""
+          android:textSize="14sp"
+          app:layout_constraintTop_toBottomOf="@id/confirm_title"
+          tools:ignore="RtlSymmetry" />
+
+        <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
+          android:id="@+id/confirm_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/space_lg"
+          android:background="@drawable/button_bg_primary_border"
+          app:icon="@drawable/ic_check_circle"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/confirm_details"
+          app:text="@string/legacy_migration_confirm_proceed" />
+
+        <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
+          android:id="@+id/cancel_confirm_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/space_md"
+          android:background="@drawable/button_bg_no_border"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/confirm_button"
+          app:text="@string/legacy_migration_confirm_cancel" />
+
+      </androidx.constraintlayout.widget.ConstraintLayout>
+
+      <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/migration_complete_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -216,14 +266,6 @@
           app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
-          android:id="@+id/paused_dust_message"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:text="@string/legacy_migration_paused_dust"
-          android:visibility="@{model.state instanceof MigrationScreenState.Paused.AllChannelsAreDust}"
-          app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
           android:id="@+id/paused_opening_message"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
@@ -236,7 +278,7 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           app:barrierDirection="bottom"
-          app:constraint_referenced_ids="paused_swapin_message, paused_forceclose_message, paused_opening_message, paused_disconnected_message, paused_dust_message" />
+          app:constraint_referenced_ids="paused_swapin_message, paused_forceclose_message, paused_opening_message, paused_disconnected_message" />
 
         <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
           android:id="@+id/paused_button"

--- a/phoenix-legacy/src/main/res/layout/fragment_migration.xml
+++ b/phoenix-legacy/src/main/res/layout/fragment_migration.xml
@@ -216,6 +216,14 @@
           app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
+          android:id="@+id/paused_dust_message"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="@string/legacy_migration_paused_dust"
+          android:visibility="@{model.state instanceof MigrationScreenState.Paused.AllChannelsAreDust}"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
           android:id="@+id/paused_opening_message"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
@@ -228,7 +236,7 @@
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           app:barrierDirection="bottom"
-          app:constraint_referenced_ids="paused_swapin_message, paused_forceclose_message, paused_opening_message, paused_disconnected_message" />
+          app:constraint_referenced_ids="paused_swapin_message, paused_forceclose_message, paused_opening_message, paused_disconnected_message, paused_dust_message" />
 
         <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
           android:id="@+id/paused_button"

--- a/phoenix-legacy/src/main/res/layout/fragment_send.xml
+++ b/phoenix-legacy/src/main/res/layout/fragment_send.xml
@@ -177,6 +177,37 @@
       </androidx.constraintlayout.widget.ConstraintLayout>
 
       <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/swapout_service_disabled"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/space_lg"
+        android:background="@drawable/rounded"
+        android:padding="@dimen/space_lg"
+        android:visibility="@{model.state instanceof SendState.Onchain.SwapOutServiceDisabled}"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/balance_section"
+        app:layout_constraintWidth_max="@dimen/max_width_sm">
+
+        <TextView
+          android:id="@+id/swapout_service_disabled_message"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="@string/legacy_send_swap_service_disabled"
+          app:layout_constraintTop_toTopOf="parent" />
+
+        <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
+          android:id="@+id/swapout_service_disabled_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/space_md"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/swapout_service_disabled_message"
+          app:text="@string/legacy_btn_ok" />
+      </androidx.constraintlayout.widget.ConstraintLayout>
+
+      <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/payment_section"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/phoenix-legacy/src/main/res/values-cs/strings.xml
+++ b/phoenix-legacy/src/main/res/values-cs/strings.xml
@@ -118,6 +118,7 @@
   <string name="legacy_send_error_sending">Nastala chyba při odesílání platby. Žádné peníze nebyly odeslány.</string>
   <string name="legacy_send_pay_button">Zaplatit</string>
   <string name="legacy_send_swap_in_progress">Probíhá směna…</string>
+  <string name="legacy_send_swap_service_disabled">Služba swap pro placení adres on-chain byla vypnuta.\n\nProsím, použijte službu třetí strany.</string>
   <string name="legacy_send_swap_error">Směna selhala. Prosím, zkuste to znovu.</string>
   <string name="legacy_send_swap_required_button">Vyžádat směnu</string>
   <string name="legacy_send_swap_complete_recap_amount">Množství</string>

--- a/phoenix-legacy/src/main/res/values-cs/strings.xml
+++ b/phoenix-legacy/src/main/res/values-cs/strings.xml
@@ -417,4 +417,33 @@
   <string name="legacy_conndialog_ok">Připojen</string>
   <string name="legacy_conndialog_not_ok">Připojuji…</string>
 
+  <!-- //////////////// Migration to KMP //////////////// -->
+
+  <string name="legacy_migration_title">Phoenix upgrade</string>
+  <string name="legacy_migration_ready_message">Upgrade na nejnovější verzi Phoenixu se špičkovým Lightning enginem a novými funkcemi.\n\nVaše kanály budou sloučeny dohromady. Tento proces je automatizovaný.</string>
+  <string name="legacy_migration_prepare_button">Upgrade</string>
+  <string name="legacy_migration_prepare_button_disconnected">Připojení…</string>
+  <string name="legacy_migration_dismiss_button">Teď ne</string>
+
+  <string name="legacy_migration_paused_swap_in">Nemůžete nyní upgradovat: čeká se na vklad na řetězec.\n\nZkuste to později, až bude tento vklad potvrzen.</string>
+  <string name="legacy_migration_paused_opening">Nemůžete nyní upgradovat: některé kanály jsou právě otevřeny.\n\nZkuste to znovu později, až budou tyto kanály otevřeny a aktivní.</string>
+  <string name="legacy_migration_paused_force_close">Nemůžete nyní upgradovat: některé kanály jsou násilně uzavřeny.\n\nZkuste to znovu později, až budou tyto kanály zcela uzavřeny. Všimněte si, že nucené uzavření může trvat několik dní.</string>
+  <string name="legacy_migration_paused_disconnected">Nemůžete nyní upgradovat, protože jste odpojeni od Lightningu a/nebo Electrumu.\n\nZkuste to znovu později, až bude spojení navázáno.</string>
+
+  <string name="legacy_migration_confirm_title">Potvrzení migrace</string>
+  <string name="legacy_migration_confirm_dust">%1$d z %2$d kanálů drží méně než je limit prachu bitcoinů (546 sat). Jejich zůstatek připadne těžařům bitcoinů.</string>
+  <string name="legacy_migration_confirm_proceed">Proceed</string>
+  <string name="legacy_migration_confirm_cancel">Zrušit</string>
+
+  <string name="legacy_migration_processing_title">Zpracování migrace…</string>
+  <string name="legacy_migration_processing_disconnected">Ztráta spojení.\nZachovat aplikaci v popředí.</string>
+
+  <string name="legacy_migration_complete_title">Migrace dokončena</string>
+  <string name="legacy_migration_complete_details">Přepnutí na novou aplikaci…</string>
+
+  <string name="legacy_migration_failure_title">Upgrade selhal</string>
+  <string name="legacy_migration_failure_generic">Některé nebo všechny kanály nemusely být migrovány.\n\nProces upgradu musí být zahájen znovu.</string>
+  <string name="legacy_migration_failure_swapin_address_error">Phoenix nemohl vygenerovat platnou adresu pro migraci.\n\nProces aktualizace musí být spuštěn znovu.</string>
+  <string name="legacy_migration_failure_closing_error">Některé kanály se nepodařilo uzavřít.\n\nPro jejich migraci je nutné proces upgradu spustit znovu.</string>
+
 </resources>

--- a/phoenix-legacy/src/main/res/values-de/strings.xml
+++ b/phoenix-legacy/src/main/res/values-de/strings.xml
@@ -815,4 +815,37 @@
   <string name="legacy_paymentmode_lightning">Bezahle mit Lightning</string>
   <string name="legacy_paymentmode_lightning_desc">Dies ist die empfohlene Option</string>
 
+  <!-- //////////////// Migration to KMP //////////////// -->
+
+  <string name="legacy_migration_title">Phoenix Upgrade</string>
+  <string name="legacy_migration_ready_message">Upgrade auf die neueste Version von Phoenix, mit einer hochmodernen Lightning-Engine und neuen Funktionen.\n\nIhre Kanäle werden zusammengeführt. Dieser Prozess ist automatisiert.</string>
+  <string name="legacy_migration_prepare_button">Upgrade</string>
+  <string name="legacy_migration_prepare_button_disconnected">Verbindung herstellen…</string>
+  <string name="legacy_migration_dismiss_button">Nicht jetzt</string>
+
+  <string name="legacy_migration_paused_swap_in">Sie können jetzt nicht upgraden: eine On-Chain-Hinterlegung steht noch aus.\n\nVersuchen Sie es später noch einmal, wenn diese Hinterlegung bestätigt wurde.</string>
+  <string name="legacy_migration_paused_opening">Sie können jetzt nicht upgraden: Einige Kanäle werden gerade geöffnet.\n\nVersuchen Sie es später erneut, wenn diese Kanäle geöffnet und aktiv sind.</string>
+  <string name="legacy_migration_paused_force_close">Sie können jetzt nicht aktualisieren: Einige Channels werden zwangsweise geschlossen.\n\nVersuchen Sie es später erneut, wenn diese Channels vollständig geschlossen wurden. Beachten Sie, dass es mehrere Tage dauern kann, bis die Schließung abgeschlossen ist.</string>
+  <string name="legacy_migration_paused_disconnected">Sie können jetzt nicht upgraden, weil die Verbindung zu Lightning und/oder Electrum unterbrochen wurde.\n\nVersuchen Sie es später erneut, wenn die Verbindung wieder hergestellt ist.</string>
+
+  <string name="legacy_migration_confirm_title">Bestätigen Sie die Migration</string>
+  <string name="legacy_migration_confirm_dust">%1$d von %2$d Channels halten weniger als das Bitcoin Dust Limit (546 sat). Ihr Guthaben geht an die Bitcoin Netzwerk Miners.</string>
+  <string name="legacy_migration_confirm_proceed">Fortfahren</string>
+  <string name="legacy_migration_confirm_cancel">Abbrechen</string>
+
+  <string name="legacy_migration_processing_title">Bearbeitung der Migration…</string>
+  <string name="legacy_migration_processing_disconnected">Verbindung unterbrochen.\nBitte lassen Sie die Anwendung im Vordergrund.</string>
+  <string name="legacy_migration_swap_address">Migrationsadresse erhalten</string>
+  <string name="legacy_migration_listing_channels">Kanäle überprüfen</string>
+  <string name="legacy_migration_closing_channels">Kanäle schließen (%1$d/%2$d)</string>
+  <string name="legacy_migration_monitoring_channels_publish">Veröffentlichen von Transaktionen (%1$s/%2$d)</string>
+
+  <string name="legacy_migration_complete_title">Migration abgeschlossen</string>
+  <string name="legacy_migration_complete_details">Umschaltung auf die neue Anwendung…</string>
+
+  <string name="legacy_migration_failure_title">Upgrade ist fehlgeschlagen</string>
+  <string name="legacy_migration_failure_generic">Einige oder alle Kanäle wurden möglicherweise nicht migriert.\n\nDer Upgrade-Prozess muss erneut gestartet werden.</string>
+  <string name="legacy_migration_failure_swapin_address_error">Phoenix konnte keine gültige Adresse für die Migration generieren.\n\nDer Upgrade-Prozess muss neu gestartet werden.</string>
+  <string name="legacy_migration_failure_closing_error">Einige Kanäle konnten nicht geschlossen werden.\n\nDer Upgrade-Prozess muss erneut gestartet werden, um diese zu migrieren.</string>
+
 </resources>

--- a/phoenix-legacy/src/main/res/values-de/strings.xml
+++ b/phoenix-legacy/src/main/res/values-de/strings.xml
@@ -111,8 +111,8 @@
   <string name="legacy_receive_min_amount_pay_to_open">
     <![CDATA[Ihre Wallet ist leer. Die erste Zahlung, die Sie erhalten, muss mindestens <b>%1$s</b> betragen.]]>
   </string>
-  <string name="legacy_receive_paytoopen_disabled">Die Erstellung von Kanälen wurde vorübergehend deaktiviert. Möglicherweise können Sie einige Zahlungen nicht erhalten.</string>
-  <string name="legacy_receive_paytoopen_disabled_nochannels">Die Erstellung von Kanälen wurde vorübergehend deaktiviert. Sie werden keine Zahlungen erhalten können.</string>
+  <string name="legacy_receive_paytoopen_disabled">Die Erstellung von Kanälen wurde deaktiviert. Möglicherweise können Sie einige Zahlungen nicht erhalten.</string>
+  <string name="legacy_receive_paytoopen_disabled_nochannels">Die Erstellung von Kanälen wurde deaktiviert. Sie werden keine Zahlungen erhalten können.</string>
   <string name="legacy_receive_address_label">Adresse</string>
   <string name="legacy_receive_withdraw_button">Benutze LNURL Link</string>
 
@@ -136,7 +136,7 @@
     <![CDATA[
     <b>Dienst deaktiviert</b>
     <br /><br />
-    Der on-Chain Einzahlungs-Swap-Dienst wurde vorübergehend deaktiviert.
+    Der on-Chain Einzahlungs-Swap-Dienst wurde deaktiviert.
     <br /><br />
     Versuchen Sie es später erneut.
   ]]>
@@ -187,6 +187,7 @@
   <string name="legacy_send_error_sending">Beim Versuch, diese Zahlung zu senden, ist ein interner Fehler aufgetreten. Es wurde kein Geld gesendet.</string>
   <string name="legacy_send_pay_button">Bezahlen</string>
   <string name="legacy_send_swap_in_progress">Transaktion wird vorbereitet</string>
+  <string name="legacy_send_swap_service_disabled">Der Swap-Service für die Bezahlung von On-Chain-Adressen wurde deaktiviert.\n\nBitte verwenden Sie einen Dienst eines Drittanbieters.</string>
   <string name="legacy_send_swap_error">Swap in die Chain ist fehlgeschlagen. Bitte versuchen Sie es erneut.</string>
   <string name="legacy_send_swap_required_button">Transaktion vorbereiten</string>
   <string name="legacy_send_swap_complete_recap_amount">Betrag</string>

--- a/phoenix-legacy/src/main/res/values-es/strings.xml
+++ b/phoenix-legacy/src/main/res/values-es/strings.xml
@@ -461,4 +461,37 @@
   Si tienes preguntas, consulta las <a href="https://phoenix.acinq.co/faq">Preguntas frecuentes</a>. También puedes contactar con el <a href="https://phoenix.acinq.co/support">soporte</a> para obtener ayuda.
   ]]></string>
 
+  <!-- //////////////// Migration to KMP //////////////// -->
+
+  <string name="legacy_migration_title">Actualización de Phoenix</string>
+  <string name="legacy_migration_ready_message">Actualízate a la última versión de Phoenix, con un motor Lightning de última generación y nuevas funciones.\n\nSus canales se fusionarán. Este proceso está automatizado.</string>
+  <string name="legacy_migration_prepare_button">Actualizar</string>
+  <string name="legacy_migration_prepare_button_disconnected">Connecting…</string>
+  <string name="legacy_migration_dismiss_button">Ahora no</string>
+
+  <string name="legacy_migration_paused_swap_in">No puede actualizar ahora: hay pendiente un depósito en la cadena.\n\nVuelva a intentarlo más tarde, cuando se haya confirmado el depósito.</string>
+  <string name="legacy_migration_paused_opening">No puede actualizar ahora: algunos canales se están abriendo en este momento.\n\nVuelve a intentarlo más tarde, cuando estos canales se hayan abierto y estén activos.</string>
+  <string name="legacy_migration_paused_force_close">No puede actualizar ahora: algunos canales están siendo cerrados a la fuerza.\n\nVuelva a intentarlo más tarde, cuando estos canales se hayan cerrado por completo. Tenga en cuenta que el cierre forzado puede tardar varios días en completarse.</string>
+  <string name="legacy_migration_paused_disconnected">No puedes actualizar ahora porque estás desconectado de Lightning y/o Electrum.\n\nVuelve a intentarlo más tarde cuando se haya establecido la conexión.</string>
+
+  <string name="legacy_migration_confirm_title">Confirmar migración</string>
+  <string name="legacy_migration_confirm_dust">%1$d de %2$d canales tienen menos del límite de polvo de Bitcoin (546 sat). Su saldo se destinará a los Bitcoin miners.</string>
+  <string name="legacy_migration_confirm_proceed">Proceda</string>
+  <string name="legacy_migration_confirm_cancel">Cancelar</string>
+
+  <string name="legacy_migration_processing_title">Procesamiento de la migración…</string>
+  <string name="legacy_migration_processing_disconnected">Conexión perdida.\nMantén la aplicación en primer plano.</string>
+  <string name="legacy_migration_swap_address">Getting migration address</string>
+  <string name="legacy_migration_listing_channels">Reviewing channels</string>
+  <string name="legacy_migration_closing_channels">Closing channels (%1$d/%2$d)</string>
+  <string name="legacy_migration_monitoring_channels_publish">Publishing transactions (%1$s/%2$d)</string>
+
+  <string name="legacy_migration_complete_title">Migración completada</string>
+  <string name="legacy_migration_complete_details">Pasar a la nueva aplicación…</string>
+
+  <string name="legacy_migration_failure_title">Actualización fallida</string>
+  <string name="legacy_migration_failure_generic">Es posible que no se hayan migrado algunos o todos los canales.\n\nEl proceso de actualización debe iniciarse de nuevo.</string>
+  <string name="legacy_migration_failure_swapin_address_error">Phoenix no pudo generar una dirección válida para la migración.\n\nEl proceso de actualización debe iniciarse de nuevo.</string>
+  <string name="legacy_migration_failure_closing_error">Algunos canales no se han podido cerrar.\n\nEl proceso de actualización debe iniciarse de nuevo para migrarlos.</string>
+
 </resources>

--- a/phoenix-legacy/src/main/res/values-es/strings.xml
+++ b/phoenix-legacy/src/main/res/values-es/strings.xml
@@ -119,6 +119,7 @@
   <string name="legacy_send_description_label">Desc.</string>
   <string name="legacy_send_error_sending">Ocurrió un error interno al intentar enviar este pago. No se ha enviado dinero.</string>
   <string name="legacy_send_pay_button">Pagar</string>
+  <string name="legacy_send_swap_service_disabled">El servicio de intercambio para realizar pagos en la cadena ha sido desactivado.\n\nPor favor, utilice un servicio de terceros.</string>
   <string name="legacy_send_swap_in_progress">Intercambio en progreso…</string>
   <string name="legacy_send_swap_error">El intercambio ha fallado. Por favor inténtalo de nuevo.</string>
   <string name="legacy_send_swap_required_button">Solicitar un intercambio</string>

--- a/phoenix-legacy/src/main/res/values-fr/strings.xml
+++ b/phoenix-legacy/src/main/res/values-fr/strings.xml
@@ -690,4 +690,37 @@
     <p>Les frais de création de nouveaux channels restent les mêmes (%1$s%%), mais ils ont désormais un plancher minimal de <b>%2$s</b>.</p>
   ]]></string>
 
+  <!-- //////////////// Migration to KMP //////////////// -->
+
+  <string name="legacy_migration_title">Mise à niveau de Phoenix</string>
+  <string name="legacy_migration_ready_message">Passez à la nouvelle version de Phoenix, utilisant un moteur Lightning de dernière génération et de nouvelles fonctionnalités.\n\nLes canaux existants seront fusionnés. Ce processus de migration est automatisé.</string>
+  <string name="legacy_migration_prepare_button">Mettre à jour</string>
+  <string name="legacy_migration_prepare_button_disconnected">Connexion…</string>
+  <string name="legacy_migration_dismiss_button">Plus tard</string>
+
+  <string name="legacy_migration_paused_swap_in">Vous ne pouvez pas mettre à jour : un dépôt on-chain est en cours.\n\nVeuillez réessayer plus tard quand il aura confirmé.</string>
+  <string name="legacy_migration_paused_opening">Vous ne pouvez pas mettre à jour : des canaux de paiements sont en train d\'être ouverts.\n\nVeuillez réessayer plus tard quand ils seront ouverts et actifs.</string>
+  <string name="legacy_migration_paused_force_close">Vous ne pouvez pas mettre à jour : certains canaux sont en clôture forcée.\n\nVeuillez réessayer plus tard quand ils seront complètement fermés. Notez que cela peut prendre plusieurs jours.</string>
+  <string name="legacy_migration_paused_disconnected">Vous ne pouvez pas mettre à jour car vous êtes déconnecté de votre pair Lightning/Electrum.\n\nVeuillez réessayer plus tard quand la connexion sera établie.</string>
+
+  <string name="legacy_migration_confirm_title">Confirmer la migration</string>
+  <string name="legacy_migration_confirm_dust">%1$d channel(s) sur %2$d contiennent moins que la limit de dust Bitcoin (546 sat). La solde de ces channels ira aux mineurs du réseau Bitcoin.</string>
+  <string name="legacy_migration_confirm_proceed">Poursuivre</string>
+  <string name="legacy_migration_confirm_cancel">Annuler</string>
+
+  <string name="legacy_migration_processing_title">Traitement de la migration…</string>
+  <string name="legacy_migration_processing_disconnected">Connexion perdue.\nGardez l\'application au premier plan.</string>
+  <string name="legacy_migration_swap_address">Calcul de l\'addresse de migration</string>
+  <string name="legacy_migration_listing_channels">Contrôle des canaux de paiements</string>
+  <string name="legacy_migration_closing_channels">Fermeture des canaux (%1$d/%2$d)</string>
+  <string name="legacy_migration_monitoring_channels_publish">Publication des transactions (%1$s/%2$d)</string>
+
+  <string name="legacy_migration_complete_title">Migration terminée</string>
+  <string name="legacy_migration_complete_details">Basculement vers la nouvelle application…</string>
+
+  <string name="legacy_migration_failure_title">Mise à jour échouée</string>
+  <string name="legacy_migration_failure_generic">Certains de vos canaux n\'ont pas été migrés.\n\nLa procédure de mise à jour devra être recommencée.</string>
+  <string name="legacy_migration_failure_swapin_address_error">Phoenix n\'a pu générer d\'adresse de migration.\n\nLa procédure de mise à jour doit être recommencée.</string>
+  <string name="legacy_migration_failure_closing_error">Certains de vos canaux n\'ont pu être fermés.\n\nLa procédure de mise à jour devra être recommencée pour migrer ceux-ci.</string>
+
 </resources>

--- a/phoenix-legacy/src/main/res/values-fr/strings.xml
+++ b/phoenix-legacy/src/main/res/values-fr/strings.xml
@@ -97,8 +97,8 @@
   <string name="legacy_receive_share_button">Partager…</string>
 
   <string name="legacy_receive_min_amount_pay_to_open"><![CDATA[Votre portefeuille est vide. Votre premier versement doit être d\'au moins <b>%1$s</b>.]]></string>
-  <string name="legacy_receive_paytoopen_disabled">La création de canaux Lightning a été désactivée temporairement. Certains paiements ne pourront pas être reçus.</string>
-  <string name="legacy_receive_paytoopen_disabled_nochannels">La création de canaux Lightning a été désactivée temporairement. Vous ne pourrez pas recevoir de paiements.</string>
+  <string name="legacy_receive_paytoopen_disabled">La création de canaux Lightning a été désactivée. Certains paiements ne pourront pas être reçus.</string>
+  <string name="legacy_receive_paytoopen_disabled_nochannels">La création de canaux Lightning a été désactivée. Vous ne pourrez pas recevoir de paiements.</string>
   <string name="legacy_receive_address_label">Adresse</string>
   <string name="legacy_receive_withdraw_button">Utiliser un lien LNURL</string>
 
@@ -107,7 +107,7 @@
   <string name="legacy_receive_swap_in_disabled"><![CDATA[
     <b>Swap entrant désactivés</b>
     <br /><br />
-    Le service de swap vers des adresses Bitcoin a été temporairement désactivé.
+    Le service de swap vers des adresses Bitcoin a été désactivé.
     <br /><br />
     Veuillez réessayer ultérieurement.
   ]]></string>
@@ -153,6 +153,7 @@
   <string name="legacy_send_error_sending">Il y a eu une erreur lors de l\'envoi du paiement. Aucun argent n\'a été envoyé.</string>
   <string name="legacy_send_pay_button">Payer</string>
   <string name="legacy_send_swap_in_progress">Création de la transaction…</string>
+  <string name="legacy_send_swap_service_disabled">Le service de swap pour faire des paiements on-chain a été désactivé.\n\nVeuillez utiliser un service tiers.</string>
   <string name="legacy_send_swap_error">La transaction n\'a pas pu être créée. Veuillez réessayer.</string>
   <string name="legacy_send_swap_required_button">Préparer transaction</string>
   <string name="legacy_send_swap_complete_recap_amount">Montant</string>

--- a/phoenix-legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/phoenix-legacy/src/main/res/values-pt-rBR/strings.xml
@@ -751,4 +751,32 @@
   <string name="legacy_paymentmode_lightning">Pagar usando a rede Relâmpago</string>
   <string name="legacy_paymentmode_lightning_desc">Esta é a opção recomendada</string>
 
+  <!-- //////////////// Migration to KMP //////////////// -->
+
+  <string name="legacy_migration_title">Atualização do Phoenix</string>
+  <string name="legacy_migration_ready_message">Atualize para a versão mais recente do Phoenix, com um mecanismo Lightning de ponta e novos recursos.\n\nSeus canais serão mesclados. Esse processo é automatizado.</string>
+  <string name="legacy_migration_prepare_button">Upgrade</string>
+  <string name="legacy_migration_prepare_button_disconnected">Conectando…</string>
+  <string name="legacy_migration_dismiss_button">Não agora</string>
+
+  <string name="legacy_migration_paused_swap_in">Você não pode fazer upgrade agora: um depósito na cadeia está pendente.\n\nTente novamente mais tarde quando esse depósito for confirmado.</string>
+  <string name="legacy_migration_paused_opening">Você não pode fazer upgrade agora: alguns canais estão sendo abertos no momento.\n\nTente novamente mais tarde quando esses canais tiverem sido abertos e estiverem ativos.</string>
+  <string name="legacy_migration_paused_force_close">Não é possível fazer upgrade agora: alguns canais estão sendo fechados à força.\n\nTente novamente mais tarde, quando esses canais tiverem sido completamente fechados. Observe que o fechamento forçado pode levar vários dias para ser concluído.</string>
+  <string name="legacy_migration_paused_disconnected">Você não pode fazer upgrade agora porque está desconectado do Lightning e/ou da Electrum.\n\nTente novamente mais tarde quando a conexão for estabelecida.</string>
+
+  <string name="legacy_migration_confirm_title">Confirmar migração</string>
+  <string name="legacy_migration_confirm_dust">%1$d de %2$d canais estão mantendo menos do que o limite de Bitcoin dust (546 sat). Seu saldo irá para os mineradores de Bitcoin.</string>
+  <string name="legacy_migration_confirm_proceed">Proceder</string>
+  <string name="legacy_migration_confirm_cancel">Cancelar</string>
+
+  <string name="legacy_migration_processing_disconnected">Perda de conexão.\nMantenha o aplicativo em primeiro plano.</string>
+
+  <string name="legacy_migration_complete_title">Migração concluída</string>
+  <string name="legacy_migration_complete_details">Mudança para o novo aplicativo…</string>
+
+  <string name="legacy_migration_failure_title">O upgrade falhou</string>
+  <string name="legacy_migration_failure_generic">Alguns ou todos os canais podem não ter sido migrados.\n\nO processo de atualização deve ser iniciado novamente.</string>
+  <string name="legacy_migration_failure_swapin_address_error">O Phoenix não pôde gerar um endereço válido para a migração.\n\nO processo de atualização deve ser iniciado novamente.</string>
+  <string name="legacy_migration_failure_closing_error">Não foi possível fechar alguns canais.\n\nO processo de atualização deve ser iniciado novamente para migrá-los.</string>
+
 </resources>

--- a/phoenix-legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/phoenix-legacy/src/main/res/values-pt-rBR/strings.xml
@@ -119,8 +119,8 @@
   <string name="legacy_receive_share_button">Compartilhar…</string>
 
   <string name="legacy_receive_min_amount_pay_to_open"><![CDATA[Carteira vazia. O primeiro pagamento que você receber precisa ser de no mínimo <b>%1$s</b>.]]></string>
-  <string name="legacy_receive_paytoopen_disabled">A abertura de canais foi temporariamente desativada. Alguns pagamentos não poderão ser recebidos.</string>
-  <string name="legacy_receive_paytoopen_disabled_nochannels">A abertura de canais foi temporariamente desativada. Você não poderá receber pagamentos.</string>
+  <string name="legacy_receive_paytoopen_disabled">A abertura de canais foi desativada. Alguns pagamentos não poderão ser recebidos.</string>
+  <string name="legacy_receive_paytoopen_disabled_nochannels">A abertura de canais foi desativada. Você não poderá receber pagamentos.</string>
 
   <string name="legacy_receive_address_label">Endereço</string>
   <string name="legacy_receive_withdraw_button">Usar link LNURL</string>
@@ -140,7 +140,7 @@
   <string name="legacy_receive_swap_in_disabled"><![CDATA[
     <b>Serviço desabilitado</b>
     <br /><br />
-    O serviço de depósito via rede Bitcoin foi temporariamente desativado.
+    O serviço de depósito via rede Bitcoin foi desativado.
     <br /><br />
     Tente novamente mais tarde.
   ]]></string>
@@ -177,6 +177,7 @@
   <string name="legacy_send_error_sending">Ocorreu um erro interno ao tentar enviar este pagamento. Pagamento não realizado.</string>
   <string name="legacy_send_pay_button">Pagar</string>
   <string name="legacy_send_swap_in_progress">Preparando transação…</string>
+  <string name="legacy_send_swap_service_disabled">O serviço de swap para fazer pagamentos na cadeia foi desativado.\n\nUse um serviço de terceiros.</string>
   <string name="legacy_send_swap_error">A troca para rede Bitcoin falhou. Tente novamente.</string>
   <string name="legacy_send_swap_required_button">Preparar transação</string>
   <string name="legacy_send_swap_complete_recap_amount">Quantidade</string>

--- a/phoenix-legacy/src/main/res/values/strings.xml
+++ b/phoenix-legacy/src/main/res/values/strings.xml
@@ -792,9 +792,7 @@ legacy_
   <!-- //////////////// Migration to KMP //////////////// -->
 
   <string name="legacy_migration_title">Phoenix upgrade</string>
-  <string name="legacy_migration_init_message">Checking your channels, please hold…</string>
   <string name="legacy_migration_ready_message">Upgrade to the latest version of Phoenix, with a cutting-edge Lightning engine and new features.\n\nYour channels will be merged together. This process is automated.</string>
-  <string name="legacy_migration_more_info_button">Learn more…</string>
   <string name="legacy_migration_prepare_button">Upgrade</string>
   <string name="legacy_migration_prepare_button_disconnected">Connecting…</string>
   <string name="legacy_migration_dismiss_button">Not now</string>
@@ -822,6 +820,6 @@ legacy_
   <string name="legacy_migration_failure_title">Upgrade has failed</string>
   <string name="legacy_migration_failure_generic">Some or all channels may not have been migrated.\n\nThe upgrade process must be started again.</string>
   <string name="legacy_migration_failure_swapin_address_error">Phoenix could not generate a valid address for the migration.\n\nThe upgrade process must be started again.</string>
-  <string name="legacy_migration_failure_closing_error">Some channels could not be migrated.\n\nThe upgrade process must be started again to migrate the remaining channels.</string>
+  <string name="legacy_migration_failure_closing_error">Some channels could not be closed.\n\nThe upgrade process must be started again to migrate those.</string>
 
 </resources>

--- a/phoenix-legacy/src/main/res/values/strings.xml
+++ b/phoenix-legacy/src/main/res/values/strings.xml
@@ -801,6 +801,7 @@ legacy_
   <string name="legacy_migration_paused_swap_in">You cannot upgrade now: an on-chain deposit is pending.\n\nTry again later when this deposit has confirmed.</string>
   <string name="legacy_migration_paused_opening">You cannot upgrade now: some channels are currently being opened.\n\nTry again later when these channels have been opened and are active.</string>
   <string name="legacy_migration_paused_force_close">You cannot upgrade now: some channels are being force-closed.\n\nTry again later when these channel have been completely closed. Note that force-close can take several days to complete.</string>
+  <string name="legacy_migration_paused_dust">You cannot upgrade: the balance of some of your channels is too low (less than 546 satoshi) and they cannot be migrated.\n\nSpend those funds over Lightning, or send them to a custodial wallet, and then try again.</string>
   <string name="legacy_migration_paused_disconnected">You cannot upgrade now because you are disconnected from Lightning and/or Electrum.\n\nTry again later when connection has been established.</string>
 
   <string name="legacy_migration_processing_title">Processing migration…</string>

--- a/phoenix-legacy/src/main/res/values/strings.xml
+++ b/phoenix-legacy/src/main/res/values/strings.xml
@@ -119,8 +119,8 @@
   <string name="legacy_receive_share_button">Share…</string>
 
   <string name="legacy_receive_min_amount_pay_to_open"><![CDATA[Your wallet is empty. First payment you receive must be at least <b>%1$s</b>.]]></string>
-  <string name="legacy_receive_paytoopen_disabled">Channel creation has been temporarily disabled. You may not be able to receive some payments.</string>
-  <string name="legacy_receive_paytoopen_disabled_nochannels">Channel creation has been temporarily disabled. You will not be able to receive any payments.</string>
+  <string name="legacy_receive_paytoopen_disabled">Channel creation has been disabled. You may not be able to receive some payments.</string>
+  <string name="legacy_receive_paytoopen_disabled_nochannels">Channel creation has been disabled. You will not be able to receive any payments.</string>
   <string name="legacy_receive_address_label">Address</string>
   <string name="legacy_receive_withdraw_button">Use LNURL link</string>
 
@@ -139,7 +139,7 @@
   <string name="legacy_receive_swap_in_disabled"><![CDATA[
     <b>Service disabled</b>
     <br /><br />
-    The on-chain deposit swap service has been temporarily disabled.
+    The on-chain deposit swap service has been disabled.
     <br /><br />
     Try again later.
   ]]></string>
@@ -184,6 +184,7 @@
   ]]></string>
   <string name="legacy_send_error_sending">There was an internal error when trying to send this payment. No money was sent.</string>
   <string name="legacy_send_pay_button">Pay</string>
+  <string name="legacy_send_swap_service_disabled">The swap service for paying on-chain addresses has been disabled.\n\nPlease use a third-party service.</string>
   <string name="legacy_send_swap_in_progress">Preparing transaction</string>
   <string name="legacy_send_swap_error">Swap to chain has failed. Please try again.</string>
   <string name="legacy_send_swap_required_button">Prepare transaction</string>

--- a/phoenix-legacy/src/main/res/values/strings.xml
+++ b/phoenix-legacy/src/main/res/values/strings.xml
@@ -792,7 +792,7 @@ legacy_
 
   <string name="legacy_migration_title">Phoenix upgrade</string>
   <string name="legacy_migration_init_message">Checking your channels, please hold…</string>
-  <string name="legacy_migration_ready_message">Upgrade to the latest version of Phoenix, with a cutting-edge Lightning engine and new features.\n\nYour channels will be merged together and you will keep your inbound liquidity.\n\nThe migration process is automated.</string>
+  <string name="legacy_migration_ready_message">Upgrade to the latest version of Phoenix, with a cutting-edge Lightning engine and new features.\n\nYour channels will be merged together. This process is automated.</string>
   <string name="legacy_migration_more_info_button">Learn more…</string>
   <string name="legacy_migration_prepare_button">Upgrade</string>
   <string name="legacy_migration_prepare_button_disconnected">Connecting…</string>
@@ -801,8 +801,12 @@ legacy_
   <string name="legacy_migration_paused_swap_in">You cannot upgrade now: an on-chain deposit is pending.\n\nTry again later when this deposit has confirmed.</string>
   <string name="legacy_migration_paused_opening">You cannot upgrade now: some channels are currently being opened.\n\nTry again later when these channels have been opened and are active.</string>
   <string name="legacy_migration_paused_force_close">You cannot upgrade now: some channels are being force-closed.\n\nTry again later when these channel have been completely closed. Note that force-close can take several days to complete.</string>
-  <string name="legacy_migration_paused_dust">You cannot upgrade: the balance of some of your channels is too low (less than 546 satoshi) and they cannot be migrated.\n\nSpend those funds over Lightning, or send them to a custodial wallet, and then try again.</string>
   <string name="legacy_migration_paused_disconnected">You cannot upgrade now because you are disconnected from Lightning and/or Electrum.\n\nTry again later when connection has been established.</string>
+
+  <string name="legacy_migration_confirm_title">Confirm migration</string>
+  <string name="legacy_migration_confirm_dust">%1$d of %2$d channels are holding less than the Bitcoin dust limit (546 sat). Their balance will go to the Bitcoin miners.</string>
+  <string name="legacy_migration_confirm_proceed">Proceed</string>
+  <string name="legacy_migration_confirm_cancel">Cancel</string>
 
   <string name="legacy_migration_processing_title">Processing migration…</string>
   <string name="legacy_migration_processing_disconnected">Connection lost.\nKeep the app in the foreground.</string>


### PR DESCRIPTION
Channels with dust balance (< 546 sat) cannot be migrated, their funds will go to the Bitcoin miners. This PR adds checks that will warn the user when that happens.

An in-app notification replaces the message displayed after a successful migration. The notification UI has been slightly improved as well, and the notifications are ordered. Migration resources have been translated in several languages (fr, es, de, cz, pt).