### PR TITLE
Use maven version 3.9.4 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ FROM eclipse-temurin:11.0.20_8-jdk-alpine as ECLAIR_CORE_BUILD
 COPY ./buildSrc/src/main/kotlin/Versions.kt .
 RUN cat Versions.kt | grep "const val eclair =" | cut -d '"' -f 2 > eclair-core-version.txt
 
-ARG MAVEN_VERSION=3.9.3
+ARG MAVEN_VERSION=3.9.4
 ARG USER_HOME_DIR="/root"
-ARG SHA=400fc5b6d000c158d5ee7937543faa06b6bda8408caa2444a9c947c21472fde0f0b64ac452b8cec8855d528c0335522ed5b6c8f77085811c7e29e1bedbb5daa2
+ARG SHA=deaa39e16b2cf20f8cd7d232a1306344f04020e1f0fb28d35492606f647a60fe729cc40d3cba33e093a17aed41bd161fe1240556d0f1b80e773abd408686217e
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN apk add --no-cache curl tar bash git


### PR DESCRIPTION
I could not build the Docker image for building the app since it seems the Maven version 3.9.3 is no longer available. I assumed it's alright to use 3.9.4 instead.