### PR TITLE
(ios) When scanned QR code is just a website link

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		DC16965F27FE0FAC003DE1DD /* KotlinExtensions+Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC16965E27FE0FAC003DE1DD /* KotlinExtensions+Currency.swift */; };
 		DC1706D926A71D8E00BAFCD0 /* UnlockErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1706D826A71D8E00BAFCD0 /* UnlockErrorView.swift */; };
 		DC175C1C28F008AE0086B9A6 /* WalletReset.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175C1B28F008AE0086B9A6 /* WalletReset.swift */; };
+		DC1771B42ABC99CE00B286C7 /* WebsiteLinkPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1771B32ABC99CE00B286C7 /* WebsiteLinkPopover.swift */; };
 		DC1844032A2690BB004D9578 /* MinerFeeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1844022A2690BB004D9578 /* MinerFeeSheet.swift */; };
 		DC18C418256FE22300A2D083 /* Prefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC18C417256FE22300A2D083 /* Prefs.swift */; };
 		DC18C41D256FF91100A2D083 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC18C41C256FF91100A2D083 /* Utils.swift */; };
@@ -402,6 +403,7 @@
 		DC16965E27FE0FAC003DE1DD /* KotlinExtensions+Currency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KotlinExtensions+Currency.swift"; sourceTree = "<group>"; };
 		DC1706D826A71D8E00BAFCD0 /* UnlockErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockErrorView.swift; sourceTree = "<group>"; };
 		DC175C1B28F008AE0086B9A6 /* WalletReset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletReset.swift; sourceTree = "<group>"; };
+		DC1771B32ABC99CE00B286C7 /* WebsiteLinkPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebsiteLinkPopover.swift; sourceTree = "<group>"; };
 		DC1844022A2690BB004D9578 /* MinerFeeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinerFeeSheet.swift; sourceTree = "<group>"; };
 		DC18C417256FE22300A2D083 /* Prefs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prefs.swift; sourceTree = "<group>"; };
 		DC18C41C256FF91100A2D083 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
@@ -842,6 +844,7 @@
 				DC118C0927B457F70080BBAC /* LnurlFlowErrorNotice.swift */,
 				DCEAE5B82943D64B00320C46 /* MsatRange.swift */,
 				DCB62F482A5E09F900912A71 /* SpliceOutProblem.swift */,
+				DC1771B32ABC99CE00B286C7 /* WebsiteLinkPopover.swift */,
 			);
 			path = send;
 			sourceTree = "<group>";
@@ -1655,6 +1658,7 @@
 				DCFAEFC92A72F48700330088 /* SwapInWalletDetails.swift in Sources */,
 				DC89857F25914747007B253F /* UIApplicationState+Phoenix.swift in Sources */,
 				DCFC72042862237400D6B293 /* Asserts.swift in Sources */,
+				DC1771B42ABC99CE00B286C7 /* WebsiteLinkPopover.swift in Sources */,
 				DCCD046127EE045C007D57A5 /* DetailsView.swift in Sources */,
 				DC6CF35B2938F32E001837EE /* ListBackgroundColor.swift in Sources */,
 				DC641C82282188E700862DCD /* Utils+CurrencyPrefs.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/views/send/WebsiteLinkPopover.swift
+++ b/phoenix-ios/phoenix-ios/views/send/WebsiteLinkPopover.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import os.log
+
+#if DEBUG && true
+fileprivate var log = Logger(
+	subsystem: Bundle.main.bundleIdentifier!,
+	category: "WebsiteLinkPopover"
+)
+#else
+fileprivate var log = Logger(OSLog.disabled)
+#endif
+
+
+struct WebsiteLinkPopover: View {
+	
+	let link: URL
+	let copyAction: (URL)->Void
+	let openAction: (URL)->Void
+	
+	enum ButtonHeight: Preference {}
+	let buttonHeightReader = GeometryPreferenceReader(
+		key: AppendValue<ButtonHeight>.self,
+		value: { [$0.size.height] }
+	)
+	@State var buttonHeight: CGFloat? = nil
+	
+	@EnvironmentObject var popoverState: PopoverState
+	
+	@ViewBuilder
+	var body: some View {
+		
+		VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
+			
+			Text("This appears to be a website (not a lightning invoice):")
+				.padding(.bottom, 10)
+			
+			Text(verbatim: link.absoluteString)
+				.foregroundColor(Color(UIColor.link))
+				.multilineTextAlignment(.leading)
+				.padding(.bottom, 20)
+			
+			HStack(alignment: VerticalAlignment.center, spacing: 10) {
+				Spacer(minLength: 0)
+				
+				Button {
+					copyLink()
+				} label: {
+					Label { Text("Copy") } icon: { Image(systemName: "square.on.square") }
+				}
+				.read(buttonHeightReader)
+				
+				if let buttonHeight {
+					Divider()
+						.frame(width: 1, height: buttonHeight)
+						.background(Color.borderColor)
+				}
+				
+				Button {
+					openLink()
+				} label: {
+					Label { Text("Open") } icon: { Image(systemName: "network") }
+				}
+				.read(buttonHeightReader)
+			}
+			.assignMaxPreference(for: buttonHeightReader.key, to: $buttonHeight)
+		}
+		.padding(20)
+	}
+	
+	func copyLink() {
+		log.trace("copyLink()")
+		
+		popoverState.close(animationCompletion: {
+			copyAction(self.link)
+		})
+	}
+	
+	func openLink() {
+		log.trace("openLink()")
+		
+		popoverState.close(animationCompletion: {
+			openAction(self.link)
+		})
+	}
+}


### PR DESCRIPTION
It's happened to me multiple times. I open up Phoenix, scan a QR code (which I assume is an LNURL), and I get this confusing error message:

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/2396a01b-cabe-4ef3-b623-261ddbc10e32"/>

It's often the case that the QR code was just a website. And if you open the link in your browser, then the website will help you generate the lightning invoice.

Other times I was just confused. Like when I saw this at a restaurant that said "Pay with crypto. Scan here"

<img height="650" src="https://github.com/ACINQ/phoenix/assets/304604/e9a368d5-65ca-424e-b68c-a32a3c954840"/>

Except that's the link for the menu. But I was very confused when I scanned it with Phoenix...

So this PR makes the experience more helpful for the user:

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/7f42333b-c394-433c-b870-fd4d807bdf31"/>

