### PR TITLE
(android) Show recently rejected payments in Home

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeNotices.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeNotices.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
+import android.text.format.DateUtils
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -32,25 +33,27 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
+import fr.acinq.lightning.LiquidityEvents
 import fr.acinq.lightning.utils.UUID
+import fr.acinq.lightning.utils.currentTimestampMillis
+import fr.acinq.phoenix.android.LocalNavController
 import fr.acinq.phoenix.android.Notice
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.Screen
 import fr.acinq.phoenix.android.components.PhoenixIcon
+import fr.acinq.phoenix.android.components.TextWithIcon
 import fr.acinq.phoenix.android.components.openLink
-import fr.acinq.phoenix.android.navController
 import fr.acinq.phoenix.android.utils.borderColor
 import fr.acinq.phoenix.data.Notification
 
-@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun NoticesButtonRow(
     modifier: Modifier = Modifier,
@@ -59,26 +62,50 @@ fun NoticesButtonRow(
     onNavigateToNotificationsList: () -> Unit,
 ) {
     val filteredNotices = notices.filterIsInstance<Notice.ShowInHome>().sortedBy { it.priority }
-    // don't display anything if there are no permanent notices
-    if (filteredNotices.isEmpty()) return
+    val now = currentTimestampMillis()
+    val recentRejectedOffchainCount = notifications.map { it.second }
+        .filterIsInstance<Notification.PaymentRejected>()
+        .filter { it.source == LiquidityEvents.Source.OffChainPayment && (now - it.createdAt) < 3 * DateUtils.HOUR_IN_MILLIS }
+        .size
 
-    val navController = navController
+    // don't display anything if there are no permanent notices or rejected offchain payments
+    if (filteredNotices.isEmpty() && recentRejectedOffchainCount == 0) return
+
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        if (recentRejectedOffchainCount > 0) {
+            PaymentsRejectedShortView(recentRejectedOffchainCount, onNavigateToNotificationsList)
+        }
+        filteredNotices.firstOrNull()?.let {
+            FirstNoticeView(notice = it, messagesCount = notices.size + notifications.size, onNavigateToNotificationsList = onNavigateToNotificationsList)
+        }
+    }
+}
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+private fun FirstNoticeView(
+    modifier: Modifier = Modifier,
+    notice: Notice.ShowInHome,
+    messagesCount: Int,
+    onNavigateToNotificationsList: () -> Unit,
+) {
     val context = LocalContext.current
+    val navController = LocalNavController.current
 
-    val elementsCount = notices.size + notifications.size
-
-    // clicking on a notice may execute the notice's action if there are no other messages. Otherwise, redirect to the notifications page.
-    val onClick: (() -> Unit)? = if (elementsCount == 1 && filteredNotices.isNotEmpty()) {
-        when (filteredNotices.first()) {
+    val onClick = if (messagesCount == 1) {
+        when (notice) {
             is Notice.MigrationFromLegacy -> {
                 { openLink(context, "https://acinq.co/blog/phoenix-splicing-update") }
             }
+
             is Notice.BackupSeedReminder -> {
-                { navController.navigate(Screen.DisplaySeed.route) }
+                { navController?.navigate(Screen.DisplaySeed.route) ?: Unit }
             }
+
             is Notice.CriticalUpdateAvailable, is Notice.UpdateAvailable -> {
                 { openLink(context, "https://play.google.com/store/apps/details?id=fr.acinq.phoenix.mainnet") }
             }
+
             is Notice.NotificationPermission -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     val notificationPermission = rememberPermissionState(permission = Manifest.permission.POST_NOTIFICATIONS)
@@ -94,7 +121,8 @@ fun NoticesButtonRow(
                     }
                 } else null
             }
-            is Notice.MempoolFull -> null
+
+            is Notice.MempoolFull -> onNavigateToNotificationsList
         }
     } else {
         onNavigateToNotificationsList
@@ -103,43 +131,46 @@ fun NoticesButtonRow(
     Row(
         modifier = modifier
             .padding(horizontal = 16.dp)
-            .clip(RoundedCornerShape(16.dp))
+            .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colors.surface)
             .fillMaxWidth()
-            .then(if (onClick != null) {
-                Modifier.clickable(
-                    onClick = onClick,
-                    role = Role.Button,
-                    onClickLabel = "Show notifications",
-                )
-            } else Modifier)
+            .then(
+                if (onClick != null) {
+                    Modifier.clickable(onClick = onClick, role = Role.Button, onClickLabel = "Show notifications")
+                } else {
+                    Modifier
+                }
+            )
             .padding(horizontal = 12.dp, vertical = 12.dp),
         verticalAlignment = Alignment.Top
     ) {
-        filteredNotices.firstOrNull()?.let { notice ->
-            when (notice) {
-                Notice.MigrationFromLegacy -> {
-                    NoticeView(text = stringResource(id = R.string.inappnotif_migration_from_legacy), icon = R.drawable.ic_party_popper)
-                }
-                Notice.MempoolFull -> {
-                    NoticeView(text = stringResource(id = R.string.inappnotif_mempool_full_message), icon = R.drawable.ic_alert_triangle)
-                }
-                Notice.UpdateAvailable -> {
-                    NoticeView(text = stringResource(id = R.string.inappnotif_upgrade_message), icon = R.drawable.ic_restore)
-                }
-                Notice.CriticalUpdateAvailable -> {
-                    NoticeView(text = stringResource(id = R.string.inappnotif_upgrade_critical_message), icon = R.drawable.ic_restore)
-                }
-                Notice.BackupSeedReminder -> {
-                    NoticeView(text = stringResource(id = R.string.inappnotif_backup_seed_message), icon = R.drawable.ic_key)
-                }
-                Notice.NotificationPermission -> {
-                    NoticeView(text = stringResource(id = R.string.inappnotif_notification_permission_message), icon = R.drawable.ic_notification)
-                }
+        when (notice) {
+            Notice.MigrationFromLegacy -> {
+                NoticeTextView(text = stringResource(id = R.string.inappnotif_migration_from_legacy), icon = R.drawable.ic_party_popper)
+            }
+
+            Notice.MempoolFull -> {
+                NoticeTextView(text = stringResource(id = R.string.inappnotif_mempool_full_message), icon = R.drawable.ic_alert_triangle)
+            }
+
+            Notice.UpdateAvailable -> {
+                NoticeTextView(text = stringResource(id = R.string.inappnotif_upgrade_message), icon = R.drawable.ic_restore)
+            }
+
+            Notice.CriticalUpdateAvailable -> {
+                NoticeTextView(text = stringResource(id = R.string.inappnotif_upgrade_critical_message), icon = R.drawable.ic_restore)
+            }
+
+            Notice.BackupSeedReminder -> {
+                NoticeTextView(text = stringResource(id = R.string.inappnotif_backup_seed_message), icon = R.drawable.ic_key)
+            }
+
+            Notice.NotificationPermission -> {
+                NoticeTextView(text = stringResource(id = R.string.inappnotif_notification_permission_message), icon = R.drawable.ic_notification)
             }
         }
 
-        if (elementsCount > 1) {
+        if (messagesCount > 1) {
             Spacer(modifier = Modifier.width(12.dp))
             Box(
                 Modifier
@@ -150,7 +181,7 @@ fun NoticesButtonRow(
             )
             Spacer(modifier = Modifier.width(12.dp))
             Text(
-                text = "+${elementsCount - 1}",
+                text = "+${messagesCount - 1}",
                 modifier = Modifier
                     .align(Alignment.CenterVertically)
                     .clip(RoundedCornerShape(10.dp))
@@ -163,12 +194,38 @@ fun NoticesButtonRow(
 }
 
 @Composable
-private fun RowScope.NoticeView(
+private fun PaymentsRejectedShortView(
+    rejectedPaymentsCount: Int,
+    onNavigateToNotificationsList: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colors.surface)
+            .fillMaxWidth()
+            .clickable(onClick = onNavigateToNotificationsList, role = Role.Button, onClickLabel = "Show payments notifications")
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+    ) {
+        TextWithIcon(
+            text = pluralStringResource(id = R.plurals.inappnotif_payments_rejection_overview, count = rejectedPaymentsCount, rejectedPaymentsCount),
+            textStyle = MaterialTheme.typography.body1.copy(fontSize = 14.sp),
+            icon = R.drawable.ic_info,
+            iconTint = MaterialTheme.colors.primary,
+            space = 10.dp
+        )
+    }
+}
+
+@Composable
+private fun RowScope.NoticeTextView(
     text: String,
     icon: Int? = null,
 ) {
     if (icon != null) {
-        PhoenixIcon(resourceId = icon, tint = MaterialTheme.colors.primary, modifier = Modifier.align(Alignment.Top).offset(y = (2).dp))
+        PhoenixIcon(resourceId = icon, tint = MaterialTheme.colors.primary, modifier = Modifier
+            .align(Alignment.Top)
+            .offset(y = (2).dp))
         Spacer(modifier = Modifier.width(10.dp))
     }
     Text(

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeNotices.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeNotices.kt
@@ -65,7 +65,7 @@ fun NoticesButtonRow(
     val now = currentTimestampMillis()
     val recentRejectedOffchainCount = notifications.map { it.second }
         .filterIsInstance<Notification.PaymentRejected>()
-        .filter { it.source == LiquidityEvents.Source.OffChainPayment && (now - it.createdAt) < 3 * DateUtils.HOUR_IN_MILLIS }
+        .filter { it.source == LiquidityEvents.Source.OffChainPayment && (now - it.createdAt) < 15 * DateUtils.HOUR_IN_MILLIS }
         .size
 
     // don't display anything if there are no permanent notices or rejected offchain payments

--- a/phoenix-android/src/main/res/values-cs/important_strings.xml
+++ b/phoenix-android/src/main/res/values-cs/important_strings.xml
@@ -164,6 +164,11 @@
     <string name="inappnotif_mempool_full_action">Podívejte se, jak je ovlivněn Phoenix</string>
 
     <string name="inappnotif_payment_onchain_pending_title">On-Chain finanční prostředky čekají na vyřízení (+%1$s)</string>
+    <plurals name="inappnotif_payments_rejection_overview">
+        <item quantity="one">%1$d nedávno zamítnutá platba</item>
+        <item quantity="few">%1$d nedávno zamítnuté platby</item>
+        <item quantity="many">%1$d nedávno zamítnutých plateb</item>
+    </plurals>
     <string name="inappnotif_payment_rejected_title">Platba zamítnuta (+%1$s)</string>
     <string name="inappnotif_payment_rejected_disabled">Automatická správa kanálů je zakázána.</string>
     <string name="inappnotif_payment_rejected_over_absolute">Poplatek byl %1$s, ale váš maximální poplatek byl nastaven na %2$s.</string>

--- a/phoenix-android/src/main/res/values-cs/important_strings.xml
+++ b/phoenix-android/src/main/res/values-cs/important_strings.xml
@@ -165,9 +165,9 @@
 
     <string name="inappnotif_payment_onchain_pending_title">On-Chain finanční prostředky čekají na vyřízení (+%1$s)</string>
     <plurals name="inappnotif_payments_rejection_overview">
-        <item quantity="one">%1$d nedávno zamítnutá platba</item>
-        <item quantity="few">%1$d nedávno zamítnuté platby</item>
-        <item quantity="many">%1$d nedávno zamítnutých plateb</item>
+        <item quantity="one">%1$d nedávno zamítnutá příchozí platba</item>
+        <item quantity="few">%1$d nedávno zamítnuté příchozí platby</item>
+        <item quantity="many">%1$d nedávno zamítnutých příchozích plateb</item>
     </plurals>
     <string name="inappnotif_payment_rejected_title">Platba zamítnuta (+%1$s)</string>
     <string name="inappnotif_payment_rejected_disabled">Automatická správa kanálů je zakázána.</string>

--- a/phoenix-android/src/main/res/values-de/important_strings.xml
+++ b/phoenix-android/src/main/res/values-de/important_strings.xml
@@ -159,8 +159,8 @@
 
     <string name="inappnotif_payment_onchain_pending_title">On-chain Guthaben ausstehend (+%1$s)</string>
     <plurals name="inappnotif_payments_rejection_overview">
-        <item quantity="one">%1$d Zahlung kürzlich abgelehnt</item>
-        <item quantity="other">%1$d Zahlungen kürzlich abgelehnt</item>
+        <item quantity="one">%1$d kürzlich abgelehnter Zahlungseingang</item>
+        <item quantity="other">%1$d kürzlich abgelehnte Zahlungseingänge</item>
     </plurals>
     <string name="inappnotif_payment_rejected_title">Zahlung abgelehnt (+%1$s)</string>
     <string name="inappnotif_payment_rejected_disabled">Automatisches Kanal-Management ist deaktiviert.</string>

--- a/phoenix-android/src/main/res/values-de/important_strings.xml
+++ b/phoenix-android/src/main/res/values-de/important_strings.xml
@@ -158,6 +158,10 @@
     <string name="inappnotif_mempool_full_action">Erfahren Sie inwiefern Phoenix davon betroffen ist</string>
 
     <string name="inappnotif_payment_onchain_pending_title">On-chain Guthaben ausstehend (+%1$s)</string>
+    <plurals name="inappnotif_payments_rejection_overview">
+        <item quantity="one">%1$d Zahlung kürzlich abgelehnt</item>
+        <item quantity="other">%1$d Zahlungen kürzlich abgelehnt</item>
+    </plurals>
     <string name="inappnotif_payment_rejected_title">Zahlung abgelehnt (+%1$s)</string>
     <string name="inappnotif_payment_rejected_disabled">Automatisches Kanal-Management ist deaktiviert.</string>
     <string name="inappnotif_payment_rejected_over_absolute">Die Gebühr wäre %1$s, aber Ihr Gebührenlimit beträgt %2$s.</string>

--- a/phoenix-android/src/main/res/values-es/important_strings.xml
+++ b/phoenix-android/src/main/res/values-es/important_strings.xml
@@ -160,8 +160,8 @@
 
     <string name="inappnotif_payment_onchain_pending_title">Fondos en cadena pendientes (+%1$s)</string>
     <plurals name="inappnotif_payments_rejection_overview">
-        <item quantity="one">%1$d pago rechazado recientemente</item>
-        <item quantity="many">%1$d pagos rechazados recientemente</item>
+        <item quantity="one">%1$d cobro rechazado recientemente</item>
+        <item quantity="many">%1$d cobros rechazados recientemente</item>
     </plurals>
     <string name="inappnotif_payment_rejected_title">Pago rechazado (+%1$s)</string>
     <string name="inappnotif_payment_rejected_disabled">La gestión automática de canales está desactivada.</string>

--- a/phoenix-android/src/main/res/values-es/important_strings.xml
+++ b/phoenix-android/src/main/res/values-es/important_strings.xml
@@ -159,6 +159,10 @@
     <string name="inappnotif_mempool_full_action">Vea cómo afecta a Phoenix</string>
 
     <string name="inappnotif_payment_onchain_pending_title">Fondos en cadena pendientes (+%1$s)</string>
+    <plurals name="inappnotif_payments_rejection_overview">
+        <item quantity="one">%1$d pago rechazado recientemente</item>
+        <item quantity="many">%1$d pagos rechazados recientemente</item>
+    </plurals>
     <string name="inappnotif_payment_rejected_title">Pago rechazado (+%1$s)</string>
     <string name="inappnotif_payment_rejected_disabled">La gestión automática de canales está desactivada.</string>
     <string name="inappnotif_payment_rejected_over_absolute">La tasa era de %1$s, pero su tasa máxima estaba fijada en %2$s.</string>
@@ -169,7 +173,7 @@
     <string name="inappnotif_watchtower_nominal_title">Informe de la Watchtower</string>
     <plurals name="inappnotif_watchtower_nominal_description">
         <item quantity="one">Se ha comprobado correctamente el canal %1$d en %2$s. No se ha encontrado ningún problema.</item>
-        <item quantity="other">Se han comprobado correctamente %1$d canales en %2$s. No se ha encontrado ningún problema.</item>
+        <item quantity="many">Se han comprobado correctamente %1$d canales en %2$s. No se ha encontrado ningún problema.</item>
     </plurals>
     <string name="inappnotif_watchtower_revokedfound_title">Alerta de la Watchtower</string>
     <string name="inappnotif_watchtower_revokedfound_description">Se han encontrado compromisos revocados en %1$s para canal(es): %2$s. Este canal puede cerrarse.</string>

--- a/phoenix-android/src/main/res/values-fr/important_strings.xml
+++ b/phoenix-android/src/main/res/values-fr/important_strings.xml
@@ -165,9 +165,9 @@
 
     <string name="inappnotif_payment_onchain_pending_title">Dépôt on-chain en attente (+%1$s)</string>
     <plurals name="inappnotif_payments_rejection_overview">
-        <item quantity="one">%1$d paiement refusé récemment</item>
-        <item quantity="many">%1$d paiements refusés récemment</item>
-        <item quantity="other">%1$d paiements refusés récemment</item>
+        <item quantity="one">%1$d paiement entrant refusé récemment</item>
+        <item quantity="many">%1$d paiements entrants refusés récemment</item>
+        <item quantity="other">%1$d paiements entrants refusés récemment</item>
     </plurals>
     <string name="inappnotif_payment_rejected_title">Paiement refusé (+%1$s)</string>
     <string name="inappnotif_payment_rejected_disabled">La gestion des channels automatisée est désactivée.</string>

--- a/phoenix-android/src/main/res/values-fr/important_strings.xml
+++ b/phoenix-android/src/main/res/values-fr/important_strings.xml
@@ -164,6 +164,11 @@
     <string name="inappnotif_migration_from_legacy_dialog_body">Ne réutilisez pas vos anciennes adresses de swap ! Elles ne fonctionneront plus.\n\nContactez le support si vous le faisiez accidentellement.</string>
 
     <string name="inappnotif_payment_onchain_pending_title">Dépôt on-chain en attente (+%1$s)</string>
+    <plurals name="inappnotif_payments_rejection_overview">
+        <item quantity="one">%1$d paiement refusé récemment</item>
+        <item quantity="many">%1$d paiements refusés récemment</item>
+        <item quantity="other">%1$d paiements refusés récemment</item>
+    </plurals>
     <string name="inappnotif_payment_rejected_title">Paiement refusé (+%1$s)</string>
     <string name="inappnotif_payment_rejected_disabled">La gestion des channels automatisée est désactivée.</string>
     <string name="inappnotif_payment_rejected_over_absolute">Les frais étaient de %1$s, mais votre max est de %2$s.</string>

--- a/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
+++ b/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
@@ -165,8 +165,8 @@
 
     <string name="inappnotif_payment_onchain_pending_title">Fundos pendentes na cadeia (+%1$s)</string>
     <plurals name="inappnotif_payments_rejection_overview">
-        <item quantity="one">%1$d pagamento rejeitado recentemente</item>
-        <item quantity="many">%1$d pagamentos rejeitados recentemente</item>
+        <item quantity="one">%1$d pagamento recebido recentemente rejeitado</item>
+        <item quantity="many">%1$d pagamentos recebidos recentemente rejeitados</item>
     </plurals>
     <string name="inappnotif_payment_rejected_title">Pagamento rejeitado (+%1$s)</string>
     <string name="inappnotif_payment_rejected_disabled">O gerenciamento automatizado de canais está desativado.</string>

--- a/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
+++ b/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
@@ -164,6 +164,10 @@
     <string name="inappnotif_mempool_full_action">Veja como a Phoenix é afetada</string>
 
     <string name="inappnotif_payment_onchain_pending_title">Fundos pendentes na cadeia (+%1$s)</string>
+    <plurals name="inappnotif_payments_rejection_overview">
+        <item quantity="one">%1$d pagamento rejeitado recentemente</item>
+        <item quantity="many">%1$d pagamentos rejeitados recentemente</item>
+    </plurals>
     <string name="inappnotif_payment_rejected_title">Pagamento rejeitado (+%1$s)</string>
     <string name="inappnotif_payment_rejected_disabled">O gerenciamento automatizado de canais está desativado.</string>
     <string name="inappnotif_payment_rejected_over_absolute">A taxa foi de %1$s, mas sua taxa máxima foi definida como %2$s.</string>

--- a/phoenix-android/src/main/res/values/important_strings.xml
+++ b/phoenix-android/src/main/res/values/important_strings.xml
@@ -164,6 +164,10 @@
     <string name="inappnotif_mempool_full_action">See how Phoenix is affected</string>
 
     <string name="inappnotif_payment_onchain_pending_title">On-chain funds pending (+%1$s)</string>
+    <plurals name="inappnotif_payments_rejection_overview">
+        <item quantity="one">%1$d payment rejected recently</item>
+        <item quantity="other">%1$d payments rejected recently</item>
+    </plurals>
     <string name="inappnotif_payment_rejected_title">Payment rejected (+%1$s)</string>
     <string name="inappnotif_payment_rejected_disabled">Automated channel management is disabled.</string>
     <string name="inappnotif_payment_rejected_over_absolute">The fee was %1$s, but your max fee was set to %2$s.</string>

--- a/phoenix-android/src/main/res/values/important_strings.xml
+++ b/phoenix-android/src/main/res/values/important_strings.xml
@@ -165,8 +165,8 @@
 
     <string name="inappnotif_payment_onchain_pending_title">On-chain funds pending (+%1$s)</string>
     <plurals name="inappnotif_payments_rejection_overview">
-        <item quantity="one">%1$d payment rejected recently</item>
-        <item quantity="other">%1$d payments rejected recently</item>
+        <item quantity="one">%1$d incoming payment rejected recently</item>
+        <item quantity="other">%1$d incoming payments rejected recently</item>
     </plurals>
     <string name="inappnotif_payment_rejected_title">Payment rejected (+%1$s)</string>
     <string name="inappnotif_payment_rejected_disabled">Automated channel management is disabled.</string>

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/notifications/NotificationsQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/notifications/NotificationsQueries.kt
@@ -55,8 +55,11 @@ internal class NotificationsQueries(val database: AppDatabase) {
     }
 
     /**
-     * Returns a list of unread notifications, grouped by content in order to avoid duplicates/spamming the UU. The set of UUIDs can be
-     * used to execute an action on all the actual relevant data in the database (for example, to mark those notifications as read).
+     * Returns a list of unread notifications, grouped by type (i.e. [Notification]), in order to avoid spamming the UI
+     * with duplicates.
+     *
+     * The set of UUIDs linked to a [Notification] can be used to execute an action on all the actual relevant data in the
+     * database (for example, to mark those notifications as read).
      */
     fun listUnread(): Flow<List<Pair<Set<UUID>, Notification>>> {
         return queries.listUnread().asFlow().mapToList().map {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/NotificationsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/NotificationsManager.kt
@@ -44,6 +44,10 @@ class NotificationsManager(
     private val log = newLogger(loggerFactory)
 
     private val _notifications = MutableStateFlow<List<Pair<Set<UUID>, Notification>>>(emptyList())
+    /**
+     * List of notifications grouped by notification type. The <Set<UUID>> can be used
+     * to execute an action on all the underlying notification data in the database.
+     */
     val notifications = _notifications.asStateFlow()
 
     init {


### PR DESCRIPTION
This PR adds a message that summarises recently rejected payments (due to the user's fee policy). 

On Android we already show a system notification when such events occurred, but these notifications are easy to miss, (system gives them low priority, or system notifications are disabled). The user is confused about why the payment seemingly never arrived - so we need to display a message.

This message only counts offchain payments rejected less than 3 hours ago. Clicking on that message redirects to the notifications list.

@robbiehanson this is similar to what was done in https://github.com/ACINQ/phoenix/pull/423 although I preferred not to show the full details of 1 single rejection (it takes a lot of place). It's more discreet that way, and the user can still get the details by clicking on the message.


### 1 payment rejected with 2 important messages

We display two messages, one about the rejected payment, and the other like before, displaying the important with highest priority. Clicking on any of these messages redirects to the notifications list screen.

<img width=280 src="https://github.com/ACINQ/phoenix/assets/5765435/a18f54a8-6e5d-414d-bebe-d9c0bb4b5893" />
<img width=280 src="https://github.com/ACINQ/phoenix/assets/5765435/d640cbd6-3734-41b3-b2ab-e17cdc8ad736" />


### 3 payments rejected with no important messages

<img width=280 src="https://github.com/ACINQ/phoenix/assets/5765435/79a34a8a-e250-4476-93f9-181bd0f174ee" />

<img width=280 src="https://github.com/ACINQ/phoenix/assets/5765435/4cc827a1-e3b8-468a-bbaf-26c02375dd53" />




