### PR TITLE
Prioritise free market exchanges rates over official ones

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/AmountInput.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/AmountInput.kt
@@ -558,7 +558,7 @@ private fun UnitDropdown(
     var selectedIndex by remember { mutableStateOf(maxOf(units.lastIndexOf(selectedUnit), 0)) }
     Box(modifier = modifier.wrapContentSize(Alignment.TopStart)) {
         Button(
-            text = units[selectedIndex].toString(),
+            text = units[selectedIndex].displayCode,
             icon = R.drawable.ic_chevron_down,
             onClick = { expanded = true },
             padding = internalPadding,
@@ -572,14 +572,14 @@ private fun UnitDropdown(
                 onDismiss()
             },
         ) {
-            units.forEachIndexed { index, s ->
+            units.forEachIndexed { index, unit ->
                 DropdownMenuItem(onClick = {
                     selectedIndex = index
                     expanded = false
                     onDismiss()
                     onUnitChange(units[index])
                 }) {
-                    Text(text = s.toString())
+                    Text(text = unit.displayCode)
                 }
             }
         }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/AmountView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/AmountView.kt
@@ -93,7 +93,7 @@ fun AmountView(
         if (!isRedacted && showUnit) {
             Spacer(modifier = Modifier.width(separatorSpace))
             Text(
-                text = unit.toString(),
+                text = unit.displayCode,
                 style = unitTextStyle,
                 modifier = Modifier.alignBy(FirstBaseline)
             )

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/datastore/UserPrefs.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/datastore/UserPrefs.kt
@@ -58,11 +58,11 @@ object UserPrefs {
     // -- unit, fiat, conversion...
 
     private val BITCOIN_UNIT = stringPreferencesKey("BITCOIN_UNIT")
-    fun getBitcoinUnit(context: Context): Flow<BitcoinUnit> = prefs(context).map { BitcoinUnit.valueOf(it[BITCOIN_UNIT] ?: BitcoinUnit.Sat.name) }
+    fun getBitcoinUnit(context: Context): Flow<BitcoinUnit> = prefs(context).map { it[BITCOIN_UNIT]?.let { BitcoinUnit.valueOfOrNull(it) } ?: BitcoinUnit.Sat }
     suspend fun saveBitcoinUnit(context: Context, coinUnit: BitcoinUnit) = context.userPrefs.edit { it[BITCOIN_UNIT] = coinUnit.name }
 
     private val FIAT_CURRENCY = stringPreferencesKey("FIAT_CURRENCY")
-    fun getFiatCurrency(context: Context): Flow<FiatCurrency> = prefs(context).map { FiatCurrency.valueOf(it[FIAT_CURRENCY] ?: FiatCurrency.USD.name) }
+    fun getFiatCurrency(context: Context): Flow<FiatCurrency> = prefs(context).map { it[FIAT_CURRENCY]?.let { FiatCurrency.valueOfOrNull(it) } ?: FiatCurrency.USD }
     suspend fun saveFiatCurrency(context: Context, currency: FiatCurrency) = context.userPrefs.edit { it[FIAT_CURRENCY] = currency.name }
 
     private val SHOW_AMOUNT_IN_FIAT = booleanPreferencesKey("SHOW_AMOUNT_IN_FIAT")

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
@@ -65,182 +65,25 @@ fun BitcoinUnit.label(): String = when (this) {
 
 @Composable
 fun FiatCurrency.labels(): Pair<String, String> {
-    val code = this.name
     val context = LocalContext.current
-    return remember(key1 = code) {
+    return remember(key1 = displayCode) {
         val fullName = when {
-            code.length == 3 -> try {
-                Currency.getInstance(code).displayName
+            // use the free market rates as default. Name for official rates gets a special tag, as those rates are usually inaccurate.
+            this == FiatCurrency.ARS -> context.getString(R.string.currency_ars_official)
+            this == FiatCurrency.ARS_BM -> context.getString(R.string.currency_ars_bm)
+            this == FiatCurrency.CUP -> context.getString(R.string.currency_cup_official)
+            this == FiatCurrency.CUP_FM -> context.getString(R.string.currency_cup_fm)
+            this == FiatCurrency.LBP -> context.getString(R.string.currency_lbp_official)
+            this == FiatCurrency.LBP_BM -> context.getString(R.string.currency_lbp_bm)
+            // use the JVM API otherwise to get the name
+            displayCode.length == 3 -> try {
+                Currency.getInstance(displayCode).displayName
             } catch (e: Exception) {
                 "N/A"
             }
-            code == "ARS_BM" -> context.getString(R.string.currency_ars_bm)
-            code == "CUP_FM" -> context.getString(R.string.currency_cup_fm)
-            code == "LBP_BM" -> context.getString(R.string.currency_lbp_bm)
             else -> "N/A"
         }
-        val flag = getFlag(code)
-        "$flag $code" to fullName
-    }
-}
-
-private fun getFlag(code: String): String {
-    return when (code) {
-        "AED" -> "🇦🇪" // United Arab Emirates Dirham
-        "AFN" -> "🇦🇫" // Afghan Afghani
-        "ALL" -> "🇦🇱" // Albanian Lek
-        "AMD" -> "🇦🇲" // Armenian Dram
-        "ANG" -> "🇳🇱" // Netherlands Antillean Guilder
-        "AOA" -> "🇦🇴" // Angolan Kwanza
-        "ARS_BM" -> "🇦🇷" // Argentine Peso (blue market)
-        "ARS" -> "🇦🇷" // Argentine Peso
-        "AUD" -> "🇦🇺" // Australian Dollar
-        "AWG" -> "🇦🇼" // Aruban Florin
-        "AZN" -> "🇦🇿" // Azerbaijani Manat
-        "BAM" -> "🇧🇦" // Bosnia-Herzegovina Convertible Mark
-        "BBD" -> "🇧🇧" // Barbadian Dollar
-        "BDT" -> "🇧🇩" // Bangladeshi Taka
-        "BGN" -> "🇧🇬" // Bulgarian Lev
-        "BHD" -> "🇧🇭" // Bahraini Dinar
-        "BIF" -> "🇧🇮" // Burundian Franc
-        "BMD" -> "🇧🇲" // Bermudan Dollar
-        "BND" -> "🇧🇳" // Brunei Dollar
-        "BOB" -> "🇧🇴" // Bolivian Boliviano
-        "BRL" -> "🇧🇷" // Brazilian Real
-        "BSD" -> "🇧🇸" // Bahamian Dollar
-        "BTN" -> "🇧🇹" // Bhutanese Ngultrum
-        "BWP" -> "🇧🇼" // Botswanan Pula
-        "BZD" -> "🇧🇿" // Belize Dollar
-        "CAD" -> "🇨🇦" // Canadian Dollar
-        "CDF" -> "🇨🇩" // Congolese Franc
-        "CHF" -> "🇨🇭" // Swiss Franc
-        "CLP" -> "🇨🇱" // Chilean Peso
-        "CNH" -> "🇨🇳" // Chinese Yuan (offshore)
-        "CNY" -> "🇨🇳" // Chinese Yuan (onshore)
-        "COP" -> "🇨🇴" // Colombian Peso
-        "CRC" -> "🇨🇷" // Costa Rican Colón
-        "CUP" -> "🇨🇺" // Cuban Peso
-        "CUP_FM" -> "🇨🇺" // Cuban Peso (free market)
-        "CVE" -> "🇨🇻" // Cape Verdean Escudo
-        "CZK" -> "🇨🇿" // Czech Koruna
-        "DJF" -> "🇩🇯" // Djiboutian Franc
-        "DKK" -> "🇩🇰" // Danish Krone
-        "DOP" -> "🇩🇴" // Dominican Peso
-        "DZD" -> "🇩🇿" // Algerian Dinar
-        "EGP" -> "🇪🇬" // Egyptian Pound
-        "ERN" -> "🇪🇷" // Eritrean Nakfa
-        "ETB" -> "🇪🇹" // Ethiopian Birr
-        "EUR" -> "🇪🇺" // Euro
-        "FJD" -> "🇫🇯" // Fijian Dollar
-        "FKP" -> "🇫🇰" // Falkland Islands Pound
-        "GBP" -> "🇬🇧" // British Pound Sterling
-        "GEL" -> "🇬🇪" // Georgian Lari
-        "GHS" -> "🇬🇭" // Ghanaian Cedi
-        "GIP" -> "🇬🇮" // Gibraltar Pound
-        "GMD" -> "🇬🇲" // Gambian Dalasi
-        "GNF" -> "🇬🇳" // Guinean Franc
-        "GTQ" -> "🇬🇹" // Guatemalan Quetzal
-        "GYD" -> "🇬🇾" // Guyanaese Dollar
-        "HKD" -> "🇭🇰" // Hong Kong Dollar
-        "HNL" -> "🇭🇳" // Honduran Lempira
-        "HRK" -> "🇭🇷" // Croatian Kuna
-        "HTG" -> "🇭🇹" // Haitian Gourde
-        "HUF" -> "🇭🇺" // Hungarian Forint
-        "IDR" -> "🇮🇩" // Indonesian Rupiah
-        "ILS" -> "🇮🇱" // Israeli New Sheqel
-        "INR" -> "🇮🇳" // Indian Rupee
-        "IQD" -> "🇮🇶" // Iraqi Dinar
-        "IRR" -> "🇮🇷" // Iranian Rial
-        "ISK" -> "🇮🇸" // Icelandic Króna
-        "JEP" -> "🇯🇪" // Jersey Pound
-        "JMD" -> "🇯🇲" // Jamaican Dollar
-        "JOD" -> "🇯🇴" // Jordanian Dinar
-        "JPY" -> "🇯🇵" // Japanese Yen
-        "KES" -> "🇰🇪" // Kenyan Shilling
-        "KGS" -> "🇰🇬" // Kyrgystani Som
-        "KHR" -> "🇰🇭" // Cambodian Riel
-        "KMF" -> "🇰🇲" // Comorian Franc
-        "KPW" -> "🇰🇵" // North Korean Won
-        "KRW" -> "🇰🇷" // South Korean Won
-        "KWD" -> "🇰🇼" // Kuwaiti Dinar
-        "KYD" -> "🇰🇾" // Cayman Islands Dollar
-        "KZT" -> "🇰🇿" // Kazakhstani Tenge
-        "LAK" -> "🇱🇦" // Laotian Kip
-        "LBP" -> "🇱🇧" // Lebanese Pound
-        "LBP_BM" -> "🇱🇧" // Lebanese Pound
-        "LKR" -> "🇱🇰" // Sri Lankan Rupee
-        "LRD" -> "🇱🇷" // Liberian Dollar
-        "LSL" -> "🇱🇸" // Lesotho Loti
-        "LYD" -> "🇱🇾" // Libyan Dinar
-        "MAD" -> "🇲🇦" // Moroccan Dirham
-        "MDL" -> "🇲🇩" // Moldovan Leu
-        "MGA" -> "🇲🇬" // Malagasy Ariary
-        "MKD" -> "🇲🇰" // Macedonian Denar
-        "MMK" -> "🇲🇲" // Myanmar Kyat
-        "MNT" -> "🇲🇳" // Mongolian Tugrik
-        "MOP" -> "🇲🇴" // Macanese Pataca
-        "MUR" -> "🇲🇺" // Mauritian Rupee
-        "MVR" -> "🇲🇻" // Maldivian Rufiyaa
-        "MWK" -> "🇲🇼" // Malawian Kwacha
-        "MXN" -> "🇲🇽" // Mexican Peso
-        "MYR" -> "🇲🇾" // Malaysian Ringgit
-        "MZN" -> "🇲🇿" // Mozambican Metical
-        "NAD" -> "🇳🇦" // Namibian Dollar
-        "NGN" -> "🇳🇬" // Nigerian Naira
-        "NIO" -> "🇳🇮" // Nicaraguan Córdoba
-        "NOK" -> "🇳🇴" // Norwegian Krone
-        "NPR" -> "🇳🇵" // Nepalese Rupee
-        "NZD" -> "🇳🇿" // New Zealand Dollar
-        "OMR" -> "🇴🇲" // Omani Rial
-        "PAB" -> "🇵🇦" // Panamanian Balboa
-        "PEN" -> "🇵🇪" // Peruvian Nuevo Sol
-        "PGK" -> "🇵🇬" // Papua New Guinean Kina
-        "PHP" -> "🇵🇭" // Philippine Peso
-        "PKR" -> "🇵🇰" // Pakistani Rupee
-        "PLN" -> "🇵🇱" // Polish Zloty
-        "PYG" -> "🇵🇾" // Paraguayan Guarani
-        "QAR" -> "🇶🇦" // Qatari Rial
-        "RON" -> "🇷🇴" // Romanian Leu
-        "RSD" -> "🇷🇸" // Serbian Dinar
-        "RUB" -> "🇷🇺" // Russian Ruble
-        "RWF" -> "🇷🇼" // Rwandan Franc
-        "SAR" -> "🇸🇦" // Saudi Riyal
-        "SBD" -> "🇸🇧" // Solomon Islands Dollar
-        "SCR" -> "🇸🇨" // Seychellois Rupee
-        "SDG" -> "🇸🇩" // Sudanese Pound
-        "SEK" -> "🇸🇪" // Swedish Krona
-        "SGD" -> "🇸🇬" // Singapore Dollar
-        "SHP" -> "🇸🇭" // Saint Helena Pound
-        "SLL" -> "🇸🇱" // Sierra Leonean Leone
-        "SOS" -> "🇸🇴" // Somali Shilling
-        "SRD" -> "🇸🇷" // Surinamese Dollar
-        "SYP" -> "🇸🇾" // Syrian Pound
-        "SZL" -> "🇸🇿" // Swazi Lilangeni
-        "THB" -> "🇹🇭" // Thai Baht
-        "TJS" -> "🇹🇯" // Tajikistani Somoni
-        "TMT" -> "🇹🇲" // Turkmenistani Manat
-        "TND" -> "🇹🇳" // Tunisian Dinar
-        "TOP" -> "🇹🇴" // Tongan Paʻanga
-        "TRY" -> "🇹🇷" // Turkish Lira
-        "TTD" -> "🇹🇹" // Trinidad and Tobago Dollar
-        "TWD" -> "🇹🇼" // New Taiwan Dollar
-        "TZS" -> "🇹🇿" // Tanzanian Shilling
-        "UAH" -> "🇺🇦" // Ukrainian Hryvnia
-        "UGX" -> "🇺🇬" // Ugandan Shilling
-        "USD" -> "🇺🇸" // United States Dollar
-        "UYU" -> "🇺🇾" // Uruguayan Peso
-        "UZS" -> "🇺🇿" // Uzbekistan Som
-        "VND" -> "🇻🇳" // Vietnamese Dong
-        "VUV" -> "🇻🇺" // Vanuatu Vatu
-        "WST" -> "🇼🇸" // Samoan Tala
-        "XAF" -> "🇨🇲" // CFA Franc BEAC        - multiple options, chose country with highest GDP
-        "XCD" -> "🇱🇨" // East Caribbean Dollar - multiple options, chose country with highest GDP
-        "XOF" -> "🇨🇮" // CFA Franc BCEAO       - multiple options, chose country with highest GDP
-        "XPF" -> "🇳🇨" // CFP Franc             - multiple options, chose country with highest GDP
-        "YER" -> "🇾🇪" // Yemeni Rial
-        "ZAR" -> "🇿🇦" // South African Rand
-        "ZMW" -> "🇿🇲" // Zambian Kwacha
-        else -> "🏳️"
+        "$flag $displayCode" to fullName
     }
 }
 

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -654,9 +654,12 @@
 
     <!-- settings: currencies -->
 
-    <string name="currency_ars_bm">Argentine Peso (blue market)</string>
-    <string name="currency_cup_fm">Cuban Peso (free market)</string>
-    <string name="currency_lbp_bm">Lebanese Pound (black market)</string>
+    <string name="currency_ars_official">Argentine Peso (official rate)</string>
+    <string name="currency_ars_bm">Argentine Peso</string>
+    <string name="currency_cup_official">Cuban Peso (official rate)</string>
+    <string name="currency_cup_fm">Cuban Peso</string>
+    <string name="currency_lbp_official">Lebanese Pound (official rate)</string>
+    <string name="currency_lbp_bm">Lebanese Pound</string>
 
     <!-- payments history -->
 

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Currency.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Currency.swift
@@ -8,16 +8,42 @@ extension FiatCurrency {
 		return code + mkt
 	}
 	
-	var splitShortName: (String, String) {
+	var splitShortName: (String, String) { // e.g. ("ARS", "off")
 		
-		if name.count <= 3 {
-			return (name.uppercased(), "")
+		return FiatCurrency.shortNameComponents(displayCode)
+	}
+	
+	var shortPreciseName: String {
+		let (code, mkt) = splitShortPreciseName
+		return code + mkt
+	}
+	
+	var splitShortPreciseName: (String, String) { // e.g. ("ARM", "bm")
+		
+		let precise: String
+		switch self {
+			case .ars   : precise = "ARS_OFF"
+			case .arsBm : precise = "ARS_BM"
+			case .cup   : precise = "CUP_OFF"
+			case .cupFm : precise = "CUP_FM"
+			case .lbp   : precise = "LBP_OFF"
+			case .lbpBm : precise = "LBP_BM"
+			default     : precise = self.displayCode
+		}
+		
+		return FiatCurrency.shortNameComponents(precise)
+	}
+	
+	private static func shortNameComponents(_ input: String) -> (String, String) {
+		
+		if input.count <= 3 {
+			return (input.uppercased(), "")
 			
 		} else { // E.g. "ARS_BM"
-			let splitIdx = name.index(name.startIndex, offsetBy: 3)
+			let splitIdx = input.index(input.startIndex, offsetBy: 3)
 			
-			let code = name[name.startIndex ..< splitIdx]
-			let mkt = name[splitIdx ..< name.endIndex]
+			let code = input[input.startIndex ..< splitIdx]
+			let mkt = input[splitIdx ..< input.endIndex]
 				.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
 			
 			return (code.uppercased(), mkt.lowercased())
@@ -31,8 +57,8 @@ extension FiatCurrency {
 		case .amd   : return "Armenian Dram"
 		case .ang   : return "Netherlands Antillean Guilder"
 		case .aoa   : return "Angolan Kwanza"
-		case .arsBm : return "Argentine Peso (blue market)"
-		case .ars   : return "Argentine Peso"
+		case .ars   : fallthrough
+		case .arsBm : return "Argentine Peso"
 		case .aud   : return "Australian Dollar"
 		case .awg   : return "Aruban Florin"
 		case .azn   : return "Azerbaijani Manat"
@@ -58,8 +84,8 @@ extension FiatCurrency {
 		case .cny   : return "Chinese Yuan"
 		case .cop   : return "Colombian Peso"
 		case .crc   : return "Costa Rican Colón"
-		case .cup   : return "Cuban Peso"
-		case .cupFm : return "Cuban Peso (free market)"
+		case .cup   : fallthrough
+		case .cupFm : return "Cuban Peso"
 		case .cve   : return "Cape Verdean Escudo"
 		case .czk   : return "Czech Koruna"
 		case .djf   : return "Djiboutian Franc"
@@ -105,8 +131,8 @@ extension FiatCurrency {
 		case .kyd   : return "Cayman Islands Dollar"
 		case .kzt   : return "Kazakhstani Tenge"
 		case .lak   : return "Laotian Kip"
-		case .lbp   : return "Lebanese Pound"
-		case .lbpBm : return "Lebanese Pound (black market)"
+		case .lbp   : fallthrough
+		case .lbpBm : return "Lebanese Pound"
 		case .lkr   : return "Sri Lankan Rupee"
 		case .lrd   : return "Liberian Dollar"
 		case .lsl   : return "Lesotho Loti"
@@ -189,8 +215,8 @@ extension FiatCurrency {
 		case .amd   : return NSLocalizedString("AMD", tableName: "Currencies", comment: "Armenian Dram")
 		case .ang   : return NSLocalizedString("ANG", tableName: "Currencies", comment: "Netherlands Antillean Guilder")
 		case .aoa   : return NSLocalizedString("AOA", tableName: "Currencies", comment: "Angolan Kwanza")
-		case .arsBm : return NSLocalizedString("ARSbm", tableName: "Currencies", comment: "Argentine Peso (blue market)")
-		case .ars   : return NSLocalizedString("ARS", tableName: "Currencies", comment: "Argentine Peso")
+		case .ars   : fallthrough
+		case .arsBm : return NSLocalizedString("ARS", tableName: "Currencies", comment: "Argentine Peso")
 		case .aud   : return NSLocalizedString("AUD", tableName: "Currencies", comment: "Australian Dollar")
 		case .awg   : return NSLocalizedString("AWG", tableName: "Currencies", comment: "Aruban Florin")
 		case .azn   : return NSLocalizedString("AZN", tableName: "Currencies", comment: "Azerbaijani Manat")
@@ -216,8 +242,8 @@ extension FiatCurrency {
 		case .cny   : return NSLocalizedString("CNY", tableName: "Currencies", comment: "Chinese Yuan (onshore)")
 		case .cop   : return NSLocalizedString("COP", tableName: "Currencies", comment: "Colombian Peso")
 		case .crc   : return NSLocalizedString("CRC", tableName: "Currencies", comment: "Costa Rican Colón")
-		case .cup   : return NSLocalizedString("CUP", tableName: "Currencies", comment: "Cuban Peso")
-		case .cupFm : return NSLocalizedString("CUPfm", tableName: "Currencies", comment: "Cuban Peso (free market)")
+		case .cup   : fallthrough
+		case .cupFm : return NSLocalizedString("CUP", tableName: "Currencies", comment: "Cuban Peso")
 		case .cve   : return NSLocalizedString("CVE", tableName: "Currencies", comment: "Cape Verdean Escudo")
 		case .czk   : return NSLocalizedString("CZK", tableName: "Currencies", comment: "Czech Koruna")
 		case .djf   : return NSLocalizedString("DJF", tableName: "Currencies", comment: "Djiboutian Franc")
@@ -263,8 +289,8 @@ extension FiatCurrency {
 		case .kyd   : return NSLocalizedString("KYD", tableName: "Currencies", comment: "Cayman Islands Dollar")
 		case .kzt   : return NSLocalizedString("KZT", tableName: "Currencies", comment: "Kazakhstani Tenge")
 		case .lak   : return NSLocalizedString("LAK", tableName: "Currencies", comment: "Laotian Kip")
-		case .lbp   : return NSLocalizedString("LBP", tableName: "Currencies", comment: "Lebanese Pound")
-		case .lbpBm : return NSLocalizedString("LBPbm", tableName: "Currencies", comment: "Lebanese Pound (black market)")
+		case .lbp   : fallthrough
+		case .lbpBm : return NSLocalizedString("LBP", tableName: "Currencies", comment: "Lebanese Pound")
 		case .lkr   : return NSLocalizedString("LKR", tableName: "Currencies", comment: "Sri Lankan Rupee")
 		case .lrd   : return NSLocalizedString("LRD", tableName: "Currencies", comment: "Liberian Dollar")
 		case .lsl   : return NSLocalizedString("LSL", tableName: "Currencies", comment: "Lesotho Loti")
@@ -340,179 +366,51 @@ extension FiatCurrency {
 		default     : return ""
 	}}
 	
+	private var longName_marketTranslation: String { switch self {
+		case .ars   : return NSLocalizedString("official rate", tableName: "Currencies", comment: "")
+		case .arsBm : return NSLocalizedString("blue market",   tableName: "Currencies", comment: "")
+		case .cup   : return NSLocalizedString("official rate", tableName: "Currencies", comment: "")
+		case .cupFm : return NSLocalizedString("free market",   tableName: "Currencies", comment: "")
+		case .lbp   : return NSLocalizedString("official rate", tableName: "Currencies", comment: "")
+		case .lbpBm : return NSLocalizedString("black market",  tableName: "Currencies", comment: "")
+		default     : return ""
+	}}
+	
 	var longName: String {
-		let manualTranslation = longName_manualTranslation
-		if !manualTranslation.isEmpty && manualTranslation != self.shortName {
-			return manualTranslation
+		let (name, mkt) = splitLongName
+		
+		if mkt.isEmpty {
+			return name
+		} else {
+			return "\(name) (\(mkt))"
 		}
-		
-		var autoTranslation: String? = nil
-		
-		let currentLocale = Locale.current
-		if currentLocale.languageCode != "en" {
-			autoTranslation = currentLocale.localizedString(forCurrencyCode: self.shortName)
-		}
-		
-		return autoTranslation ?? longName_englishTranslation
 	}
 	
-	var flag: String { switch self {
-		case .aed   : return "🇦🇪" // United Arab Emirates Dirham
-		case .afn   : return "🇦🇫" // Afghan Afghani
-		case .all   : return "🇦🇱" // Albanian Lek
-		case .amd   : return "🇦🇲" // Armenian Dram
-		case .ang   : return "🇳🇱" // Netherlands Antillean Guilder
-		case .aoa   : return "🇦🇴" // Angolan Kwanza
-		case .arsBm : return "🇦🇷" // Argentine Peso (blue market)
-		case .ars   : return "🇦🇷" // Argentine Peso
-		case .aud   : return "🇦🇺" // Australian Dollar
-		case .awg   : return "🇦🇼" // Aruban Florin
-		case .azn   : return "🇦🇿" // Azerbaijani Manat
-		case .bam   : return "🇧🇦" // Bosnia-Herzegovina Convertible Mark
-		case .bbd   : return "🇧🇧" // Barbadian Dollar
-		case .bdt   : return "🇧🇩" // Bangladeshi Taka
-		case .bgn   : return "🇧🇬" // Bulgarian Lev
-		case .bhd   : return "🇧🇭" // Bahraini Dinar
-		case .bif   : return "🇧🇮" // Burundian Franc
-		case .bmd   : return "🇧🇲" // Bermudan Dollar
-		case .bnd   : return "🇧🇳" // Brunei Dollar
-		case .bob   : return "🇧🇴" // Bolivian Boliviano
-		case .brl   : return "🇧🇷" // Brazilian Real
-		case .bsd   : return "🇧🇸" // Bahamian Dollar
-		case .btn   : return "🇧🇹" // Bhutanese Ngultrum
-		case .bwp   : return "🇧🇼" // Botswanan Pula
-		case .bzd   : return "🇧🇿" // Belize Dollar
-		case .cad   : return "🇨🇦" // Canadian Dollar
-		case .cdf   : return "🇨🇩" // Congolese Franc
-		case .chf   : return "🇨🇭" // Swiss Franc
-		case .clp   : return "🇨🇱" // Chilean Peso
-		case .cnh   : return "🇨🇳" // Chinese Yuan (offshore)
-		case .cny   : return "🇨🇳" // Chinese Yuan (onshore)
-		case .cop   : return "🇨🇴" // Colombian Peso
-		case .crc   : return "🇨🇷" // Costa Rican Colón
-		case .cup   : return "🇨🇺" // Cuban Peso
-		case .cupFm : return "🇨🇺" // Cuban Peso (free market)
-		case .cve   : return "🇨🇻" // Cape Verdean Escudo
-		case .czk   : return "🇨🇿" // Czech Koruna
-		case .djf   : return "🇩🇯" // Djiboutian Franc
-		case .dkk   : return "🇩🇰" // Danish Krone
-		case .dop   : return "🇩🇴" // Dominican Peso
-		case .dzd   : return "🇩🇿" // Algerian Dinar
-		case .egp   : return "🇪🇬" // Egyptian Pound
-		case .ern   : return "🇪🇷" // Eritrean Nakfa
-		case .etb   : return "🇪🇹" // Ethiopian Birr
-		case .eur   : return "🇪🇺" // Euro
-		case .fjd   : return "🇫🇯" // Fijian Dollar
-		case .fkp   : return "🇫🇰" // Falkland Islands Pound
-		case .gbp   : return "🇬🇧" // British Pound Sterling
-		case .gel   : return "🇬🇪" // Georgian Lari
-		case .ghs   : return "🇬🇭" // Ghanaian Cedi
-		case .gip   : return "🇬🇮" // Gibraltar Pound
-		case .gmd   : return "🇬🇲" // Gambian Dalasi
-		case .gnf   : return "🇬🇳" // Guinean Franc
-		case .gtq   : return "🇬🇹" // Guatemalan Quetzal
-		case .gyd   : return "🇬🇾" // Guyanaese Dollar
-		case .hkd   : return "🇭🇰" // Hong Kong Dollar
-		case .hnl   : return "🇭🇳" // Honduran Lempira
-		case .hrk   : return "🇭🇷" // Croatian Kuna
-		case .htg   : return "🇭🇹" // Haitian Gourde
-		case .huf   : return "🇭🇺" // Hungarian Forint
-		case .idr   : return "🇮🇩" // Indonesian Rupiah
-		case .ils   : return "🇮🇱" // Israeli New Sheqel
-		case .inr   : return "🇮🇳" // Indian Rupee
-		case .iqd   : return "🇮🇶" // Iraqi Dinar
-		case .irr   : return "🇮🇷" // Iranian Rial
-		case .isk   : return "🇮🇸" // Icelandic Króna
-		case .jep   : return "🇯🇪" // Jersey Pound
-		case .jmd   : return "🇯🇲" // Jamaican Dollar
-		case .jod   : return "🇯🇴" // Jordanian Dinar
-		case .jpy   : return "🇯🇵" // Japanese Yen
-		case .kes   : return "🇰🇪" // Kenyan Shilling
-		case .kgs   : return "🇰🇬" // Kyrgystani Som
-		case .khr   : return "🇰🇭" // Cambodian Riel
-		case .kmf   : return "🇰🇲" // Comorian Franc
-		case .kpw   : return "🇰🇵" // North Korean Won
-		case .krw   : return "🇰🇷" // South Korean Won
-		case .kwd   : return "🇰🇼" // Kuwaiti Dinar
-		case .kyd   : return "🇰🇾" // Cayman Islands Dollar
-		case .kzt   : return "🇰🇿" // Kazakhstani Tenge
-		case .lak   : return "🇱🇦" // Laotian Kip
-		case .lbp   : return "🇱🇧" // Lebanese Pound
-		case .lbpBm : return "🇱🇧" // Lebanese Pound (black market)
-		case .lkr   : return "🇱🇰" // Sri Lankan Rupee
-		case .lrd   : return "🇱🇷" // Liberian Dollar
-		case .lsl   : return "🇱🇸" // Lesotho Loti
-		case .lyd   : return "🇱🇾" // Libyan Dinar
-		case .mad   : return "🇲🇦" // Moroccan Dirham
-		case .mdl   : return "🇲🇩" // Moldovan Leu
-		case .mga   : return "🇲🇬" // Malagasy Ariary
-		case .mkd   : return "🇲🇰" // Macedonian Denar
-		case .mmk   : return "🇲🇲" // Myanmar Kyat
-		case .mnt   : return "🇲🇳" // Mongolian Tugrik
-		case .mop   : return "🇲🇴" // Macanese Pataca
-		case .mur   : return "🇲🇺" // Mauritian Rupee
-		case .mvr   : return "🇲🇻" // Maldivian Rufiyaa
-		case .mwk   : return "🇲🇼" // Malawian Kwacha
-		case .mxn   : return "🇲🇽" // Mexican Peso
-		case .myr   : return "🇲🇾" // Malaysian Ringgit
-		case .mzn   : return "🇲🇿" // Mozambican Metical
-		case .nad   : return "🇳🇦" // Namibian Dollar
-		case .ngn   : return "🇳🇬" // Nigerian Naira
-		case .nio   : return "🇳🇮" // Nicaraguan Córdoba
-		case .nok   : return "🇳🇴" // Norwegian Krone
-		case .npr   : return "🇳🇵" // Nepalese Rupee
-		case .nzd   : return "🇳🇿" // New Zealand Dollar
-		case .omr   : return "🇴🇲" // Omani Rial
-		case .pab   : return "🇵🇦" // Panamanian Balboa
-		case .pen   : return "🇵🇪" // Peruvian Nuevo Sol
-		case .pgk   : return "🇵🇬" // Papua New Guinean Kina
-		case .php   : return "🇵🇭" // Philippine Peso
-		case .pkr   : return "🇵🇰" // Pakistani Rupee
-		case .pln   : return "🇵🇱" // Polish Zloty
-		case .pyg   : return "🇵🇾" // Paraguayan Guarani
-		case .qar   : return "🇶🇦" // Qatari Rial
-		case .ron   : return "🇷🇴" // Romanian Leu
-		case .rsd   : return "🇷🇸" // Serbian Dinar
-		case .rub   : return "🇷🇺" // Russian Ruble
-		case .rwf   : return "🇷🇼" // Rwandan Franc
-		case .sar   : return "🇸🇦" // Saudi Riyal
-		case .sbd   : return "🇸🇧" // Solomon Islands Dollar
-		case .scr   : return "🇸🇨" // Seychellois Rupee
-		case .sdg   : return "🇸🇩" // Sudanese Pound
-		case .sek   : return "🇸🇪" // Swedish Krona
-		case .sgd   : return "🇸🇬" // Singapore Dollar
-		case .shp   : return "🇸🇭" // Saint Helena Pound
-		case .sll   : return "🇸🇱" // Sierra Leonean Leone
-		case .sos   : return "🇸🇴" // Somali Shilling
-		case .srd   : return "🇸🇷" // Surinamese Dollar
-		case .syp   : return "🇸🇾" // Syrian Pound
-		case .szl   : return "🇸🇿" // Swazi Lilangeni
-		case .thb   : return "🇹🇭" // Thai Baht
-		case .tjs   : return "🇹🇯" // Tajikistani Somoni
-		case .tmt   : return "🇹🇲" // Turkmenistani Manat
-		case .tnd   : return "🇹🇳" // Tunisian Dinar
-		case .top   : return "🇹🇴" // Tongan Paʻanga
-		case .try_  : return "🇹🇷" // Turkish Lira
-		case .ttd   : return "🇹🇹" // Trinidad and Tobago Dollar
-		case .twd   : return "🇹🇼" // New Taiwan Dollar
-		case .tzs   : return "🇹🇿" // Tanzanian Shilling
-		case .uah   : return "🇺🇦" // Ukrainian Hryvnia
-		case .ugx   : return "🇺🇬" // Ugandan Shilling
-		case .usd   : return "🇺🇸" // United States Dollar
-		case .uyu   : return "🇺🇾" // Uruguayan Peso
-		case .uzs   : return "🇺🇿" // Uzbekistan Som
-		case .vnd   : return "🇻🇳" // Vietnamese Dong
-		case .vuv   : return "🇻🇺" // Vanuatu Vatu
-		case .wst   : return "🇼🇸" // Samoan Tala
-		case .xaf   : return "🇨🇲" // CFA Franc BEAC        - multiple options, chose country with highest GDP
-		case .xcd   : return "🇱🇨" // East Caribbean Dollar - multiple options, chose country with highest GDP
-		case .xof   : return "🇨🇮" // CFA Franc BCEAO       - multiple options, chose country with highest GDP
-		case .xpf   : return "🇳🇨" // CFP Franc             - multiple options, chose country with highest GDP
-		case .yer   : return "🇾🇪" // Yemeni Rial
-		case .zar   : return "🇿🇦" // South African Rand
-		case .zmw   : return "🇿🇲" // Zambian Kwacha
-		default     : return "🏳️"
-	}}
+	var splitLongName: (String, String) { // e.g. ("Argentine Peso", "blue market")
+		
+		let (code, _) = splitShortName
+		
+		let manualTranslation = longName_manualTranslation
+		if !manualTranslation.isEmpty && manualTranslation != code {
+			return (manualTranslation, longName_marketTranslation)
+		}
+
+		var autoTranslation: String? = nil
+
+		let currentLocale = Locale.current
+		if currentLocale.languageCode != "en" {
+			let (code, mkt) = splitShortPreciseName
+			if mkt.isEmpty {
+				autoTranslation = currentLocale.localizedString(forCurrencyCode: code)
+			}
+		}
+
+		if let autoTranslation {
+			return (autoTranslation, longName_marketTranslation)
+		} else {
+			return (longName_englishTranslation, longName_marketTranslation)
+		}
+	}
 	
 	fileprivate struct _Key {
 		static var matchingLocales = 0
@@ -521,6 +419,8 @@ extension FiatCurrency {
 	
 	func matchingLocales() -> [Locale] {
 		
+		let (selfCurrencyCode, _) = self.splitShortName
+		
 		return self.getSetAssociatedObject(storageKey: &_Key.matchingLocales) {
 			
 			var matchingLocales = [Locale]()
@@ -528,7 +428,7 @@ extension FiatCurrency {
 			
 				let locale = Locale(identifier: identifier)
 				if let currencyCode = locale.currencyCode,
-					currencyCode.caseInsensitiveCompare(self.name) == .orderedSame
+					currencyCode.caseInsensitiveCompare(selfCurrencyCode) == .orderedSame
 				{
 					matchingLocales.append(locale)
 				}

--- a/phoenix-ios/phoenix-ios/prefs/UserDefaults+Serialization.swift
+++ b/phoenix-ios/phoenix-ios/prefs/UserDefaults+Serialization.swift
@@ -37,7 +37,7 @@ extension FiatCurrency {
 		
 		for fiat in FiatCurrency.companion.values {
 			
-			let fiatCode = fiat.name // e.g. "AUD", "BRL"
+			let fiatCode = fiat.displayCode // e.g. "AUD", "BRL"
 			
 			if currencyCode.caseInsensitiveCompare(fiatCode) == .orderedSame {
 				return fiat

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
@@ -24,7 +24,15 @@ enum class BitcoinUnit(override val displayCode: String) : CurrencyUnit {
 
     companion object {
         val values = values().toList()
+
+        fun valueOfOrNull(code: String): BitcoinUnit? = try {
+            valueOf(code)
+        } catch (e: Exception) {
+            null
+        }
     }
+
+
 }
 
 /**

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/data/AppConfiguration.kt
@@ -9,11 +9,14 @@ import fr.acinq.lightning.wire.InitTlv
 import kotlinx.serialization.Serializable
 
 
-interface CurrencyUnit
+interface CurrencyUnit {
+    /** Code that should be displayed in the UI. */
+    val displayCode: String
+}
 
 @Serializable
-enum class BitcoinUnit : CurrencyUnit {
-    Sat, Bit, MBtc, Btc;
+enum class BitcoinUnit(override val displayCode: String) : CurrencyUnit {
+    Sat("sat"), Bit("bit"), MBtc("mbtc"), Btc("btc");
 
     override fun toString(): String {
         return super.toString().lowercase()
@@ -24,162 +27,165 @@ enum class BitcoinUnit : CurrencyUnit {
     }
 }
 
+/**
+ * @param flag when multiple countries use that currency, use the flag of the country with highest GDP
+ */
 @Serializable
-enum class FiatCurrency : CurrencyUnit {
-    AED, // United Arab Emirates Dirham
-    AFN, // Afghan Afghani
-    ALL, // Albanian Lek
-    AMD, // Armenian Dram
-    ANG, // Netherlands Antillean Guilder
-    AOA, // Angolan Kwanza
-    ARS, // Argentine Peso
-    ARS_BM, // Argentine Peso (blue market)
-    AUD, // Australian Dollar
-    AWG, // Aruban Florin
-    AZN, // Azerbaijani Manat
-    BAM, // Bosnia-Herzegovina Convertible Mark
-    BBD, // Barbadian Dollar
-    BDT, // Bangladeshi Taka
-    BGN, // Bulgarian Lev
-    BHD, // Bahraini Dinar
-    BIF, // Burundian Franc
-    BMD, // Bermudan Dollar
-    BND, // Brunei Dollar
-    BOB, // Bolivian Boliviano
-    BRL, // Brazilian Real
-    BSD, // Bahamian Dollar
-    BTN, // Bhutanese Ngultrum
-    BWP, // Botswanan Pula
-    BZD, // Belize Dollar
-    CAD, // Canadian Dollar
-    CDF, // Congolese Franc
-    CHF, // Swiss Franc
-    CLP, // Chilean Peso
-    CNH, // Chinese Yuan (offshore)
-    CNY, // Chinese Yuan (onshore)
-    COP, // Colombian Peso
-    CRC, // Costa Rican Colón
-    CUP, // Cuban Peso
-    CUP_FM, // Cuban Peso (free market)
-    CVE, // Cape Verdean Escudo
-    CZK, // Czech Republic Koruna
-    DJF, // Djiboutian Franc
-    DKK, // Danish Krone
-    DOP, // Dominican Peso
-    DZD, // Algerian Dinar
-    EGP, // Egyptian Pound
-    ERN, // Eritrean Nakfa
-    ETB, // Ethiopian Birr
-    EUR, // Euro
-    FJD, // Fijian Dollar
-    FKP, // Falkland Islands Pound
-    GBP, // British Pound Sterling
-    GEL, // Georgian Lari
-    GHS, // Ghanaian Cedi
-    GIP, // Gibraltar Pound
-    GMD, // Gambian Dalasi
-    GNF, // Guinean Franc
-    GTQ, // Guatemalan Quetzal
-    GYD, // Guyanaese Dollar
-    HKD, // Hong Kong Dollar
-    HNL, // Honduran Lempira
-    HRK, // Croatian Kuna
-    HTG, // Haitian Gourde
-    HUF, // Hungarian Forint
-    IDR, // Indonesian Rupiah
-    ILS, // Israeli New Sheqel
-    INR, // Indian Rupee
-    IQD, // Iraqi Dinar
-    IRR, // Iranian Rial
-    ISK, // Icelandic Króna
-    JEP, // Jersey Pound
-    JMD, // Jamaican Dollar
-    JOD, // Jordanian Dinar
-    JPY, // Japanese Yen
-    KES, // Kenyan Shilling
-    KGS, // Kyrgystani Som
-    KHR, // Cambodian Riel
-    KMF, // Comorian Franc
-    KPW, // North Korean Won
-    KRW, // South Korean Won
-    KWD, // Kuwaiti Dinar
-    KYD, // Cayman Islands Dollar
-    KZT, // Kazakhstani Tenge
-    LAK, // Laotian Kip
-    LBP, // Lebanese Pound
-    LBP_BM, // Lebanese Pound (black market)
-    LKR, // Sri Lankan Rupee
-    LRD, // Liberian Dollar
-    LSL, // Lesotho Loti
-    LYD, // Libyan Dinar
-    MAD, // Moroccan Dirham
-    MDL, // Moldovan Leu
-    MGA, // Malagasy Ariary
-    MKD, // Macedonian Denar
-    MMK, // Myanma Kyat
-    MNT, // Mongolian Tugrik
-    MOP, // Macanese Pataca
-    MUR, // Mauritian Rupee
-    MVR, // Maldivian Rufiyaa
-    MWK, // Malawian Kwacha
-    MXN, // Mexican Peso
-    MYR, // Malaysian Ringgit
-    MZN, // Mozambican Metical
-    NAD, // Namibian Dollar
-    NGN, // Nigerian Naira
-    NIO, // Nicaraguan Córdoba
-    NOK, // Norwegian Krone
-    NPR, // Nepalese Rupee
-    NZD, // New Zealand Dollar
-    OMR, // Omani Rial
-    PAB, // Panamanian Balboa
-    PEN, // Peruvian Sol
-    PGK, // Papua New Guinean Kina
-    PHP, // Philippine Peso
-    PKR, // Pakistani Rupee
-    PLN, // Polish Zloty
-    PYG, // Paraguayan Guarani
-    QAR, // Qatari Rial
-    RON, // Romanian Leu
-    RSD, // Serbian Dinar
-    RUB, // Russian Ruble
-    RWF, // Rwandan Franc
-    SAR, // Saudi Riyal
-    SBD, // Solomon Islands Dollar
-    SCR, // Seychellois Rupee
-    SDG, // Sudanese Pound
-    SEK, // Swedish Krona
-    SGD, // Singapore Dollar
-    SHP, // Saint Helena Pound
-    SLL, // Sierra Leonean Leone
-    SOS, // Somali Shilling
-    SRD, // Surinamese Dollar
-    SYP, // Syrian Pound
-    SZL, // Swazi Lilangeni
-    THB, // Thai Baht
-    TJS, // Tajikistani Somoni
-    TMT, // Turkmenistani Manat
-    TND, // Tunisian Dinar
-    TOP, // Tongan Paʻanga
-    TRY, // Turkish Lira
-    TTD, // Trinidad and Tobago Dollar
-    TWD, // Taiwan Dollar
-    TZS, // Tanzanian Shilling
-    UAH, // Ukrainian Hryvnia
-    UGX, // Ugandan Shilling
-    USD, // United States Dollar
-    UYU, // Uruguayan Peso
-    UZS, // Uzbekistan Som
-    VND, // Vietnamese Dong
-    VUV, // Vanuatu Vatu
-    WST, // Samoan Tala
-    XAF, // CFA Franc BEAC
-    XCD, // East Caribbean Dollar
-    XOF, // CFA Franc BCEAO
-    XPF, // CFP Franc
-    YER, // Yemeni Rial
-    ZAR, // South African Rand
-    ZMW; // Zambian Kwacha
+enum class FiatCurrency(override val displayCode: String, val flag: String = "🏳️") : CurrencyUnit {
+    AED(displayCode = "AED", flag = "🇦🇪"), // United Arab Emirates Dirham
+    AFN(displayCode = "AFN", flag = "🇦🇫"), // Afghan Afghani
+    ALL(displayCode = "ALL", flag = "🇦🇱"), // Albanian Lek
+    AMD(displayCode = "AMD", flag = "🇦🇲"), // Armenian Dram
+    ANG(displayCode = "ANG", flag = "🇳🇱"), // Netherlands Antillean Guilder
+    AOA(displayCode = "AOA", flag = "🇦🇴"), // Angolan Kwanza
+    ARS_BM(displayCode = "ARS", flag = "🇦🇷"), // Argentine Peso (blue market)
+    ARS(displayCode = "ARS_OFF", flag = "🇦🇷"), // Argentine Peso (official rate)
+    AUD(displayCode = "AUD", flag = "🇦🇺"), // Australian Dollar
+    AWG(displayCode = "AWG", flag = "🇦🇼"), // Aruban Florin
+    AZN(displayCode = "AZN", flag = "🇦🇿"), // Azerbaijani Manat
+    BAM(displayCode = "BAM", flag = "🇧🇦"), // Bosnia-Herzegovina Convertible Mark
+    BBD(displayCode = "BBD", flag = "🇧🇧"), // Barbadian Dollar
+    BDT(displayCode = "BDT", flag = "🇧🇩"), // Bangladeshi Taka
+    BGN(displayCode = "BGN", flag = "🇧🇬"), // Bulgarian Lev
+    BHD(displayCode = "BHD", flag = "🇧🇭"), // Bahraini Dinar
+    BIF(displayCode = "BIF", flag = "🇧🇮"), // Burundian Franc
+    BMD(displayCode = "BMD", flag = "🇧🇲"), // Bermudan Dollar
+    BND(displayCode = "BND", flag = "🇧🇳"), // Brunei Dollar
+    BOB(displayCode = "BOB", flag = "🇧🇴"), // Bolivian Boliviano
+    BRL(displayCode = "BRL", flag = "🇧🇷"), // Brazilian Real
+    BSD(displayCode = "BSD", flag = "🇧🇸"), // Bahamian Dollar
+    BTN(displayCode = "BTN", flag = "🇧🇹"), // Bhutanese Ngultrum
+    BWP(displayCode = "BWP", flag = "🇧🇼"), // Botswanan Pula
+    BZD(displayCode = "BZD", flag = "🇧🇿"), // Belize Dollar
+    CAD(displayCode = "CAD", flag = "🇨🇦"), // Canadian Dollar
+    CDF(displayCode = "CDF", flag = "🇨🇩"), // Congolese Franc
+    CHF(displayCode = "CHF", flag = "🇨🇭"), // Swiss Franc
+    CLP(displayCode = "CLP", flag = "🇨🇱"), // Chilean Peso
+    CNH(displayCode = "CNH", flag = "🇨🇳"), // Chinese Yuan (offshore)
+    CNY(displayCode = "CNY", flag = "🇨🇳"), // Chinese Yuan (onshore)
+    COP(displayCode = "COP", flag = "🇨🇴"), // Colombian Peso
+    CRC(displayCode = "CRC", flag = "🇨🇷"), // Costa Rican Colón
+    CUP_FM(displayCode = "CUP", flag = "🇨🇺"), // Cuban Peso (free market)
+    CUP(displayCode = "CUP_OFF", flag = "🇨🇺"), // Cuban Peso (official rate)
+    CVE(displayCode = "CVE", flag = "🇨🇻"), // Cape Verdean Escudo
+    CZK(displayCode = "CZK", flag = "🇨🇿"), // Czech Republic Koruna
+    DJF(displayCode = "DJF", flag = "🇩🇯"), // Djiboutian Franc
+    DKK(displayCode = "DKK", flag = "🇩🇰"), // Danish Krone
+    DOP(displayCode = "DOP", flag = "🇩🇴"), // Dominican Peso
+    DZD(displayCode = "DZD", flag = "🇩🇿"), // Algerian Dinar
+    EGP(displayCode = "EGP", flag = "🇪🇬"), // Egyptian Pound
+    ERN(displayCode = "ERN", flag = "🇪🇷"), // Eritrean Nakfa
+    ETB(displayCode = "ETB", flag = "🇪🇹"), // Ethiopian Birr
+    EUR(displayCode = "EUR", flag = "🇪🇺"), // Euro
+    FJD(displayCode = "FJD", flag = "🇫🇯"), // Fijian Dollar
+    FKP(displayCode = "FKP", flag = "🇫🇰"), // Falkland Islands Pound
+    GBP(displayCode = "GBP", flag = "🇬🇧"), // British Pound Sterling
+    GEL(displayCode = "GEL", flag = "🇬🇪"), // Georgian Lari
+    GHS(displayCode = "GHS", flag = "🇬🇭"), // Ghanaian Cedi
+    GIP(displayCode = "GIP", flag = "🇬🇮"), // Gibraltar Pound
+    GMD(displayCode = "GMD", flag = "🇬🇲"), // Gambian Dalasi
+    GNF(displayCode = "GNF", flag = "🇬🇳"), // Guinean Franc
+    GTQ(displayCode = "GTQ", flag = "🇬🇹"), // Guatemalan Quetzal
+    GYD(displayCode = "GYD", flag = "🇬🇾"), // Guyanaese Dollar
+    HKD(displayCode = "HKD", flag = "🇭🇰"), // Hong Kong Dollar
+    HNL(displayCode = "HNL", flag = "🇭🇳"), // Honduran Lempira
+    HRK(displayCode = "HRK", flag = "🇭🇷"), // Croatian Kuna
+    HTG(displayCode = "HTG", flag = "🇭🇹"), // Haitian Gourde
+    HUF(displayCode = "HUF", flag = "🇭🇺"), // Hungarian Forint
+    IDR(displayCode = "IDR", flag = "🇮🇩"), // Indonesian Rupiah
+    ILS(displayCode = "ILS", flag = "🇮🇱"), // Israeli New Sheqel
+    INR(displayCode = "INR", flag = "🇮🇳"), // Indian Rupee
+    IQD(displayCode = "IQD", flag = "🇮🇶"), // Iraqi Dinar
+    IRR(displayCode = "IRR", flag = "🇮🇷"), // Iranian Rial
+    ISK(displayCode = "ISK", flag = "🇮🇸"), // Icelandic Króna
+    JEP(displayCode = "JEP", flag = "🇯🇪"), // Jersey Pound
+    JMD(displayCode = "JMD", flag = "🇯🇲"), // Jamaican Dollar
+    JOD(displayCode = "JOD", flag = "🇯🇴"), // Jordanian Dinar
+    JPY(displayCode = "JPY", flag = "🇯🇵"), // Japanese Yen
+    KES(displayCode = "KES", flag = "🇰🇪"), // Kenyan Shilling
+    KGS(displayCode = "KGS", flag = "🇰🇬"), // Kyrgystani Som
+    KHR(displayCode = "KHR", flag = "🇰🇭"), // Cambodian Riel
+    KMF(displayCode = "KMF", flag = "🇰🇲"), // Comorian Franc
+    KPW(displayCode = "KPW", flag = "🇰🇵"), // North Korean Won
+    KRW(displayCode = "KRW", flag = "🇰🇷"), // South Korean Won
+    KWD(displayCode = "KWD", flag = "🇰🇼"), // Kuwaiti Dinar
+    KYD(displayCode = "KYD", flag = "🇰🇾"), // Cayman Islands Dollar
+    KZT(displayCode = "KZT", flag = "🇰🇿"), // Kazakhstani Tenge
+    LAK(displayCode = "LAK", flag = "🇱🇦"), // Laotian Kip
+    LBP_BM(displayCode = "LBP", flag = "🇱🇧"), // Lebanese Pound (black market)
+    LBP(displayCode = "LBP_OFF", flag = "🇱🇧"), // Lebanese Pound (official rate)
+    LKR(displayCode = "LKR", flag = "🇱🇰"), // Sri Lankan Rupee
+    LRD(displayCode = "LRD", flag = "🇱🇷"), // Liberian Dollar
+    LSL(displayCode = "LSL", flag = "🇱🇸"), // Lesotho Loti
+    LYD(displayCode = "LYD", flag = "🇱🇾"), // Libyan Dinar
+    MAD(displayCode = "MAD", flag = "🇲🇦"), // Moroccan Dirham
+    MDL(displayCode = "MDL", flag = "🇲🇩"), // Moldovan Leu
+    MGA(displayCode = "MGA", flag = "🇲🇬"), // Malagasy Ariary
+    MKD(displayCode = "MKD", flag = "🇲🇰"), // Macedonian Denar
+    MMK(displayCode = "MMK", flag = "🇲🇲"), // Myanma Kyat
+    MNT(displayCode = "MNT", flag = "🇲🇳"), // Mongolian Tugrik
+    MOP(displayCode = "MOP", flag = "🇲🇴"), // Macanese Pataca
+    MUR(displayCode = "MUR", flag = "🇲🇺"), // Mauritian Rupee
+    MVR(displayCode = "MVR", flag = "🇲🇻"), // Maldivian Rufiyaa
+    MWK(displayCode = "MWK", flag = "🇲🇼"), // Malawian Kwacha
+    MXN(displayCode = "MXN", flag = "🇲🇽"), // Mexican Peso
+    MYR(displayCode = "MYR", flag = "🇲🇾"), // Malaysian Ringgit
+    MZN(displayCode = "MZN", flag = "🇲🇿"), // Mozambican Metical
+    NAD(displayCode = "NAD", flag = "🇳🇦"), // Namibian Dollar
+    NGN(displayCode = "NGN", flag = "🇳🇬"), // Nigerian Naira
+    NIO(displayCode = "NIO", flag = "🇳🇮"), // Nicaraguan Córdoba
+    NOK(displayCode = "NOK", flag = "🇳🇴"), // Norwegian Krone
+    NPR(displayCode = "NPR", flag = "🇳🇵"), // Nepalese Rupee
+    NZD(displayCode = "NZD", flag = "🇳🇿"), // New Zealand Dollar
+    OMR(displayCode = "OMR", flag = "🇴🇲"), // Omani Rial
+    PAB(displayCode = "PAB", flag = "🇵🇦"), // Panamanian Balboa
+    PEN(displayCode = "PEN", flag = "🇵🇪"), // Peruvian Sol
+    PGK(displayCode = "PGK", flag = "🇵🇬"), // Papua New Guinean Kina
+    PHP(displayCode = "PHP", flag = "🇵🇭"), // Philippine Peso
+    PKR(displayCode = "PKR", flag = "🇵🇰"), // Pakistani Rupee
+    PLN(displayCode = "PLN", flag = "🇵🇱"), // Polish Zloty
+    PYG(displayCode = "PYG", flag = "🇵🇾"), // Paraguayan Guarani
+    QAR(displayCode = "QAR", flag = "🇶🇦"), // Qatari Rial
+    RON(displayCode = "RON", flag = "🇷🇴"), // Romanian Leu
+    RSD(displayCode = "RSD", flag = "🇷🇸"), // Serbian Dinar
+    RUB(displayCode = "RUB", flag = "🇷🇺"), // Russian Ruble
+    RWF(displayCode = "RWF", flag = "🇷🇼"), // Rwandan Franc
+    SAR(displayCode = "SAR", flag = "🇸🇦"), // Saudi Riyal
+    SBD(displayCode = "SBD", flag = "🇸🇧"), // Solomon Islands Dollar
+    SCR(displayCode = "SCR", flag = "🇸🇨"), // Seychellois Rupee
+    SDG(displayCode = "SDG", flag = "🇸🇩"), // Sudanese Pound
+    SEK(displayCode = "SEK", flag = "🇸🇪"), // Swedish Krona
+    SGD(displayCode = "SGD", flag = "🇸🇬"), // Singapore Dollar
+    SHP(displayCode = "SHP", flag = "🇸🇭"), // Saint Helena Pound
+    SLL(displayCode = "SLL", flag = "🇸🇱"), // Sierra Leonean Leone
+    SOS(displayCode = "SOS", flag = "🇸🇴"), // Somali Shilling
+    SRD(displayCode = "SRD", flag = "🇸🇷"), // Surinamese Dollar
+    SYP(displayCode = "SYP", flag = "🇸🇾"), // Syrian Pound
+    SZL(displayCode = "SZL", flag = "🇸🇿"), // Swazi Lilangeni
+    THB(displayCode = "THB", flag = "🇹🇭"), // Thai Baht
+    TJS(displayCode = "TJS", flag = "🇹🇯"), // Tajikistani Somoni
+    TMT(displayCode = "TMT", flag = "🇹🇲"), // Turkmenistani Manat
+    TND(displayCode = "TND", flag = "🇹🇳"), // Tunisian Dinar
+    TOP(displayCode = "TOP", flag = "🇹🇴"), // Tongan Paʻanga
+    TRY(displayCode = "TRY", flag = "🇹🇷"), // Turkish Lira
+    TTD(displayCode = "TTD", flag = "🇹🇹"), // Trinidad and Tobago Dollar
+    TWD(displayCode = "TWD", flag = "🇹🇼"), // Taiwan Dollar
+    TZS(displayCode = "TZS", flag = "🇹🇿"), // Tanzanian Shilling
+    UAH(displayCode = "UAH", flag = "🇺🇦"), // Ukrainian Hryvnia
+    UGX(displayCode = "UGX", flag = "🇺🇬"), // Ugandan Shilling
+    USD(displayCode = "USD", flag = "🇺🇸"), // United States Dollar
+    UYU(displayCode = "UYU", flag = "🇺🇾"), // Uruguayan Peso
+    UZS(displayCode = "UZS", flag = "🇺🇿"), // Uzbekistan Som
+    VND(displayCode = "VND", flag = "🇻🇳"), // Vietnamese Dong
+    VUV(displayCode = "VUV", flag = "🇻🇺"), // Vanuatu Vatu
+    WST(displayCode = "WST", flag = "🇼🇸"), // Samoan Tala
+    XAF(displayCode = "XAF", flag = "🇨🇲"), // CFA Franc BEAC
+    XCD(displayCode = "XCD", flag = "🇱🇨"), // East Caribbean Dollar
+    XOF(displayCode = "XOF", flag = "🇨🇮"), // CFA Franc BCEAO
+    XPF(displayCode = "XPF", flag = "🇳🇨"), // CFP Franc
+    YER(displayCode = "YER", flag = "🇾🇪"), // Yemeni Rial
+    ZAR(displayCode = "ZAR", flag = "🇿🇦"), // South African Rand
+    ZMW(displayCode = "ZMW", flag = "🇿🇲"); // Zambian Kwacha
 
     companion object {
         val values = values().toList()


### PR DESCRIPTION
Some currencies have two rates, the official rate (whose value is decided unilaterally usually by a state body) and the free market rate. The free market one should take precedence over the official rate, as it is the rate that is commonly used.

We could remove the official rate altogether, but it may still be useful to have some reference in the app.

@robbiehanson I've added new attributes in the `FiatCurrency` object because it makes sense to share data as much as possible. If it's an issue (for example, the flag code in Swift), we can revert that. 

### new `displayCode` in `FiatCurrency`

It helps decoupling the internal API code from the actual ticker displayed in the UI. For example, we want to keep using the `ARS` code internally for the official ARS rate. That way we don't break the data in the app database, and we don't break the code fetching the rate from the coinbase API. But the UI uses a different ticker, in this case `ARS_OFF` to show that it's the official rate and not the Blue Market one. 

Conversely, for the Blue Market rate, we keep using `ARS_BM` internally, but in the Android UI I now use `displayCode` which prints `ARS`.

Let me know what you think.


---

Note: As usual there's a separate commit for the changes in the `phoenix-shared` module, and another commit that's only about `phoenix-android` and that you can disregard.