### PR TITLE
Update sync-related hooks to support new payment types

### DIFF
--- a/phoenix-shared/src/androidMain/kotlin/fr/acinq/phoenix/db/SqlPaymentHooks.kt
+++ b/phoenix-shared/src/androidMain/kotlin/fr/acinq/phoenix/db/SqlPaymentHooks.kt
@@ -3,7 +3,7 @@ package fr.acinq.phoenix.db
 import fr.acinq.phoenix.data.WalletPaymentId
 import fr.acinq.phoenix.db.payments.CloudKitInterface
 
-actual fun didCompleteWalletPayment(id: WalletPaymentId, database: PaymentsDatabase) {}
+actual fun didSaveWalletPayment(id: WalletPaymentId, database: PaymentsDatabase) {}
 actual fun didDeleteWalletPayment(id: WalletPaymentId, database: PaymentsDatabase) {}
 actual fun didUpdateWalletPaymentMetadata(id: WalletPaymentId, database: PaymentsDatabase) {}
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
@@ -655,14 +655,14 @@ data class WalletPaymentOrderRow(
 }
 
 /**
- * Implement this function to execute platform specific code when a payment completes.
+ * Implement this function to execute platform specific code when a payment is saved to the database.
  * For example, on iOS this is used to enqueue the (encrypted) payment for upload to CloudKit.
  *
  * This function is invoked inside the same transaction used to add/modify the row.
  * This means any database operations performed in this function are atomic,
  * with respect to the referenced row.
  */
-expect fun didCompleteWalletPayment(id: WalletPaymentId, database: PaymentsDatabase)
+expect fun didSaveWalletPayment(id: WalletPaymentId, database: PaymentsDatabase)
 
 /**
  * Implement this function to execute platform specific code when a payment is deleted.

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
@@ -31,7 +31,7 @@ import fr.acinq.lightning.utils.*
 import fr.acinq.lightning.wire.FailureMessage
 import fr.acinq.phoenix.data.WalletPaymentId
 import fr.acinq.phoenix.db.PaymentsDatabase
-import fr.acinq.phoenix.db.didCompleteWalletPayment
+import fr.acinq.phoenix.db.didSaveWalletPayment
 import fr.acinq.phoenix.utils.migrations.LegacyChannelCloseHelper
 import fr.acinq.secp256k1.Hex
 
@@ -96,7 +96,7 @@ class OutgoingQueries(val database: PaymentsDatabase) {
             if (queries.changes().executeAsOne() != 1L) {
                 result = false
             } else {
-                didCompleteWalletPayment(WalletPaymentId.LightningOutgoingPaymentId(id), database)
+                didSaveWalletPayment(WalletPaymentId.LightningOutgoingPaymentId(id), database)
             }
         }
         return result

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/SqlPaymentHooks.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/SqlPaymentHooks.kt
@@ -6,7 +6,7 @@ import fr.acinq.phoenix.db.payments.CloudKitInterface
 import fracinqphoenixdb.Cloudkit_payments_queue
 
 
-actual fun didCompleteWalletPayment(id: WalletPaymentId, database: PaymentsDatabase) {
+actual fun didSaveWalletPayment(id: WalletPaymentId, database: PaymentsDatabase) {
     database.cloudKitPaymentsQueries.addToQueue(
         type = id.dbType.value,
         id = id.dbId,


### PR DESCRIPTION
We previously had the following 3 sync-related hook methods:

```kotlin
expect fun didCompleteWalletPayment(/* ... */)
expect fun didDeleteWalletPayment(/* ... */)
expect fun didUpdateWalletPaymentMetadata(/* ... */)
```

The idea with `didCompleteWalletPayment` was that we didn't sync the payment to the cloud until after it had completed. For lightning payments this made sense, since generally the payment either succeeds or fails within a few seconds. So there's no use in syncing the pending payment, and then updating it 500 milliseconds later when it completes.

With the new on-chain payments, things are different. We don't want to wait for the payment to complete, because that implies waiting for a block confirmation. So I'm replacing `didCompleteWalletPayment` with `didSaveWalletPayment`, which is invoked anytime the payment is modified in the database. And now the sync code can decide what to do based on the payment type & status.

```kotlin
/**
 * Implement this function to execute platform specific code when a payment is saved to the database.
 * For example, on iOS this is used to enqueue the (encrypted) payment for upload to CloudKit.
 *
 * This function is invoked inside the same transaction used to add/modify the row.
 * This means any database operations performed in this function are atomic,
 * with respect to the referenced row.
 */
expect fun didSaveWalletPayment(id: WalletPaymentId, database: PaymentsDatabase)
```

Note that the contract guarantees the hook function is invoked within the same database transaction. (Which is required because the hook function also needs to update the database, and we want to do this in a single atomic transaction.) So I've wrapped a few function bodies in a database transaction:


```kotlin
// Before
fun updateFoobar(id: UUID, foobar: Boolean) {
   queries.setFoobar(
      id = id.toString(),
      foobar = foobar
   )
}

// After
fun updateFoobar(id: UUID, foobar: Boolean) {
   database.transaction {
      queries.setFoobar(
         id = id.toString(),
         foobar = foobar
      )
      didSaveWalletPayment(id, database)
   }
}
```

It's safe to start a transaction within a transaction:
```kotlin
database.transaction {
   database.transaction { // no problem
      queries.setFoobar(/* ... */)
   }
}
```

[SqlDelight Docs](https://cashapp.github.io/sqldelight/2.0.0-rc01/2.x/runtime/app.cash.sqldelight/-transacter/transaction.html) give you the option to opt-out if you really want:

```kotlin
database.transaction {
   database.transaction(noEnclosing = true) { // throws IllegalStateException
   }
}
```

