### PR TITLE
iOS: Beta3 changes

### DIFF
--- a/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers+Lightning.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers+Lightning.swift
@@ -26,12 +26,10 @@ extension Lightning_kmpElectrumClient {
 			/// Transforming from Kotlin:
 			/// `notifications: Flow<ElectrumSubscriptionResponse>`
 			///
-			KotlinPassthroughSubject<
-				/*obj-c:*/ Lightning_kmpElectrumSubscriptionResponse,
-				/*swift:*/ Lightning_kmpElectrumSubscriptionResponse
-			>(
+			KotlinPassthroughSubject<Lightning_kmpElectrumSubscriptionResponse>(
 				self.notifications
 			)
+			.compactMap { $0 }
 			.eraseToAnyPublisher()
 		}
 	}
@@ -51,9 +49,10 @@ extension Lightning_kmpElectrumWatcher {
 			/// Transforming from Kotlin:
 			/// `openUpToDateFlow(): Flow<Long>`
 			///
-			KotlinPassthroughSubject<KotlinLong, Int64>(
+			KotlinPassthroughSubject<KotlinLong>(
 				self.openUpToDateFlow()
 			)
+			.compactMap { $0?.int64Value }
 			.eraseToAnyPublisher()
 		}
 	}
@@ -73,7 +72,7 @@ extension Lightning_kmpNodeParams {
 			/// Transforming from Kotlin:
 			/// `nodeEvents: SharedFlow<NodeEvents>`
 			///
-			KotlinPassthroughSubject<Lightning_kmpNodeEvents, Lightning_kmpNodeEvents?>(
+			KotlinPassthroughSubject<Lightning_kmpNodeEvents>(
 				self.nodeEvents
 			)
 			.compactMap { $0 }

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers+Phoenix.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers+Phoenix.swift
@@ -28,7 +28,7 @@ extension PeerManager {
 			// ```
 			// peerState: StateFlow<Peer?>
 			// ```
-			KotlinCurrentValueSubject<Lightning_kmpPeer, Lightning_kmpPeer?>(
+			KotlinCurrentValueSubject<Lightning_kmpPeer>(
 				self.peerState
 			)
 			.compactMap { $0 }
@@ -44,10 +44,10 @@ extension PeerManager {
 			// ```
 			// channelsFlow: StateFlow<Map<ByteVector32, LocalChannelInfo>?>
 			// ```
-			KotlinCurrentValueSubject<NSDictionary, [Bitcoin_kmpByteVector32: LocalChannelInfo]?>(
+			KotlinCurrentValueSubject<NSDictionary>(
 				self.channelsFlow
 			)
-			.compactMap { $0 }
+			.compactMap { $0 as? [Bitcoin_kmpByteVector32: LocalChannelInfo] }
 			.map { Array($0.values) }
 			.eraseToAnyPublisher()
 		}
@@ -61,10 +61,7 @@ extension PeerManager {
 			// ```
 			// finalWallet: StateFlow<WalletState.WalletWithConfirmations?>
 			// ```
-			KotlinCurrentValueSubject<
-				Lightning_kmpWalletState.WalletWithConfirmations,
-				Lightning_kmpWalletState.WalletWithConfirmations?
-			>(
+			KotlinCurrentValueSubject<Lightning_kmpWalletState.WalletWithConfirmations>(
 				self.finalWallet
 			)
 			.map { $0 ?? Lightning_kmpWalletState.WalletWithConfirmations.empty() }
@@ -87,7 +84,7 @@ extension AppConfigurationManager {
 			// Transforming from Kotlin:
 			// `walletContext: StateFlow<WalletContext?>`
 			//
-			KotlinCurrentValueSubject<WalletContext, WalletContext?>(
+			KotlinCurrentValueSubject<WalletContext>(
 				self.walletContext
 			)
 			.compactMap { $0 }
@@ -111,7 +108,7 @@ extension BalanceManager {
 			// Transforming from Kotlin:
 			// `balance: StateFlow<MilliSatoshi?>`
 			//
-			KotlinCurrentValueSubject<Lightning_kmpMilliSatoshi, Lightning_kmpMilliSatoshi?>(
+			KotlinCurrentValueSubject<Lightning_kmpMilliSatoshi>(
 				self.balance
 			)
 			.eraseToAnyPublisher()
@@ -126,10 +123,7 @@ extension BalanceManager {
 			// ```
 			// swapInWallet: StateFlow<WalletState.WalletWithConfirmations?>
 			// ```
-			KotlinCurrentValueSubject<
-				Lightning_kmpWalletState.WalletWithConfirmations,
-				Lightning_kmpWalletState.WalletWithConfirmations?
-			>(
+			KotlinCurrentValueSubject<Lightning_kmpWalletState.WalletWithConfirmations>(
 				self.swapInWallet
 			)
 			.map { $0 ?? Lightning_kmpWalletState.WalletWithConfirmations.empty() }
@@ -152,9 +146,10 @@ extension ConnectionsManager {
 			// Transforming from Kotlin:
 			// `connections: StateFlow<Connections>`
 			//
-			KotlinCurrentValueSubject<Connections, Connections>(
+			KotlinCurrentValueSubject<Connections>(
 				self.connections
 			)
+			.compactMap { $0 }
 			.eraseToAnyPublisher()
 		}
 	}
@@ -175,9 +170,10 @@ extension CurrencyManager {
 			// Transforming from Kotlin:
 			// `ratesFlow: StateFlow<List<ExchangeRate>>`
 			//
-			KotlinCurrentValueSubject<NSArray, [ExchangeRate]>(
+			KotlinCurrentValueSubject<NSArray>(
 				self.ratesFlow
 			)
+			.compactMap { $0 as? [ExchangeRate] }
 			.eraseToAnyPublisher()
 		}
 	}
@@ -189,9 +185,10 @@ extension CurrencyManager {
 			// Transforming from Kotlin:
 			// `refreshFlow: StateFlow<Set<FiatCurrency>>`
 			//
-			KotlinCurrentValueSubject<NSSet, Set<FiatCurrency>>(
+			KotlinCurrentValueSubject<NSSet>(
 				self.refreshFlow
 			)
+			.compactMap { $0 as? Set<FiatCurrency> }
 			.map { (targets: Set<FiatCurrency>) -> Bool in
 				return !targets.isEmpty
 			}
@@ -214,7 +211,7 @@ extension NodeParamsManager {
 			// Transforming from Kotlin:
 			// `nodeParams: StateFlow<NodeParams?>`
 			//
-			KotlinCurrentValueSubject<Lightning_kmpNodeParams, Lightning_kmpNodeParams?>(
+			KotlinCurrentValueSubject<Lightning_kmpNodeParams>(
 				self.nodeParams
 			)
 			.compactMap { $0 }
@@ -262,9 +259,10 @@ extension PhoenixShared.NotificationsManager {
 			// Transforming from Kotlin:
 			// `notifications = StateFlow<List<Pair<Set<UUID>, Notification>>>`
 			// 
-			KotlinCurrentValueSubject<NSArray, Array<AnyObject>>(
+			KotlinCurrentValueSubject<NSArray>(
 				self.notifications
 			)
+			.compactMap { $0 as? Array<AnyObject> }
 			.map { originalArray in
 				let transformedArray: [NotificationItem] = originalArray.compactMap { value in
 					guard
@@ -300,9 +298,10 @@ extension PaymentsManager {
 			// Transforming from Kotlin:
 			// `paymentsCount: StateFlow<Long>`
 			//
-			KotlinCurrentValueSubject<KotlinLong, Int64>(
+			KotlinCurrentValueSubject<KotlinLong>(
 				self.paymentsCount
 			)
+			.compactMap { $0?.int64Value }
 			.eraseToAnyPublisher()
 		}
 	}
@@ -314,7 +313,7 @@ extension PaymentsManager {
 			// Transforming from Kotlin:
 			// `lastCompletedPayment: StateFlow<WalletPayment?>`
 			//
-			KotlinCurrentValueSubject<Lightning_kmpWalletPayment, Lightning_kmpWalletPayment?>(
+			KotlinCurrentValueSubject<Lightning_kmpWalletPayment>(
 				self.lastCompletedPayment
 			)
 			.compactMap { $0 }
@@ -329,12 +328,10 @@ extension PaymentsManager {
 			// Transforming from Kotlin:
 			// `lastCompletedPayment: StateFlow<WalletPayment?>`
 			//
-			KotlinCurrentValueSubject<Lightning_kmpWalletPayment, Lightning_kmpWalletPayment?>(
+			KotlinCurrentValueSubject<Lightning_kmpWalletPayment>(
 				self.lastCompletedPayment
 			)
-			.compactMap {
-				return $0 as? Lightning_kmpIncomingPayment
-			}
+			.compactMap { $0 as? Lightning_kmpIncomingPayment }
 			.eraseToAnyPublisher()
 		}
 	}
@@ -346,12 +343,11 @@ extension PaymentsManager {
 			// Transforming from Kotlin:
 			// `inFlightOutgoingPayments: StateFlow<Set<UUID>>`
 			//
-			KotlinCurrentValueSubject<NSSet, Set<Lightning_kmpUUID>>(
+			KotlinCurrentValueSubject<NSSet>(
 				self.inFlightOutgoingPayments
 			)
-			.map {
-				return $0.count
-			}
+			.compactMap { $0 as? Set<Lightning_kmpUUID> }
+			.map { $0.count }
 			.eraseToAnyPublisher()
 		}
 	}
@@ -371,9 +367,10 @@ extension PaymentsPageFetcher {
 			// Transforming from Kotlin:
 			// `paymentsPage: StateFlow<PaymentsPage>`
 			//
-			KotlinCurrentValueSubject<PaymentsPage, PaymentsPage>(
+			KotlinCurrentValueSubject<PaymentsPage>(
 				self.paymentsPage
 			)
+			.compactMap { $0 as? PaymentsPage }
 			.eraseToAnyPublisher()
 		}
 	}
@@ -394,12 +391,10 @@ extension CloudKitDb {
 			/// Transforming from Kotlin:
 			/// `queueCount: StateFlow<Long>`
 			///
-			KotlinCurrentValueSubject<KotlinLong, KotlinLong>(
+			KotlinCurrentValueSubject<KotlinLong>(
 				self.queueCount
 			)
-			.map {
-				$0.int64Value
-			}
+			.compactMap { $0?.int64Value }
 			.eraseToAnyPublisher()
 		}
 	}

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/SwapInWalletDetails.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/SwapInWalletDetails.swift
@@ -336,6 +336,7 @@ struct SwapInWalletDetails: View {
 		
 		let paymentRejected = bizNotifications
 			.compactMap { $0.notification as? PhoenixShared.Notification.PaymentRejected }
+			.filter { $0.source == Lightning_kmpLiquidityEventsSource.onchainwallet }
 			.first
 		
 		if let overAbsoluteFee = paymentRejected as? PhoenixShared.Notification.PaymentRejected.OverAbsoluteFee {

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/SwapInWalletDetails.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/SwapInWalletDetails.swift
@@ -26,6 +26,12 @@ struct SwapInWalletDetails: View {
 	@State var swapInWallet = Biz.business.balanceManager.swapInWalletValue()
 	let swapInWalletPublisher = Biz.business.balanceManager.swapInWalletPublisher()
 	
+	let swapInRejectedPublisher = Biz.swapInRejectedPublisher
+	@State var swapInRejected: Lightning_kmpLiquidityEventsRejected? = nil
+	
+	let bizNotificationsPublisher = Biz.business.notificationsManager.notificationsPublisher()
+	@State var bizNotifications: [PhoenixShared.NotificationsManager.NotificationItem] = []
+	
 	@State var blockchainExplorerTxid: String? = nil
 	
 	enum NavBarButtonWidth: Preference {}
@@ -104,6 +110,7 @@ struct SwapInWalletDetails: View {
 		
 		List {
 			section_info()
+			section_lastAttempt()
 			section_confirmed()
 			section_unconfirmed()
 		}
@@ -115,6 +122,12 @@ struct SwapInWalletDetails: View {
 		.onReceive(swapInWalletPublisher) {
 			swapInWalletChanged($0)
 		}
+		.onReceive(swapInRejectedPublisher) {
+			swapInRejectedStateChange($0)
+		}
+		.onReceive(bizNotificationsPublisher) {
+			bizNotificationsChanged($0)
+		}
 	}
 	
 	@ViewBuilder
@@ -124,13 +137,38 @@ struct SwapInWalletDetails: View {
 			
 			VStack(alignment: HorizontalAlignment.leading, spacing: 20) {
 				
-				let maxFee = maxSwapInFee()
-				Text(
-					"""
-					On-chain funds will automatically be swapped to Lightning if the \
-					fee is **less than \(maxFee.string)**.
-					"""
-				)
+				if !liquidityPolicy.enabled {
+					
+					Text(
+						"""
+						You have **disabled** automated channel management. \
+						Funds will not be swapped, and will be unavailable for spending within Phoenix.
+						"""
+					)
+					
+				} else {
+					
+					let (maxFee, isPercentBased) = maxSwapInFeeDetails()
+					if isPercentBased {
+						
+						let percent = basisPointsAsPercent(liquidityPolicy.effectiveMaxFeeBasisPoints)
+						Text(
+							"""
+							On-chain funds will automatically be swapped to Lightning if the \
+							fee is **less than \(percent)** (\(maxFee.string)) of the amount.
+							"""
+						)
+						
+					} else {
+						
+						Text(
+							"""
+							On-chain funds will automatically be swapped to Lightning if the \
+							fee is **less than \(maxFee.string)**.
+							"""
+						)
+					}
+				}
 				
 				Button {
 					navigateToLiquiditySettings()
@@ -148,6 +186,37 @@ struct SwapInWalletDetails: View {
 
 		} // </Section>
 		.assignMaxPreference(for: iconWidthReader.key, to: $iconWidth)
+	}
+	
+	@ViewBuilder
+	func section_lastAttempt() -> some View {
+		
+		if liquidityPolicy.enabled, let notification = paymentRejectedNotification() {
+			
+			Section {
+				
+				switch notification {
+				case .Left(let reason):
+					
+					let actualFee = Utils.formatBitcoin(currencyPrefs, msat: reason.fee)
+					let maxAllowedFee = Utils.formatBitcoin(currencyPrefs, sat: reason.maxAbsoluteFee)
+					
+					Text("The fee was **\(actualFee.string)** but your max fee was set to **\(maxAllowedFee.string)**.")
+					
+				case .Right(let reason):
+					
+					let actualFee = Utils.formatBitcoin(currencyPrefs, msat: reason.fee)
+					let percent = basisPointsAsPercent(reason.maxRelativeFeeBasisPoints)
+					
+					Text("The fee was **\(actualFee.string)** which is more than **\(percent)** of the amount.")
+					
+				} // </switch>
+				
+			} header: {
+				Text("Last Attempt")
+				
+			} // </Section>
+		}
 	}
 	
 	@ViewBuilder
@@ -238,9 +307,8 @@ struct SwapInWalletDetails: View {
 	// MARK: View Helpers
 	// --------------------------------------------------
 	
-	func maxSwapInFee() -> FormattedAmount {
+	func maxSwapInFeeDetails() -> (FormattedAmount, Bool) {
 		
-		let effectiveMax: Int64
 		let absoluteMax: Int64 = liquidityPolicy.effectiveMaxFeeSats
 		
 		let swapInBalance: Int64 = swapInWallet.totalBalance.sat
@@ -249,14 +317,52 @@ struct SwapInWalletDetails: View {
 			let maxPercent: Double = Double(liquidityPolicy.effectiveMaxFeeBasisPoints) / Double(10_000)
 			let percentMax: Int64 = Int64(Double(swapInBalance) * maxPercent)
 			
-			effectiveMax = min(absoluteMax, percentMax)
-			
-		} else {
-			
-			effectiveMax = absoluteMax
+			if percentMax < absoluteMax {
+				
+				let formatted = Utils.formatBitcoin(currencyPrefs, sat: percentMax)
+				return (formatted, true)
+			}
 		}
 		
-		return Utils.formatBitcoin(currencyPrefs, sat: effectiveMax)
+		let formatted = Utils.formatBitcoin(currencyPrefs, sat: absoluteMax)
+		return (formatted, false)
+	}
+	
+	func paymentRejectedNotification(
+	) -> Either<
+		PhoenixShared.Notification.PaymentRejected.OverAbsoluteFee,
+		PhoenixShared.Notification.PaymentRejected.OverRelativeFee
+	>? {
+		
+		let paymentRejected = bizNotifications
+			.compactMap { $0.notification as? PhoenixShared.Notification.PaymentRejected }
+			.first
+		
+		if let overAbsoluteFee = paymentRejected as? PhoenixShared.Notification.PaymentRejected.OverAbsoluteFee {
+			return Either.Left(overAbsoluteFee)
+		}
+		if let overRelativeFee = paymentRejected as? PhoenixShared.Notification.PaymentRejected.OverRelativeFee {
+			return Either.Right(overRelativeFee)
+		}
+		
+		return nil
+	}
+	
+	func basisPointsAsPercent(_ basisPoints: Int32) -> String {
+		
+		// Example: 30% == 3,000 basis points
+		//
+		// 3,000 / 100       => 30.0 => 3000%
+		// 3,000 / 100 / 100 =>  0.3 => 30%
+		
+		let percent = Double(basisPoints) / Double(10_000)
+		
+		let formatter = NumberFormatter()
+		formatter.numberStyle = .percent
+		formatter.minimumFractionDigits = 0
+		formatter.maximumFractionDigits = 2
+		
+		return formatter.string(from: NSNumber(value: percent)) ?? "?%"
 	}
 	
 	func confirmedBalance() -> (FormattedAmount, FormattedAmount) {
@@ -314,6 +420,21 @@ struct SwapInWalletDetails: View {
 		log.trace("swapInWalletChanged()")
 		
 		swapInWallet = newValue
+	}
+	
+	func swapInRejectedStateChange(_ state: Lightning_kmpLiquidityEventsRejected?) {
+		log.trace("swapInRejectedStateChange()")
+		
+		swapInRejected = state
+	}
+	
+	func bizNotificationsChanged(_ list: [PhoenixShared.NotificationsManager.NotificationItem]) {
+		log.trace("bizNotificationsChanges()")
+		
+		if !list.isEmpty {
+			log.debug("list = \(list)")
+		}
+		bizNotifications = list
 	}
 	
 	// --------------------------------------------------

--- a/phoenix-ios/phoenix-ios/views/environment/DeviceInfo.swift
+++ b/phoenix-ios/phoenix-ios/views/environment/DeviceInfo.swift
@@ -25,6 +25,10 @@ class DeviceInfo: ObservableObject {
 		return windowSize
 	}
 	
+	var isIPhone: Bool {
+		return UIDevice.current.userInterfaceIdiom == .phone
+	}
+	
 	var isIPad: Bool {
 		return UIDevice.current.userInterfaceIdiom == .pad
 	}

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
@@ -192,6 +192,7 @@ struct SummaryView: View {
 					
 				} else if let completedAtDate = payment.completedAtDate {
 					Text(completedAtDate.format())
+						.multilineTextAlignment(.center)
 						.font(.subheadline)
 						.foregroundColor(.secondary)
 				}
@@ -257,6 +258,7 @@ struct SummaryView: View {
 				
 				if let completedAtDate = payment.completedAtDate {
 					Text(completedAtDate.format())
+						.multilineTextAlignment(.center)
 						.font(Font.subheadline)
 						.foregroundColor(.secondary)
 				}

--- a/phoenix-ios/phoenix-ios/views/main/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/main/HomeView.swift
@@ -285,6 +285,7 @@ struct HomeView : MVIView {
 			
 				if swapInRejected != nil {
 					Image(systemName: "zzz")
+						.foregroundColor(.appNegative)
 						.padding(.trailing, 2)
 				} else {
 					Image(systemName: "link")
@@ -317,16 +318,18 @@ struct HomeView : MVIView {
 	@ViewBuilder
 	func notices() -> some View {
 		
-		Group {
-			let count = noticeCount()
-			if count > 1 {
-				notice_multiple(count: count)
-			} else if count == 1 {
-				notice_single()
+		let count = noticeCount()
+		if count > 0 {
+			Group {
+				if count > 1 {
+					notice_multiple(count: count)
+				} else if count == 1 {
+					notice_single()
+				}
 			}
+			.frame(maxWidth: deviceInfo.textColumnMaxWidth)
+			.padding([.leading, .trailing, .bottom], 10)
 		}
-		.frame(maxWidth: deviceInfo.textColumnMaxWidth)
-		.padding([.leading, .trailing, .bottom], 10)
 	}
 	
 	@ViewBuilder
@@ -404,7 +407,7 @@ struct HomeView : MVIView {
 				NotificationCell.mempoolFull(action: flag ? openMempoolFullURL : nil)
 				
 			} else if let item = primaryBizNotification() {
-				BizNotificationCell(action: flag ? {} : nil, item: item)
+				BizNotificationCell(item: item, location: .HomeView, action: flag ? {} : nil)
 			}
 		}
 		.font(.caption)
@@ -581,12 +584,12 @@ struct HomeView : MVIView {
 	}
 	
 	func primaryBizNotification() -> PhoenixShared.NotificationsManager.NotificationItem? {
-		return nil
-//		let firstPaymentRejectedNotification = bizNotifications.first { item in
-//			return item.notification is PhoenixShared.Notification.PaymentRejected
-//		}
-//
-//		return firstPaymentRejectedNotification ?? bizNotifications.first
+		
+		let firstPaymentRejectedNotification = bizNotifications.first { item in
+			return item.notification is PhoenixShared.Notification.PaymentRejected
+		}
+		
+		return firstPaymentRejectedNotification ?? bizNotifications.first
 	}
 	
 	// --------------------------------------------------

--- a/phoenix-ios/phoenix-ios/views/notifications/NotificationCell.swift
+++ b/phoenix-ios/phoenix-ios/views/notifications/NotificationCell.swift
@@ -161,13 +161,13 @@ class NotificationCell {
 struct BizNotificationCell: View {
 	
 	enum Location {
-		case HomeView
-		case NotificationsView
+		case HomeView_Single(preAction: ()->Void)
+		case HomeView_Multiple
+		case NotificationsView(preAction: ()->Void)
 	}
 	
 	let item: PhoenixShared.NotificationsManager.NotificationItem
 	let location: Location
-	let action: (() -> Void)?
 	
 	@EnvironmentObject var currencyPrefs: CurrencyPrefs
 	@EnvironmentObject var deepLinkManager: DeepLinkManager
@@ -213,20 +213,27 @@ struct BizNotificationCell: View {
 		
 		VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
 			
-			let amt = Utils.formatBitcoin(currencyPrefs, msat: amount(either))
-			Group {
-				if isOnChain(either) {
-					switch location {
-					case .HomeView:
-						Text("On-chain funds pending") // amount is already displayed on screen
-					case .NotificationsView:
+			// Title
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				Group {
+					let amt = Utils.formatBitcoin(currencyPrefs, msat: amount(either))
+					if isOnChain(either) {
 						Text("On-chain funds pending (+\(amt.string))")
+					} else {
+						Text("Payment rejected (+\(amt.string))")
 					}
-				} else {
-					Text("Payment rejected (+\(amt.string))")
 				}
-			}
-			.font(.headline)
+				.font(.headline)
+				
+				if isDismissable() {
+					Spacer(minLength: 0)
+					Button {
+						dismiss()
+					} label: {
+						Image(systemName: "xmark")
+					}
+				}
+			} // </HStack>
 			
 			switch either {
 			case .Left(let reason):
@@ -251,23 +258,9 @@ struct BizNotificationCell: View {
 				
 			} // </switch>
 			
-			HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 4) {
-				if action != nil {
-					Button {
-						navigateToLiquiditySettings()
-					} label: {
-						Text("Check fee settings")
-							.font(.callout)
-					}
-				}
-				Spacer(minLength: 0)
-				Text(timestamp())
-					.font(.caption)
-					.foregroundColor(.secondary)
-			} // </HStack>
-			.padding(.top, action != nil ? 15 : 5)
+			body_paymentRejected_footer()
 			
-		} // </VStac>
+		} // </VStack>
 		.accessibilityElement(children: .combine)
 		.accessibilityAddTraits(.isButton)
 		.accessibilitySortPriority(47)
@@ -280,9 +273,21 @@ struct BizNotificationCell: View {
 		
 		VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
 			
-			let amt = Utils.formatBitcoin(currencyPrefs, msat: reason.amount)
-			Text("Payment rejected (+\(amt.string))")
-				.font(.headline)
+			// Title
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				let amt = Utils.formatBitcoin(currencyPrefs, msat: reason.amount)
+				Text("Payment rejected (+\(amt.string))")
+					.font(.headline)
+				
+				if isDismissable() {
+					Spacer(minLength: 0)
+					Button {
+						dismiss()
+					} label: {
+						Image(systemName: "xmark")
+					}
+				}
+			} // </HStack>
 			
 			Group {
 				if reason is PhoenixShared.Notification.PaymentRejected.FeePolicyDisabled {
@@ -297,26 +302,33 @@ struct BizNotificationCell: View {
 			}
 			.padding(.top, 10)
 			
-			HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 4) {
-				if action != nil {
-					Button {
-						navigateToLiquiditySettings()
-					} label: {
-						Text("Check fee settings")
-							.font(.callout)
-					}
-				}
-				Spacer(minLength: 0)
-				Text(timestamp())
-					.font(.caption)
-					.foregroundColor(.secondary)
-			} // </HStack>
-			.padding(.top, action != nil ? 15 : 5)
+			body_paymentRejected_footer()
 			
 		} // </VStac>
 		.accessibilityElement(children: .combine)
 		.accessibilityAddTraits(.isButton)
 		.accessibilitySortPriority(47)
+	}
+	
+	@ViewBuilder
+	func body_paymentRejected_footer() -> some View {
+		
+		let showAction = shouldShowAction()
+		HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 4) {
+			if showAction {
+				Button {
+					navigateToLiquiditySettings()
+				} label: {
+					Text("Check fee settings")
+						.font(.callout)
+				}
+			}
+			Spacer(minLength: 0)
+			Text(timestamp())
+				.font(.caption)
+				.foregroundColor(.secondary)
+		} // </HStack>
+		.padding(.top, showAction ? 15 : 5)
 	}
 	
 	@ViewBuilder
@@ -326,8 +338,21 @@ struct BizNotificationCell: View {
 		
 		VStack(alignment: HorizontalAlignment.leading, spacing: 10) {
 			
-			Text("Watchtower report")
-				.font(.headline)
+			// Title
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				Text("Watchtower report")
+					.font(.headline)
+				
+				if isDismissable() {
+					Spacer(minLength: 0)
+					Button {
+						dismiss()
+					} label: {
+						Image(systemName: "xmark")
+					}
+				}
+				
+			} // </HStack>
 			
 			if reason.channelsWatchedCount == 1 {
 				Text("1 channel was successfully checked. No issues were found.")
@@ -350,8 +375,20 @@ struct BizNotificationCell: View {
 		
 		VStack(alignment: HorizontalAlignment.leading, spacing: 10) {
 			
-			Text("Watchtower alert")
-				.font(.headline)
+			// Title
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				Text("Watchtower alert")
+					.font(.headline)
+				
+				if isDismissable() {
+					Spacer(minLength: 0)
+					Button {
+						dismiss()
+					} label: {
+						Image(systemName: "xmark")
+					}
+				}
+			} // </HStack>
 			
 			Text("Revoked commits found on \(reason.channels.count) channel(s)!")
 				.font(.callout)
@@ -372,8 +409,20 @@ struct BizNotificationCell: View {
 		
 		VStack(alignment: HorizontalAlignment.leading, spacing: 10) {
 			
-			Text("Watchtower unable to complete")
-				.font(.headline)
+			// Title
+			HStack(alignment: VerticalAlignment.center, spacing: 0) {
+				Text("Watchtower unable to complete")
+					.font(.headline)
+				
+				if isDismissable() {
+					Spacer(minLength: 0)
+					Button {
+						dismiss()
+					} label: {
+						Image(systemName: "xmark")
+					}
+				}
+			} // </HStack>
 			
 			Text("A new attempt is scheduled in a few hours.")
 				.font(.callout)
@@ -382,6 +431,24 @@ struct BizNotificationCell: View {
 		.accessibilityElement(children: .combine)
 		.accessibilityAddTraits(.isButton)
 		.accessibilitySortPriority(47)
+	}
+	
+	func isDismissable() -> Bool {
+		
+		switch location {
+			case .HomeView_Single   : return true
+			case .HomeView_Multiple : return false
+			case .NotificationsView : return false
+		}
+	}
+	
+	func shouldShowAction() -> Bool {
+		
+		switch location {
+			case .HomeView_Single   : return true
+			case .HomeView_Multiple : return false
+			case .NotificationsView : return true
+		}
 	}
 	
 	func timestamp() -> String {
@@ -447,9 +514,17 @@ struct BizNotificationCell: View {
 	func navigateToLiquiditySettings() {
 		log.trace("navigateToLiquiditySettings()")
 		
-		if let action {
-			action()
+		switch location {
+			case .HomeView_Single(let preAction)   : preAction()
+			case .HomeView_Multiple                : break
+			case .NotificationsView(let preAction) : preAction()
 		}
 		deepLinkManager.broadcast(.liquiditySettings)
+	}
+		
+	func dismiss() {
+		log.trace("dismiss()")
+		
+		Biz.business.notificationsManager.dismissNotifications(ids: item.ids)
 	}
 }

--- a/phoenix-ios/phoenix-ios/views/notifications/NotificationsView.swift
+++ b/phoenix-ios/phoenix-ios/views/notifications/NotificationsView.swift
@@ -142,7 +142,7 @@ struct NotificationsView : View {
 		Section {
 			
 			ForEach(self.bizNotifications_payment) { item in
-				BizNotificationCell(action: closeSheet, item: item)
+				BizNotificationCell(item: item, location: .NotificationsView, action: closeSheet)
 					.padding(12)
 					.background(
 						RoundedRectangle(cornerRadius: 8)
@@ -171,7 +171,7 @@ struct NotificationsView : View {
 		Section {
 			
 			ForEach(self.bizNotifications_watchtower) { item in
-				BizNotificationCell(action: closeSheet, item: item)
+				BizNotificationCell(item: item, location: .NotificationsView, action: closeSheet)
 					.padding(12)
 					.background(
 						RoundedRectangle(cornerRadius: 8)

--- a/phoenix-ios/phoenix-ios/views/notifications/NotificationsView.swift
+++ b/phoenix-ios/phoenix-ios/views/notifications/NotificationsView.swift
@@ -142,7 +142,7 @@ struct NotificationsView : View {
 		Section {
 			
 			ForEach(self.bizNotifications_payment) { item in
-				BizNotificationCell(item: item, location: .NotificationsView, action: closeSheet)
+				BizNotificationCell(item: item, location: .NotificationsView(preAction: closeSheet))
 					.padding(12)
 					.background(
 						RoundedRectangle(cornerRadius: 8)
@@ -171,7 +171,7 @@ struct NotificationsView : View {
 		Section {
 			
 			ForEach(self.bizNotifications_watchtower) { item in
-				BizNotificationCell(item: item, location: .NotificationsView, action: closeSheet)
+				BizNotificationCell(item: item, location: .NotificationsView(preAction: closeSheet))
 					.padding(12)
 					.background(
 						RoundedRectangle(cornerRadius: 8)

--- a/phoenix-ios/phoenix-ios/views/transactions/PaymentCell.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/PaymentCell.swift
@@ -29,6 +29,9 @@ struct PaymentCell : View {
 	
 	@ScaledMetric var textScaling: CGFloat = 100
 	
+	@Environment(\.dynamicTypeSize) var dynamicTypeSize: DynamicTypeSize
+	
+	@EnvironmentObject var deviceInfo: DeviceInfo
 	@EnvironmentObject var currencyPrefs: CurrencyPrefs
 
 	init(
@@ -54,82 +57,24 @@ struct PaymentCell : View {
 		}
 	}
 	
+	// --------------------------------------------------
+	// MARK: View Builders
+	// --------------------------------------------------
+	
 	@ViewBuilder
 	var body: some View {
 		
-		HStack(alignment: VerticalAlignment.center, spacing: 0) {
+		Group {
+			// Accessibility Notes:
+			// Every cell should use the same layout.
+			// So it's preferred to make a layout decision based on device type & state.
 			
-			Group {
-				if let payment = fetched?.payment {
-					switch payment.state() {
-						case WalletPaymentState.successonchain  : Image(systemName: "link.circle.fill")
-						case WalletPaymentState.successoffchain : Image(systemName: "checkmark.circle.fill")
-						case WalletPaymentState.pendingonchain  : Image(systemName: "clock.fill")
-						case WalletPaymentState.pendingoffchain : Image(systemName: "clock.fill")
-						case WalletPaymentState.failure         : Image(systemName: "x.circle.fill")
-						default                                 : Image(systemName: "magnifyingglass.circle.fill")
-					}
-				} else {
-					Image(systemName: "magnifyingglass.circle.fill")
-				}
-			}
-			.font(.title3)
-			.imageScale(.large)
-			.foregroundColor(.appAccent)
-
-			VStack(alignment: HorizontalAlignment.leading) {
-				Text(paymentDescription())
-					.lineLimit(1)
-					.truncationMode(.tail)
-					.foregroundColor(.primaryForeground)
-
-				Text(paymentTimestamp())
-					.font(.caption)
-					.foregroundColor(.secondary)
-			}
-			.frame(maxWidth: .infinity, alignment: .leading)
-			.padding(.leading, 12)
-			.padding(.trailing, 6)
-
-			let (amount, isFailure, isOutgoing) = paymentAmountInfo()
-			if currencyPrefs.hideAmounts {
-				
-				HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
-					
-					// Do not display any indication as to whether payment in incoming or outgoing
-					Text(verbatim: amount.digits)
-						.foregroundColor(Color(UIColor.systemGray2))
-						.accessibilityLabel("hidden amount")
-				}
-					
+			if dynamicTypeSize.isAccessibilitySize && deviceInfo.isIPhone {
+				body_accessibility()
 			} else {
-			
-				HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
-					
-					let color: Color = isFailure ? .secondary : (isOutgoing ? .appNegative : .appPositive)
-					HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
-					
-						Text(verbatim: isOutgoing ? "-" : "+")
-							.foregroundColor(color)
-							.padding(.trailing, 1)
-						
-						Text(verbatim: amount.digits)
-							.foregroundColor(color)
-					}
-					.environment(\.layoutDirection, .leftToRight) // issue #237
-					
-					Text(verbatim: " ") // separate for RTL languages
-						.font(.caption)
-						.foregroundColor(.gray)
-					Text_CurrencyName(currency: amount.currency, fontTextStyle: .caption)
-						.foregroundColor(.gray)
-				} // </HStack>
-				.accessibilityElement()
-				.accessibilityLabel("\(isOutgoing ? "-" : "+")\(amount.string)")
-				
-			} // </amount>
-			
-		} // </HStack>
+				body_standard()
+			}
+		}
 		.padding([.top, .bottom], 14)
 		.padding([.leading, .trailing], 12)
 		.onAppear {
@@ -139,7 +84,133 @@ struct PaymentCell : View {
 			onDisappear()
 		}
 	}
+	
+	@ViewBuilder
+	func body_standard() -> some View {
+		
+		HStack(alignment: VerticalAlignment.center, spacing: 0) {
+			
+			paymentImage()
 
+			VStack(alignment: HorizontalAlignment.leading) {
+				Text(paymentDescription())
+					.lineLimit(1)
+					.truncationMode(.tail)
+					.foregroundColor(.primaryForeground)
+
+				Text(paymentTimestamp())
+					.font(.caption)
+					.lineLimit(1)
+					.truncationMode(.tail)
+					.foregroundColor(.secondary)
+			}
+			.frame(maxWidth: .infinity, alignment: .leading)
+			.padding(.leading, 12)
+			.padding(.trailing, 6)
+			
+			paymentAmount()
+			
+		} // </HStack>
+	}
+	
+	@ViewBuilder
+	func body_accessibility() -> some View {
+		
+		HStack(alignment: VerticalAlignment.center, spacing: 0) {
+			
+			paymentImage()
+			
+			VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
+				
+				Text(paymentDescription())
+					.lineLimit(1)
+					.truncationMode(.tail)
+					.foregroundColor(.primaryForeground)
+				
+				Text(paymentTimestamp())
+					.font(.caption)
+					.lineLimit(1)
+					.truncationMode(.tail)
+					.foregroundColor(.secondary)
+				
+				HStack(alignment: VerticalAlignment.center, spacing: 0) {
+					Spacer(minLength: 0)
+					paymentAmount()
+				}
+			}
+			.frame(maxWidth: .infinity, alignment: .leading)
+			.padding(.leading, 12)
+		}
+	}
+	
+	@ViewBuilder
+	func paymentImage() -> some View {
+		
+		Group {
+			if let payment = fetched?.payment {
+				switch payment.state() {
+					case WalletPaymentState.successonchain  : Image(systemName: "link.circle.fill")
+					case WalletPaymentState.successoffchain : Image(systemName: "checkmark.circle.fill")
+					case WalletPaymentState.pendingonchain  : Image(systemName: "clock.fill")
+					case WalletPaymentState.pendingoffchain : Image(systemName: "clock.fill")
+					case WalletPaymentState.failure         : Image(systemName: "x.circle.fill")
+					default                                 : Image(systemName: "magnifyingglass.circle.fill")
+				}
+			} else {
+				Image(systemName: "magnifyingglass.circle.fill")
+			}
+		}
+		.font(.title3)
+		.imageScale(.large)
+		.foregroundColor(.appAccent)
+	}
+	
+	@ViewBuilder
+	func paymentAmount() -> some View {
+		
+		let (amount, isFailure, isOutgoing) = paymentAmountInfo()
+		if currencyPrefs.hideAmounts {
+			
+			HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
+				
+				// Do not display any indication as to whether payment in incoming or outgoing
+				Text(verbatim: amount.digits)
+					.foregroundColor(Color(UIColor.systemGray2))
+					.accessibilityLabel("hidden amount")
+			}
+				
+		} else {
+		
+			HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
+				
+				let color: Color = isFailure ? .secondary : (isOutgoing ? .appNegative : .appPositive)
+				HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
+				
+					Text(verbatim: isOutgoing ? "-" : "+")
+						.foregroundColor(color)
+						.padding(.trailing, 1)
+					
+					Text(verbatim: amount.digits)
+						.foregroundColor(color)
+				}
+				.environment(\.layoutDirection, .leftToRight) // issue #237
+				
+				Text(verbatim: " ") // separate for RTL languages
+					.font(.caption)
+					.foregroundColor(.gray)
+				Text_CurrencyName(currency: amount.currency, fontTextStyle: .caption)
+					.foregroundColor(.gray)
+			} // </HStack>
+			.accessibilityElement()
+			.accessibilityLabel("\(isOutgoing ? "-" : "+")\(amount.string)")
+			
+		} // </amount>
+	}
+
+	// --------------------------------------------------
+	// MARK: View Helpers
+	// --------------------------------------------------
+	
 	func paymentDescription() -> String {
 
 		if let fetched = fetched {
@@ -210,6 +281,10 @@ struct PaymentCell : View {
 			return (amount, isFailure, isOutgoing)
 		}
 	}
+	
+	// --------------------------------------------------
+	// MARK: Notifications
+	// --------------------------------------------------
 	
 	func onAppear() {
 		


### PR DESCRIPTION
Most of the changes are surrounding notifications. We no longer display the notification on the Home screen for `PaymentRejected` if `source == onChain`. Instead we simply show a red "zzz" icon next to the incoming amount:

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/f26eb623-ceee-41ef-b8f6-a42f4b165231"/>

The "Swap-In Wallet Details" screen has been updated to reflect the `PaymentRejected` information:

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/4f3cc9e7-04c1-4717-8c05-29ad9854f0cf"/>

With additional information if the rejection was due to the percentage check:

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/af4a8eb2-6e18-4a72-a7b4-399c3735d094"/>

Or if the user disabled channel management:

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/d7ca1fd4-0ac6-4e19-ad10-5c1a6514bbaa"/>

Note that we still have notifications on the Home screen for rejected **Lightning** payments (and these can now be dismissed with the X button):

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/56dfac0f-0256-42a0-aa80-eceec5cb45e7"/>

