### PR TITLE
Compatibility with Xcode 15

### DIFF
--- a/phoenix-shared/build.gradle.kts
+++ b/phoenix-shared/build.gradle.kts
@@ -35,6 +35,11 @@ kotlin {
                     // But with standard allocation, we're using less then half the limit.
                     kotlinOptions.freeCompilerArgs += "-Xallocator=std"
                     kotlinOptions.freeCompilerArgs += listOf("-linker-options", "-application_extension")
+                    // workaround for xcode 15 and kotlin < 1.9.10: 
+                    // https://youtrack.jetbrains.com/issue/KT-60230/Native-unknown-options-iossimulatorversionmin-sdkversion-with-Xcode-15-beta-3
+                    if (System.getenv("XCODE_VERSION_MAJOR") == "1500") {
+                        linkerOpts += "-ld64"
+                    }
                 }
             }
         }


### PR DESCRIPTION
Xcode 15 brings a new `ld_prime` static linker which is not compatible with kotlin < 1.9.10. This workaround forces xcode to use `ld64`, until we move to kotlin 1.9.10. See https://youtrack.jetbrains.com/issue/KT-60230/Native-unknown-options-iossimulatorversionmin-sdkversion-with-Xcode-15-beta-3 for details.

@robbiehanson There's another issue with `wasDisconnected` in `MempoolMonitor.swift`, method `startNetworkMonitor`. Can you take a look?