### PR TITLE
Display swap-in grace period & timeouts

### DIFF
--- a/phoenix-android/build.gradle.kts
+++ b/phoenix-android/build.gradle.kts
@@ -121,6 +121,7 @@ dependencies {
     implementation("androidx.compose.material:material:${Versions.Android.compose}")
     implementation("androidx.compose.animation:animation:${Versions.Android.compose}")
     implementation("androidx.compose.animation:animation-graphics:${Versions.Android.compose}")
+    implementation("androidx.compose.material3:material3:1.1.2")
     // -- jetpack compose: navigation
     implementation("androidx.navigation:navigation-compose:${Versions.Android.navCompose}")
     // -- jetpack compose: accompanist (utility library for compose)

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Buttons.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Buttons.kt
@@ -123,10 +123,10 @@ fun FilledButton(
 @Composable
 fun InlineButton(
     text: String,
+    modifier: Modifier = Modifier,
     icon: Int? = null,
     fontSize: TextUnit = MaterialTheme.typography.body1.fontSize,
     iconSize: Dp = ButtonDefaults.IconSize,
-    modifier: Modifier = Modifier,
     padding: PaddingValues = PaddingValues(horizontal = 2.dp, vertical = 1.dp),
     space: Dp = 6.dp,
     maxLines: Int = Int.MAX_VALUE,
@@ -237,8 +237,8 @@ fun PhoenixIcon(
 @Composable
 fun Button(
     onClick: () -> Unit,
-    onLongClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
     text: String? = null,
     icon: Int? = null,
     iconTint: Color = MaterialTheme.colors.primary,
@@ -373,6 +373,7 @@ fun WebLink(
     modifier: Modifier = Modifier,
     fontSize: TextUnit = MaterialTheme.typography.body1.fontSize,
     iconSize: Dp = ButtonDefaults.IconSize,
+    padding: PaddingValues = PaddingValues(horizontal = 2.dp, vertical = 1.dp),
     space: Dp = 8.dp,
     maxLines: Int = Int.MAX_VALUE,
     onClickLabel: String = stringResource(id = R.string.accessibility_link),
@@ -383,6 +384,7 @@ fun WebLink(
         icon = R.drawable.ic_external_link,
         fontSize = fontSize,
         iconSize = iconSize,
+        padding = padding,
         space = space,
         maxLines = maxLines,
         onClickLabel = onClickLabel,

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeBalance.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeBalance.kt
@@ -33,6 +33,7 @@ import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.utils.toMilliSatoshi
 import fr.acinq.phoenix.android.LocalBitcoinUnit
 import fr.acinq.phoenix.android.R
+import fr.acinq.phoenix.android.business
 import fr.acinq.phoenix.android.components.*
 import fr.acinq.phoenix.android.fiatRate
 import fr.acinq.phoenix.android.preferredAmountUnit
@@ -93,9 +94,14 @@ private fun IncomingBalance(
 ) {
     val balance = swapInBalance.total.toMilliSatoshi() + pendingChannelsBalance
     if (balance > 0.msat) {
+        val nextSwapTimeout by business.peerManager.swapInNextTimeout.collectAsState(initial = null)
         val undecidedSwapBalance = swapInBalance.unconfirmed + swapInBalance.weaklyConfirmed
         FilledButton(
-            icon = if (undecidedSwapBalance == 0.sat && pendingChannelsBalance == 0.msat) R.drawable.ic_sleep else R.drawable.ic_clock,
+            icon = when {
+                nextSwapTimeout?.let { it.second < 144 } ?: false -> R.drawable.ic_alert_triangle
+                undecidedSwapBalance == 0.sat && pendingChannelsBalance == 0.msat -> R.drawable.ic_sleep
+                else -> R.drawable.ic_clock
+            },
             iconTint = MaterialTheme.typography.caption.color,
             text = if (balanceDisplayMode == HomeAmountDisplayMode.REDACTED) "****" else {
                 stringResource(id = R.string.home__onchain_incoming, balance.toPrettyString(preferredAmountUnit, fiatRate, withUnit = true))

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
@@ -184,7 +184,7 @@ fun HomeView(
 
     MVIView(CF::home) { model, _ ->
         val balance = model.balance
-        val notices = noticesViewModel.notices.values.toList()
+        val notices = noticesViewModel.notices
         val notifications by business.notificationsManager.notifications.collectAsState(emptyList())
 
         Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
@@ -216,10 +216,11 @@ fun HomeView(
                 )
                 PrimarySeparator(modifier = Modifier.layoutId("separator"))
                 if (notices.isNotEmpty() || notifications.isNotEmpty()) {
-                    NoticesButtonRow(
+                    HomeNotices(
                         modifier = Modifier.layoutId("notices"),
-                        notices = noticesViewModel.notices.values.toList(),
+                        notices = notices,
                         notifications = notifications,
+                        onNavigateToSwapInWallet = onShowSwapInWallet,
                         onNavigateToNotificationsList = onShowNotifications,
                     )
                 } else {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/SettingsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/SettingsView.kt
@@ -62,7 +62,7 @@ fun SettingsView(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var debugClickCount by remember { mutableStateOf(0) }
-    val notices = noticesViewModel.notices.values
+    val notices = noticesViewModel.notices
     val notifications = business.notificationsManager.notifications.collectAsState()
 
     DefaultScreenLayout {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/WalletInfoView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/WalletInfoView.kt
@@ -95,7 +95,7 @@ private fun SwapInWalletView(onSwapInWalletClick: () -> Unit) {
         onClick = onSwapInWalletClick,
     ) {
         swapInWallet?.let { wallet ->
-            OnchainBalanceView(confirmed = wallet.deeplyConfirmed.balance, unconfirmed = wallet.unconfirmed.balance + wallet.weaklyConfirmed.balance)
+            OnchainBalanceView(confirmed = (wallet.deeplyConfirmed + wallet.lockedUntilRefund + wallet.readyForRefund).balance, unconfirmed = wallet.unconfirmed.balance + wallet.weaklyConfirmed.balance)
         } ?: ProgressView(text = stringResource(id = R.string.walletinfo_loading_data))
         keyManager?.let {
             HSeparator(modifier = Modifier.padding(start = 16.dp), width = 50.dp)

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/datastore/UserPrefs.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/datastore/UserPrefs.kt
@@ -212,21 +212,6 @@ object UserPrefs {
         it[INCOMING_MAX_PROP_FEE_INTERNAL_TRACKER] ?: NodeParamsManager.defaultLiquidityPolicy.maxRelativeFeeBasisPoints
     }
 
-    // -- system notifications
-
-    /** Do not spam user with several notifications for the same on-chain deposit. */
-    private val LAST_REJECTED_ONCHAIN_SWAP_AMOUNT = longPreferencesKey("LAST_REJECTED_ONCHAIN_SWAP_AMOUNT")
-    private val LAST_REJECTED_ONCHAIN_SWAP_TIMESTAMP = longPreferencesKey("LAST_REJECTED_ONCHAIN_SWAP_TIMESTAMP")
-    fun getLastRejectedOnchainSwap(context: Context): Flow<Pair<MilliSatoshi, Long>?> = prefs(context).map {
-        val amount = it[LAST_REJECTED_ONCHAIN_SWAP_AMOUNT]
-        val timestamp = it[LAST_REJECTED_ONCHAIN_SWAP_TIMESTAMP]
-        if (amount != null && timestamp != null) amount.msat to timestamp else null
-    }
-    suspend fun saveRejectedOnchainSwap(context: Context, liquidityEvent: LiquidityEvents.Rejected) = context.userPrefs.edit {
-        it[LAST_REJECTED_ONCHAIN_SWAP_AMOUNT] = liquidityEvent.amount.msat
-        it[LAST_REJECTED_ONCHAIN_SWAP_TIMESTAMP] = currentTimestampMillis()
-    }
-
     // -- lnurl
 
     private val LNURL_AUTH_SCHEME = intPreferencesKey("LNURL_AUTH_SCHEME")

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
@@ -30,6 +30,9 @@ import fr.acinq.phoenix.data.BitcoinUnit
 import fr.acinq.phoenix.data.FiatCurrency
 import java.security.cert.CertificateException
 import java.util.*
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * Utility method rebinding any exceptions thrown by a method into another exception, using the origin exception as the root cause.
@@ -44,6 +47,14 @@ inline fun <T> tryWith(exception: Exception, action: () -> T): T = try {
 
 inline fun <T1 : Any, T2 : Any, R : Any> safeLet(p1: T1?, p2: T2?, block: (T1, T2) -> R?): R? {
     return if (p1 != null && p2 != null) block(p1, p2) else null
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun <T, R> T.ifLet(block: (T) -> R): R {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
+    return block(this)
 }
 
 fun Context.findActivity(): MainActivity {

--- a/phoenix-android/src/main/res/values-cs/important_strings.xml
+++ b/phoenix-android/src/main/res/values-cs/important_strings.xml
@@ -36,8 +36,11 @@
     <string name="notif_rejected_deposit_title">On-Chain záloha čeká na vyřízení (+%1$s)</string>
     <string name="notif_rejected_payment_title">Zamítnutí platby (+%1$s)</string>
     <string name="notif_rejected_policy_disabled">Automatická správa kanálů je zakázána. Můžete to změnit v nastavení.</string>
+    <string name="notif_rejected_policy_disabled_timeout">Automatická správa kanálů je zakázána. Platnost této zálohy vyprší %1$s.</string>
     <string name="notif_rejected_over_absolute">Poplatek činil %1$s, ale váš maximální poplatek byl nastaven na %2$s. Můžete to upravit v nastavení.</string>
+    <string name="notif_rejected_over_absolute_timeout">Poplatek činil %1$s, ale váš maximální poplatek byl nastaven na %2$s. Platnost této zálohy vyprší %3$s.</string>
     <string name="notif_rejected_over_relative">Poplatek činil %1$s, což je více než %2$s%% z přijaté částky. Můžete to upravit v nastavení.</string>
+    <string name="notif_rejected_over_relative_timeout">Poplatek činil %1$s, což je více než %2$s%% z přijaté částky. Platnost této zálohy vyprší %3$s.</string>
     <string name="notif_rejected_channels_initializing">Vaše kanály se inicializovaly a nemohly tuto platbu přijmout. Zkuste to později.</string>
 
     <string name="notif_watcher_revoked_commit_title">Spusťte prosím Phoenix</string>
@@ -153,6 +156,9 @@
     <string name="inappnotif_notification_permission_message">Oznámení jsou v nastavení systému Android zakázána. Phoenix vás nebude moci upozornit na zpracování platby.</string>
     <string name="inappnotif_notification_permission_enable">Povolit</string>
 
+    <string name="inappnotif_swapin_timeout_message">Záloha brzy vyprší.</string>
+    <string name="inappnotif_swapin_timeout_action">Zobrazit podrobnosti</string>
+
     <string name="inappnotif_watchtower_late_message">Phoenix pravidelně monitoruje Blockchain na pozadí, ale v posledních dnech se mu to nedařilo.\n\nUjistěte se, že systém Android neblokuje aplikaci Phoenix a že se může připojit ke službě Electrum.</string>
     <string name="inappnotif_watchtower_late_action">Odmítnout</string>
 
@@ -175,6 +181,7 @@
     <string name="inappnotif_payment_rejected_over_relative">Poplatek byl %1$s, což je více než %2$s%% částky.</string>
     <string name="inappnotif_payment_rejected_channel_initializing">Vaše kanály se stále inicializují a nemohly tuto platbu přijmout.</string>
     <string name="inappnotif_payment_rejected_tweak_setting">Klepnutím na položku provedete konfiguraci.</string>
+    <string name="inappnotif_payment_rejected_view_wallet">Zobrazit podrobnosti</string>
 
     <string name="inappnotif_watchtower_nominal_title">Watchtower report</string>
     <plurals name="inappnotif_watchtower_nominal_description">
@@ -239,13 +246,24 @@
 
     <string name="walletinfo_onchain_swapin">Swap-in peněženka</string>
     <string name="walletinfo_onchain_swapin_help">Prostředky zaslané do této On-Chain peněženky se automaticky převádějí do Lightningu.</string>
+    <string name="walletinfo_onchain_swapin_help_faq_link">Podívejte se, jak to funguje</string>
     <string name="walletinfo_onchain_swapin_policy_view">Klepnutím na položku provedete konfiguraci.</string>
     <string name="walletinfo_onchain_swapin_policy_auto_details">Pokud je poplatek <b>menší než %1$s</b>, budou prostředky na Blockchainu automaticky převedeny do služby Lightning.</string>
+    <string name="walletinfo_onchain_swapin_policy_auto_details_timeout">Prostředky, které nebyly vyměněny <b>po %1$d měsících</b>, lze získat zpět na řetězci.</string>
     <string name="walletinfo_onchain_swapin_policy_disabled_details">Automatizovaná poplatková politika <b>je vypnutá</b>. Prostředky nebudou vyměňovány. Zůstanou na této peněžence.</string>
     <string name="walletinfo_onchain_swapin_last_attempt">Poslední pokus (%1$s).</string>
     <string name="walletinfo_onchain_swapin_last_attempt_disabled">Automatizovaná poplatková politika je vypnutá.</string>
     <string name="walletinfo_onchain_swapin_last_attempt_channels_init">Vaše kanály byly inicializovány.</string>
     <string name="walletinfo_onchain_swapin_empty">Neprobíhají žádné výměny.</string>
+
+    <string name="walletinfo_onchain_swapin_timeout_1day">Platnost této výměny vyprší za den!</string>
+    <string name="walletinfo_onchain_swapin_timeout">Tento swap vyprší za %1$s dní.</string>
+
+    <string name="walletinfo_onchain_swapin_locked_title">Vyčerpané prostředky</string>
+    <string name="walletinfo_onchain_swapin_locked_description">Tyto prostředky budou k dispozici za %1$s dní.</string>
+
+    <string name="walletinfo_onchain_swapin_refund_title">Zrušené prostředky</string>
+    <string name="walletinfo_onchain_swapin_refund_description">Tyto prostředky nebyly včas vyměněny. Pro jejich zpřístupnění použijte deskriptor peněženky.</string>
 
     <string name="walletinfo_onchain_final_about">On-Chain peněženka odvozená od vašeho seedu.\n\nKonečná peněženka je místo, kam se ve výchozím nastavení posílají prostředky, když jsou vaše Lightning kanály uzavřeny.</string>
 

--- a/phoenix-android/src/main/res/values-cs/strings.xml
+++ b/phoenix-android/src/main/res/values-cs/strings.xml
@@ -677,7 +677,7 @@
     <string name="walletinfo_xpub">Hlavní veřejný klíč</string>
     <string name="walletinfo_path">(Cesta: %1$s)</string>
     <string name="walletinfo_swappable_title">Připraveno na swap</string>
-    <string name="walletinfo_not_swappable_title">Čekání na %1$d potvrzení</string>
+    <string name="walletinfo_confirming_title">Čekání na %1$d potvrzení</string>
     <string name="walletinfo_confirmed_title">Potvrzený zůstatek</string>
     <string name="walletinfo_unconfirmed_title">Nepotvrzený zůstatek</string>
     <string name="walletinfo_incoming_balance">Přichází +%1$s</string>

--- a/phoenix-android/src/main/res/values-de/important_strings.xml
+++ b/phoenix-android/src/main/res/values-de/important_strings.xml
@@ -36,8 +36,11 @@
     <string name="notif_rejected_deposit_title">On-chain Einzahlung ausstehend (+%1$s)</string>
     <string name="notif_rejected_payment_title">Zahlung abgelehnt (+%1$s)</string>
     <string name="notif_rejected_policy_disabled">Automatisches Kanal-Management ist deaktiviert. Sie können es in den Einstellungen aktivieren.</string>
+    <string name="notif_rejected_policy_disabled_timeout">Automatisches Kanal-Management ist deaktiviert. Diese Einzahlung verfällt am %1$s.</string>
     <string name="notif_rejected_over_absolute">Die Gebühr wäre %1$s, aber Ihr Gebührenlimit beträgt %2$s. Sie können dies in den Einstellungen anpassen.</string>
+    <string name="notif_rejected_over_absolute_timeout">Die Gebühr wäre %1$s, aber Ihr Gebührenlimit beträgt %2$s. Diese Einzahlung verfällt am %3$s.</string>
     <string name="notif_rejected_over_relative">Die Gebühr wäre %1$s, was mehr als %2$s%% des zu empfangenden Betrags ist. Sie können dies in den Einstellungen anpassen.</string>
+    <string name="notif_rejected_over_relative_timeout">Die Gebühr wäre %1$s, was mehr als %2$s%% des zu empfangenden Betrags ist. Diese Einzahlung verfällt am %3$s.</string>
     <string name="notif_rejected_channels_initializing">Ihre Kanäle werden gerade initialisiert und konnten die Zahlung nicht empfangen. Versuchen Sie es später noch mal.</string>
 
     <string name="notif_watcher_revoked_commit_title">Bitte öffnen Sie Phoenix</string>
@@ -147,6 +150,9 @@
     <string name="inappnotif_notification_permission_message">Benachrichtigungen sind in den Android-Einstellungen deaktiviert. Phoenix kann Sie nicht benachrichtigen, wenn eine Zahlung durchgeführt wird.</string>
     <string name="inappnotif_notification_permission_enable">Aktivieren</string>
 
+    <string name="inappnotif_swapin_timeout_message">Eine Einzahlung wird bald ablaufen.</string>
+    <string name="inappnotif_swapin_timeout_action">Details ansehen</string>
+
     <string name="inappnotif_watchtower_late_message">Phoenix beobachtet die Blockchain regelmäßig im Hintergrund, war aber in den letzten Tagen nicht in der Lage, dies zu tun.\n\nStellen Sie sicher, dass Phoenix nicht durch Android blockiert wird, sodass eine Verbindung zu Electrum möglich ist.</string>
     <string name="inappnotif_watchtower_late_action">Schließen</string>
 
@@ -168,6 +174,7 @@
     <string name="inappnotif_payment_rejected_over_relative">Die Gebühr wäre %1$s, was mehr als %2$s%% des zu empfangenden Betrags ist.</string>
     <string name="inappnotif_payment_rejected_channel_initializing">Ihre Kanäle werden gerade initialisiert und konnten die Zahlung nicht empfangen.</string>
     <string name="inappnotif_payment_rejected_tweak_setting">Tippen, um zu bestätigen.</string>
+    <string name="inappnotif_payment_rejected_view_wallet">Details ansehen</string>
 
     <string name="inappnotif_watchtower_nominal_title">Watchtower-Bericht</string>
     <plurals name="inappnotif_watchtower_nominal_description">
@@ -231,13 +238,24 @@
 
     <string name="walletinfo_onchain_swapin">Swap-in Wallet</string>
     <string name="walletinfo_onchain_swapin_help">Guthaben, das an diese On-Chain-Wallet gesendet wird, wird automatisch in Lightning umgewandelt.</string>
+    <string name="walletinfo_onchain_swapin_help_faq_link">Sehen Sie, wie es funktioniert</string>
     <string name="walletinfo_onchain_swapin_policy_view">Tippen, um dies zu konfigurieren.</string>
     <string name="walletinfo_onchain_swapin_policy_auto_details">On-Chain-Guthaben wird automatisch in Lightning umgewandelt, wenn die Gebühr <b>weniger als %1$s</b> beträgt.</string>
+    <string name="walletinfo_onchain_swapin_policy_auto_details_timeout">Guthaben, die <b>nach %1$d Monaten</b> nicht getauscht wurden, können auf der Kette zurückgefordert werden.</string>
     <string name="walletinfo_onchain_swapin_policy_disabled_details">Die automatische Gebührenregelung <b>ist deaktiviert</b>. Guthaben werden nicht umgewandelt. Sie verbleiben in dieser Wallet.</string>
     <string name="walletinfo_onchain_swapin_last_attempt">Letzter Versuch (%1$s).</string>
     <string name="walletinfo_onchain_swapin_last_attempt_disabled">Die automatische Gebührenregelung ist deaktiviert.</string>
     <string name="walletinfo_onchain_swapin_last_attempt_channels_init">Channels were still initializing.</string>
     <string name="walletinfo_onchain_swapin_empty">Es sind keine Swaps in Bearbeitung.</string>
+
+    <string name="walletinfo_onchain_swapin_timeout_1day">Dieser Swap wird in einem Tag auslaufen!</string>
+    <string name="walletinfo_onchain_swapin_timeout">Dieser Swap wird in %1$s Tagen auslaufen.</string>
+
+    <string name="walletinfo_onchain_swapin_locked_title">Ausgelaufen</string>
+    <string name="walletinfo_onchain_swapin_locked_description">Diese Guthaben werden ab %1$s Tagen verfügbar sein.</string>
+
+    <string name="walletinfo_onchain_swapin_refund_title">Abgebrochen</string>
+    <string name="walletinfo_onchain_swapin_refund_description">Diese Guthaben konnten nicht rechtzeitig getauscht werden. Verwenden Sie den Deskriptor der Wallet, um auf sie zuzugreifen.</string>
 
     <string name="walletinfo_onchain_final_about">Eine On-Chain-Wallet, die von Ihrem Seed abgeleitet ist.\n\nWenn Ihre Lightning-Kanäle geschlossen werden, werden die entsprechenden Guthaben standardmäßig an die finale Wallet gesendet.</string>
 

--- a/phoenix-android/src/main/res/values-de/strings.xml
+++ b/phoenix-android/src/main/res/values-de/strings.xml
@@ -654,7 +654,7 @@
     <string name="walletinfo_xpub">Master public key</string>
     <string name="walletinfo_path">(Pfad: %1$s)</string>
     <string name="walletinfo_swappable_title">Bereit für Swap</string>
-    <string name="walletinfo_not_swappable_title">Warte auf %1$d Bestätigungen</string>
+    <string name="walletinfo_confirming_title">Warte auf %1$d Bestätigungen</string>
     <string name="walletinfo_confirmed_title">Bestätigtes Guthaben</string>
     <string name="walletinfo_unconfirmed_title">Unbestätigtes Guthaben</string>
     <string name="walletinfo_incoming_balance">+%1$s eingehend</string>

--- a/phoenix-android/src/main/res/values-es/important_strings.xml
+++ b/phoenix-android/src/main/res/values-es/important_strings.xml
@@ -30,11 +30,17 @@
     <string name="notif_pending_settlement_title">Por favor, inicie Phoenix</string>
     <string name="notif_pending_settlement_message">Está pendiente una liquidación.</string>
 
+    <string name="notif_missed_title">Se ha producido un impago</string>
+    <string name="notif_missed_unavailable">Phoenix no pudo arrancar en segundo plano.</string>
+
     <string name="notif_rejected_deposit_title">Depósito en cadena pendiente (+%1$s)</string>
     <string name="notif_rejected_payment_title">Pago rechazado (+%1$s)</string>
     <string name="notif_rejected_policy_disabled">La gestión automática de canales está desactivada. Puede cambiarlo en la configuración.</string>
+    <string name="notif_rejected_policy_disabled_timeout">La gestión automática de canales está desactivada. Este depósito expirará el %1$s.</string>
     <string name="notif_rejected_over_absolute">La tasa era %1$s, pero tu tarifa máxima estaba fijada en %2$s. Puedes modificarlo en los ajustes.</string>
+    <string name="notif_rejected_over_absolute_timeout">La tasa era %1$s, pero tu tarifa máxima estaba fijada en %2$s. Este depósito expirará el %3$s.</string>
     <string name="notif_rejected_over_relative">La tasa fue de %1$s, que es más del %2$s%% del importe recibido. Puedes modificarlo en la configuración.</string>
+    <string name="notif_rejected_over_relative_timeout">La tasa fue de %1$s, que es más del %2$s%% del importe recibido. Este depósito expirará el %3$s.</string>
     <string name="notif_rejected_channels_initializing">Sus canales se estaban inicializando y no pudieron aceptar ese pago. Vuelva a intentarlo más tarde.</string>
 
     <string name="notif_watcher_revoked_commit_title">Por favor, inicie Phoenix</string>
@@ -148,6 +154,9 @@
     <string name="inappnotif_notification_permission_message">Las notificaciones están desactivadas en los ajustes de Android. Phoenix no podrá notificarte cuando se esté procesando un pago.</string>
     <string name="inappnotif_notification_permission_enable">Activar</string>
 
+    <string name="inappnotif_swapin_timeout_message">Un depósito expirará pronto.</string>
+    <string name="inappnotif_swapin_timeout_action">Ver detalles</string>
+
     <string name="inappnotif_watchtower_late_message">Phoenix monitorea regularmente el blockchain cuando está en segundo plano, pero no pudo hacerlo los últimos días.\n\nAsegúrate de que Android no bloquee Phoenix, y que pueda conectarse a Electrum.</string>
     <string name="inappnotif_watchtower_late_action">Desestimar</string>
 
@@ -169,6 +178,7 @@
     <string name="inappnotif_payment_rejected_over_relative">La tasa ascendía a %1$s, lo que supone más del %2$s%% del importe.</string>
     <string name="inappnotif_payment_rejected_channel_initializing">Sus canales aún se están inicializando y no han podido recibir ese pago.</string>
     <string name="inappnotif_payment_rejected_tweak_setting">Puntee para configurar.</string>
+    <string name="inappnotif_payment_rejected_view_wallet">Ver detalles</string>
 
     <string name="inappnotif_watchtower_nominal_title">Informe de la Watchtower</string>
     <plurals name="inappnotif_watchtower_nominal_description">
@@ -232,13 +242,24 @@
 
     <string name="walletinfo_onchain_swapin">Cartera swap-in</string>
     <string name="walletinfo_onchain_swapin_help">Los fondos enviados a esta cartera en cadena se cambian automáticamente a Lightning.</string>
+    <string name="walletinfo_onchain_swapin_help_faq_link">Vea cómo funciona</string>
     <string name="walletinfo_onchain_swapin_policy_view">Puntee para configurar.</string>
     <string name="walletinfo_onchain_swapin_policy_auto_details">Los fondos en cadena se cambiarán automáticamente a Lightning si la tasa es <b>inferior a %1$s</b>.</string>
+    <string name="walletinfo_onchain_swapin_policy_auto_details_timeout">Los fondos no cambiados <b>después de %1$d meses</b> son recuperables en cadena.</string>
     <string name="walletinfo_onchain_swapin_policy_disabled_details">La política de tasas automatizadas <b>está desactivada</b>. Los fondos no serán intercambiados. Permanecerán en esta cartera.</string>
     <string name="walletinfo_onchain_swapin_last_attempt">Último intento (%1$s).</string>
     <string name="walletinfo_onchain_swapin_last_attempt_disabled">La política de tasas automatizadas está desactivada.</string>
     <string name="walletinfo_onchain_swapin_last_attempt_channels_init">Sus canales aún se estaban inicializando.</string>
     <string name="walletinfo_onchain_swapin_empty">No hay intercambios en curso.</string>
+
+    <string name="walletinfo_onchain_swapin_timeout_1day">Este swap caducará en un día.</string>
+    <string name="walletinfo_onchain_swapin_timeout">Este swap vencerá en %1$s días.</string>
+
+    <string name="walletinfo_onchain_swapin_locked_title">Expirados</string>
+    <string name="walletinfo_onchain_swapin_locked_description">Estos fondos estarán disponibles a partir de %1$s días.</string>
+
+    <string name="walletinfo_onchain_swapin_refund_title">Cancelados</string>
+    <string name="walletinfo_onchain_swapin_refund_description">Estos fondos no fueron canjeados a tiempo. Utilice el descriptor de la cartera para acceder a ellos.</string>
 
     <string name="walletinfo_onchain_final_about">Una cartera en la cadena derivada de su semilla.\n\nLa cartera final es donde se envían los fondos por defecto cuando se cierran sus canales Lightning.</string>
 

--- a/phoenix-android/src/main/res/values-fr/important_strings.xml
+++ b/phoenix-android/src/main/res/values-fr/important_strings.xml
@@ -36,8 +36,11 @@
     <string name="notif_rejected_deposit_title">Dépôt on-chain en attente (+%1$s)</string>
     <string name="notif_rejected_payment_title">Paiement entrant refusé (+%1$s)</string>
     <string name="notif_rejected_policy_disabled">La gestion des canaux automatisée est désactivée. Cette configuration peut être changée.</string>
+    <string name="notif_rejected_policy_disabled_timeout">La gestion des canaux automatisée est désactivée. Le dépôt expirera le %1$s.</string>
     <string name="notif_rejected_over_absolute">Les frais étaient de %1$s, mais votre max est de %2$s. Cette configuration peut être changée.</string>
+    <string name="notif_rejected_over_absolute_timeout">Les frais étaient de %1$s, mais votre max est de %2$s. Le dépôt expirera le %3$s.</string>
     <string name="notif_rejected_over_relative">Les frais étaient de %1$s et dépassent %2$s%% du montant. Cette configuration peut être changée.</string>
+    <string name="notif_rejected_over_relative_timeout">Les frais étaient de %1$s et dépassent %2$s%% du montant. Le dépôt expirera le %3$s.</string>
     <string name="notif_rejected_channels_initializing">Vos canaux de paiement étaient en initialisation, et n\'ont pu accepter ce paiement.</string>
 
     <string name="notif_watcher_revoked_commit_title">Veuillez démarrer Phoenix</string>
@@ -148,6 +151,9 @@
     <string name="inappnotif_notification_permission_message">Les notifications systèmes sont désactivées dans les préferences Android. Phoenix ne pourra pas vous indiquer lorsque des paiements sont en cours, ou rejetés.</string>
     <string name="inappnotif_notification_permission_enable">Activer</string>
 
+    <string name="inappnotif_swapin_timeout_message">Un dépôt va bientôt expirer.</string>
+    <string name="inappnotif_swapin_timeout_action">Voir les détails</string>
+
     <string name="inappnotif_watchtower_late_message">Phoenix vérifie périodiquement la blockchain lorsque l\'application est éteinte. Ces derniers jours elle n\'a pas pu le faire. \n\nAssurez vous qu\'Android ne restreigne pas Phoenix, et que l\'application puisse se connecter à Electrum.</string>
     <string name="inappnotif_watchtower_late_action">Fermer</string>
 
@@ -175,6 +181,7 @@
     <string name="inappnotif_payment_rejected_over_relative">Les frais de %1$s représentaient plus de %2$s%% du montant.</string>
     <string name="inappnotif_payment_rejected_channel_initializing">Vous canaux étaient en initialisation et n\'ont pu recevoir ce paiement.</string>
     <string name="inappnotif_payment_rejected_tweak_setting">Cliquez pour configurer.</string>
+    <string name="inappnotif_payment_rejected_view_wallet">Voir les détails</string>
 
     <string name="inappnotif_watchtower_nominal_title">Veille en arrière-plan</string>
     <plurals name="inappnotif_watchtower_nominal_description" tools:ignore="MissingQuantity">
@@ -238,13 +245,24 @@
 
     <string name="walletinfo_onchain_swapin">Swap-in wallet</string>
     <string name="walletinfo_onchain_swapin_help">Les fonds envoyés vers ce wallet sont automatiquement basculés (\"swap\") sur Lightning.</string>
+    <string name="walletinfo_onchain_swapin_help_faq_link">Voir comment ça marche</string>
     <string name="walletinfo_onchain_swapin_policy_view">Cliquez pour configurer.</string>
-    <string name="walletinfo_onchain_swapin_policy_auto_details">Les fonds seront automatiquement basculés sur Lightning si les frais sont <b>inférieurs à %1$s</b>.</string>
+    <string name="walletinfo_onchain_swapin_policy_auto_details">Les fonds seront automatiquement basculés sur Lightning si les frais sont <b>inférieurs à %1$s</b> (configurable).</string>
+    <string name="walletinfo_onchain_swapin_policy_auto_details_timeout">Les fonds qui ne sont pas sur Lightning <b>après %1$d mois</b> seront récupérables on-chain.</string>
     <string name="walletinfo_onchain_swapin_policy_disabled_details">La gestion des canaux automatisée <b>est désactivée</b>. Les fonds ne seront pas basculés sur Lightning et vont rester sur ce wallet.</string>
     <string name="walletinfo_onchain_swapin_last_attempt">Dernière tentative (%1$s).</string>
     <string name="walletinfo_onchain_swapin_last_attempt_disabled">La gestion des canaux automatisée était désactivée.</string>
     <string name="walletinfo_onchain_swapin_last_attempt_channels_init">Les canaux étaient encore en cours d\'initialisation.</string>
     <string name="walletinfo_onchain_swapin_empty">Il n\'y a pas de fonds en attente de swap.</string>
+
+    <string name="walletinfo_onchain_swapin_timeout_1day">Ce swap va expirer dans moins d\'une journée!</string>
+    <string name="walletinfo_onchain_swapin_timeout">Ce swap va expirer dans %1$s jours.</string>
+
+    <string name="walletinfo_onchain_swapin_locked_title">Expirés</string>
+    <string name="walletinfo_onchain_swapin_locked_description">Ces fonds seront disponibles d\'ici %1$s jours.</string>
+
+    <string name="walletinfo_onchain_swapin_refund_title">Annulés</string>
+    <string name="walletinfo_onchain_swapin_refund_description">Ces fonds n\'ont pas été swappés à temps. Utilisez le descriptor du wallet pour accéder à ces fonds.</string>
 
     <string name="walletinfo_onchain_final_about">Un wallet on-chain dérivé de votre clé.\n\nLe wallet final est par défaut là où les fonds seront envoyés lorsqu\'un canal de paiement ferme.</string>
 

--- a/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
+++ b/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
@@ -36,8 +36,11 @@
     <string name="notif_rejected_deposit_title">Depósito em cadeia pendente (+%1$s)</string>
     <string name="notif_rejected_payment_title">Pagamento rejeitado (+%1$s)</string>
     <string name="notif_rejected_policy_disabled">O gerenciamento automatizado de canais está desativado. Você pode alterar isso nas configurações.</string>
+    <string name="notif_rejected_policy_disabled_timeout">O gerenciamento automatizado de canais está desativado. Esse depósito expirará em %1$s.</string>
     <string name="notif_rejected_over_absolute">A taxa foi de %1$s, mas sua taxa máxima foi definida como %2$s. Você pode ajustar isso nas configurações.</string>
+    <string name="notif_rejected_over_absolute_timeout">A taxa foi de %1$s, mas sua taxa máxima foi definida como %2$s. Esse depósito expirará em %3$s.</string>
     <string name="notif_rejected_over_relative">A taxa foi de %1$s, que é mais do que %2$s%% do valor recebido. Você pode ajustar isso nas configurações.</string>
+    <string name="notif_rejected_over_relative_timeout">A taxa foi de %1$s, que é mais do que %2$s%% do valor recebido. Esse depósito expirará em %3$s.</string>
     <string name="notif_rejected_channels_initializing">Seus canais estavam sendo inicializados e não puderam aceitar esse pagamento. Tente novamente mais tarde.</string>
 
     <string name="notif_watcher_revoked_commit_title">Por favor, inicie o Phoenix</string>
@@ -153,6 +156,9 @@
     <string name="inappnotif_notification_permission_message">As notificações estão desativadas nas configurações do Android. O Phoenix não poderá notificá-lo quando um pagamento estiver sendo processado.</string>
     <string name="inappnotif_notification_permission_enable">Ativar</string>
 
+    <string name="inappnotif_swapin_timeout_message">Um depósito expirará em breve.</string>
+    <string name="inappnotif_swapin_timeout_action">Ver detalhes</string>
+
     <string name="inappnotif_watchtower_late_message">O Phoenix monitora regularmente o blockchain quando está em segundo plano, mas não conseguiu fazer isso nos últimos dias.\n\nCertifique-se de que o Android não bloqueie o Phoenix e que ele possa se conectar à Electrum.</string>
     <string name="inappnotif_watchtower_late_action">Dispensar</string>
 
@@ -174,6 +180,7 @@
     <string name="inappnotif_payment_rejected_over_relative">A taxa foi de %1$s, que é mais do que %2$s%% do valor.</string>
     <string name="inappnotif_payment_rejected_channel_initializing">Seus canais ainda estão sendo inicializados e não puderam receber esse pagamento.</string>
     <string name="inappnotif_payment_rejected_tweak_setting">Toque para configurar.</string>
+    <string name="inappnotif_payment_rejected_view_wallet">Ver detalhes</string>
 
     <string name="inappnotif_watchtower_nominal_title">Watchtower report</string>
     <plurals name="inappnotif_watchtower_nominal_description">
@@ -237,13 +244,24 @@
 
     <string name="walletinfo_onchain_swapin">Swap-in wallet</string>
     <string name="walletinfo_onchain_swapin_help">Os fundos enviados para essa carteira na cadeia são automaticamente trocados para o Lightning.</string>
+    <string name="walletinfo_onchain_swapin_help_faq_link">Veja como funciona</string>
     <string name="walletinfo_onchain_swapin_policy_view">Toque para configurar.</string>
     <string name="walletinfo_onchain_swapin_policy_auto_details">Os fundos on-chain serão automaticamente trocados para o Lightning se a taxa for <b>inferior a %1$s</b>.</string>
+    <string name="walletinfo_onchain_swapin_policy_auto_details_timeout">Os fundos não trocados <b>após %1$d meses</b> são recuperáveis na cadeia.</string>
     <string name="walletinfo_onchain_swapin_policy_disabled_details">A política de taxas automatizadas <b>está desativada</b>. Os fundos não serão trocados. Eles permanecerão nessa carteira.</string>
     <string name="walletinfo_onchain_swapin_last_attempt">Última tentativa (%1$s).</string>
     <string name="walletinfo_onchain_swapin_last_attempt_disabled">A política de taxas automatizadas está desativada.</string>
     <string name="walletinfo_onchain_swapin_last_attempt_channels_init">Seus canais ainda estavam sendo inicializados.</string>
     <string name="walletinfo_onchain_swapin_empty">Não há swaps em andamento.</string>
+
+    <string name="walletinfo_onchain_swapin_timeout_1day">Essa troca expirará em um dia!</string>
+    <string name="walletinfo_onchain_swapin_timeout">Essa troca expirará em %1$s dias.</string>
+
+    <string name="walletinfo_onchain_swapin_locked_title">Temporizada</string>
+    <string name="walletinfo_onchain_swapin_locked_description">Esses fundos estarão disponíveis a partir de %1$s dias.</string>
+
+    <string name="walletinfo_onchain_swapin_refund_title">Cancelado</string>
+    <string name="walletinfo_onchain_swapin_refund_description">Esses fundos não foram trocados a tempo. Use o descritor da carteira para acessá-los.</string>
 
     <string name="walletinfo_onchain_final_about">Uma carteira na cadeia derivada de sua semente.\n\nA carteira final é para onde os fundos são enviados por padrão quando seus canais Lightning são fechados.</string>
 

--- a/phoenix-android/src/main/res/values/important_strings.xml
+++ b/phoenix-android/src/main/res/values/important_strings.xml
@@ -262,7 +262,7 @@
     <string name="walletinfo_onchain_swapin_locked_description">These funds will be available from %1$s days onwards.</string>
 
     <string name="walletinfo_onchain_swapin_refund_title">Cancelled funds</string>
-    <string name="walletinfo_onchain_swapin_refund_description">These funds were not be swapped in time. Use the wallet\'s descriptor to access them.</string>
+    <string name="walletinfo_onchain_swapin_refund_description">These funds were not swapped in time. Use the wallet\'s descriptor to access them.</string>
 
     <string name="walletinfo_onchain_final_about">An on-chain wallet derived from your seed.\n\nThe final wallet is where funds are sent by default when your Lightning channels are closed.</string>
 

--- a/phoenix-android/src/main/res/values/important_strings.xml
+++ b/phoenix-android/src/main/res/values/important_strings.xml
@@ -35,9 +35,12 @@
 
     <string name="notif_rejected_deposit_title">On-chain deposit pending (+%1$s)</string>
     <string name="notif_rejected_payment_title">Payment rejected (+%1$s)</string>
-    <string name="notif_rejected_policy_disabled">Automated channel management is disabled. You can change that in the settings.</string>
-    <string name="notif_rejected_over_absolute">The fee was %1$s, but your max fee was set to %2$s. You can tweak that in the settings.</string>
-    <string name="notif_rejected_over_relative">The fee was %1$s which is more than %2$s%% of the amount received. You can tweak that in the settings.</string>
+    <string name="notif_rejected_policy_disabled">Automated channel management is disabled. Tap for details.</string>
+    <string name="notif_rejected_policy_disabled_timeout">Automated channel management is disabled. This deposit will expire by %1$s.</string>
+    <string name="notif_rejected_over_absolute">The fee was %1$s, but your max fee was set to %2$s. Tap for details.</string>
+    <string name="notif_rejected_over_absolute_timeout">The fee was %1$s, but your max fee was set to %2$s. This deposit will expire by %3$s.</string>
+    <string name="notif_rejected_over_relative">The fee was %1$s which is more than %2$s%% of the amount received. Tap for details.</string>
+    <string name="notif_rejected_over_relative_timeout">The fee was %1$s which is more than %2$s%% of the amount received. This deposit will expire by %3$s.</string>
     <string name="notif_rejected_channels_initializing">Your channels were initializing and could not accept that payment. Try again later.</string>
 
     <string name="notif_watcher_revoked_commit_title">Please start Phoenix</string>
@@ -153,6 +156,9 @@
     <string name="inappnotif_notification_permission_message">Notifications are disabled in Android settings. Phoenix won\'t be able to notify you when a payment is processing.</string>
     <string name="inappnotif_notification_permission_enable">Enable</string>
 
+    <string name="inappnotif_swapin_timeout_message">A deposit will expire soon.</string>
+    <string name="inappnotif_swapin_timeout_action">View details</string>
+
     <string name="inappnotif_watchtower_late_message">Phoenix regularly monitors the blockchain when in the background, but was unable to do so the last few days.\n\nMake sure Android does not block Phoenix, and that it can connect to Electrum.</string>
     <string name="inappnotif_watchtower_late_action">Dismiss</string>
 
@@ -174,6 +180,7 @@
     <string name="inappnotif_payment_rejected_over_relative">The fee was %1$s which is more than %2$s%% of the amount.</string>
     <string name="inappnotif_payment_rejected_channel_initializing">Your channels are still initializing and could not receive that payment.</string>
     <string name="inappnotif_payment_rejected_tweak_setting">Tap to configure.</string>
+    <string name="inappnotif_payment_rejected_view_wallet">View details</string>
 
     <string name="inappnotif_watchtower_nominal_title">Watchtower report</string>
     <plurals name="inappnotif_watchtower_nominal_description">
@@ -236,14 +243,26 @@
     <!-- wallet info -->
 
     <string name="walletinfo_onchain_swapin">Swap-in wallet</string>
-    <string name="walletinfo_onchain_swapin_help">Funds sent to this on-chain wallet are automatically swapped to Lightning.</string>
-    <string name="walletinfo_onchain_swapin_policy_view">Tap to configure.</string>
-    <string name="walletinfo_onchain_swapin_policy_auto_details">On-chain funds will automatically be swapped to Lightning if the fee is <b>less than %1$s</b>.</string>
-    <string name="walletinfo_onchain_swapin_policy_disabled_details">Automated channels management <b>is disabled</b>. Funds will not be swapped. They will remain on this wallet.</string>
-    <string name="walletinfo_onchain_swapin_last_attempt">Last attempt (%1$s).</string>
+    <string name="walletinfo_onchain_swapin_help">Funds sent to this on-chain wallet are automatically swapped to Lightning if the conditions are right.</string>
+    <string name="walletinfo_onchain_swapin_help_faq_link">See how it works</string>
+    <string name="walletinfo_onchain_swapin_policy_view">Tap to configure</string>
+    <string name="walletinfo_onchain_swapin_empty">There are no swaps in progress.</string>
+
+    <string name="walletinfo_onchain_swapin_policy_auto_details">Funds are automatically swapped to Lightning if the fee is <b>less than %1$s</b> (can be configured).</string>
+    <string name="walletinfo_onchain_swapin_policy_auto_details_timeout">Funds not swapped <b>after %1$d months</b> are recoverable on-chain.</string>
+    <string name="walletinfo_onchain_swapin_policy_disabled_details">Automated channels management <b>is disabled</b>. Funds will remain on-chain. No swap will occur.</string>
+
+    <string name="walletinfo_onchain_swapin_last_attempt">A swap attempt failed %1$s</string>
     <string name="walletinfo_onchain_swapin_last_attempt_disabled">Channels management was disabled.</string>
     <string name="walletinfo_onchain_swapin_last_attempt_channels_init">Channels were still initializing.</string>
-    <string name="walletinfo_onchain_swapin_empty">There are no swaps in progress.</string>
+    <string name="walletinfo_onchain_swapin_timeout_1day">This swap will expire in a day!</string>
+    <string name="walletinfo_onchain_swapin_timeout">This swap will expire in %1$s days.</string>
+
+    <string name="walletinfo_onchain_swapin_locked_title">Timed out</string>
+    <string name="walletinfo_onchain_swapin_locked_description">These funds will be available from %1$s days onwards.</string>
+
+    <string name="walletinfo_onchain_swapin_refund_title">Cancelled funds</string>
+    <string name="walletinfo_onchain_swapin_refund_description">These funds were not be swapped in time. Use the wallet\'s descriptor to access them.</string>
 
     <string name="walletinfo_onchain_final_about">An on-chain wallet derived from your seed.\n\nThe final wallet is where funds are sent by default when your Lightning channels are closed.</string>
 

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -34,6 +34,9 @@
     <string name="notification_headless_title">Running in the background</string>
     <string name="notification_headless_desc">Tells you when Phoenix is running in the background.</string>
 
+    <string name="notification_swap_timeout_title">Swap timeout</string>
+    <string name="notification_swap_timeout_desc">Tells you when a swap is going to timeout.</string>
+
     <!-- init wallet / automated wallet creation -->
 
     <string name="autocreate_generating">Creating your wallet…</string>
@@ -696,7 +699,8 @@
     <string name="walletinfo_xpub">Master public key</string>
     <string name="walletinfo_path">(Path: %1$s)</string>
     <string name="walletinfo_swappable_title">Ready for swap</string>
-    <string name="walletinfo_not_swappable_title">Waiting for %1$d confirmations</string>
+    <string name="walletinfo_confirming_title">Waiting for %1$d confirmations</string>
+    <string name="walletinfo_confirming_more">+%1$d more…</string>
     <string name="walletinfo_confirmed_title">Confirmed balance</string>
     <string name="walletinfo_unconfirmed_title">Unconfirmed balance</string>
     <string name="walletinfo_incoming_balance">+%1$s incoming</string>

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/BalanceManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/BalanceManager.kt
@@ -107,6 +107,8 @@ class BalanceManager(
                     wallet.confirmationsNeeded(it)
                 },
                 unconfirmed = wallet.unconfirmed.balance,
+                locked = wallet.lockedUntilRefund.balance,
+                readyForRefund = wallet.readyForRefund.balance
             )
         }
     }
@@ -115,21 +117,25 @@ class BalanceManager(
 /**
  * Helper class representing the balance of the swap-in wallet. See [WalletState.WalletWithConfirmations].
  *
- * @param deeplyConfirmed amount that is confirmed and that can be used for a swap. This amount would always be 0 if we were to
+ * @param deeplyConfirmed balance that is confirmed and that can be used for a swap. This amount would always be 0 if we were to
  *      systematically accept swaps. But swaps can fail, or be rejected (fee too high).
- * @param weaklyConfirmed  amount that is confirmed but not deep enough for a swap.
+ * @param weaklyConfirmed  balance that is confirmed but not deep enough for a swap.
  * @param weaklyConfirmedMinBlockNeeded minimum depth that the wallet's weakly confirmed utxos must reach.
- * @param unconfirmed amount that is not confirmed yet.
+ * @param unconfirmed balance that is not confirmed yet.
+ * @param locked balance that cannot be swapped anymore, but cannot be spent yet either.
+ * @param readyForRefund balance that cannot be swapped anymore, but can be spent unilaterally.
  */
 data class WalletBalance(
     val deeplyConfirmed: Satoshi,
     val weaklyConfirmed: Satoshi,
     val weaklyConfirmedMinBlockNeeded: Int?,
+    val locked: Satoshi,
+    val readyForRefund: Satoshi,
     val unconfirmed: Satoshi,
 ) {
-    val total get() = deeplyConfirmed + weaklyConfirmed + unconfirmed
+    val total get() = readyForRefund + locked + deeplyConfirmed + weaklyConfirmed + unconfirmed
 
     companion object {
-        fun empty() = WalletBalance(0.sat, 0.sat, null, 0.sat)
+        fun empty() = WalletBalance(0.sat, 0.sat, null, 0.sat, 0.sat, 0.sat)
     }
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/extensions/WalletStateExtensions.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/extensions/WalletStateExtensions.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.utils.extensions
+
+import fr.acinq.lightning.SwapInParams
+import fr.acinq.lightning.blockchain.electrum.WalletState
+import kotlin.math.ceil
+
+/** Number of confirmation during which a utxo is locked between the swap window closing and the refund delay. */
+val SwapInParams.gracePeriod: Int
+    get() = refundDelay - maxConfirmations
+val SwapInParams.gracePeriodInDays: Int
+    get() = ceil( gracePeriod.toDouble() / 144).toInt()
+val SwapInParams.maxConfirmationsInDays: Int
+    get() = ceil(maxConfirmations.toDouble() / 144).toInt()
+val SwapInParams.refundDelayInDays: Int
+    get() = ceil(refundDelay.toDouble() / 144).toInt()
+
+/** Returns the block count after which a utxo will NOT be swappable anymore, according to the wallet's swap params. */
+fun WalletState.WalletWithConfirmations.timeoutIn(utxo: WalletState.Utxo): Int {
+    return (swapInParams.maxConfirmations - confirmations(utxo)).coerceAtLeast(0)
+}
+
+/** A map of deeply confirmed utxos to their expiry, according to the wallet's swap params. */
+val WalletState.WalletWithConfirmations.deeplyConfirmedToExpiry: List<Pair<WalletState.Utxo, Int>>
+    get() = deeplyConfirmed.map { it to timeoutIn(it) }
+
+/** A map of deeply confirmed utxos to their expiry, according to the wallet's swap params. */
+val WalletState.WalletWithConfirmations.nextTimeout: Pair<WalletState.Utxo, Int>?
+    get() = deeplyConfirmedToExpiry.minByOrNull { it.second }


### PR DESCRIPTION
Phoenix uses the swap-in potentiam scheme to trustlessly swap on-chain deposits to Lightning with 0 confirmations channels.

[This scheme introduces a duration of 4 months](https://github.com/ACINQ/lightning-kmp/pull/540) during which swaps can be attempted. After this four months have passed, deposits that have not been swapped time out and enter a grace period of two months. After this two months period has passed, these deposits can be unilaterally spent by the user's wallet to any address.

#### Getting the closest timeout

`PeerManager` exposes a new `swapInNextTimeout` flow that contains a `Pair` of `Utxo -> Block to timeout`.

#### Swap-in screen

This PR improves the swap-in screen by discriminating funds according to their status (confirming, swappable, timed-out, and cancelled), based on their confirmation count.

Note that in the screenshot below, the timeout was set to 1 month for a test, but production value is 4 months.

![Screenshot_20231013_165303](https://github.com/ACINQ/phoenix/assets/5765435/10e0812c-8ff4-430d-b2b2-f1872fdd1e0d)

This elements are not clickable. The UI does not display the details of each UTXO with their remaining block count before timeout. I've tried doing this and it made things overwhelmingly complex while bringing no real utility to the user.

#### Notice in home

An important notice is also added to the home screen, if a swap is going to time out soon (< 1 month). Also the icon changes to `/!\` if the timeout is less than a day (not the case on the screenshot below).

![Screenshot_20231013_165833](https://github.com/ACINQ/phoenix/assets/5765435/7faa57d6-36f9-4bab-b039-455f8eda68f0)

#### System notification

The notifications for pending deposits will mention the timeout if it is available at the time of the notification.

![Screenshot_20231013_165557](https://github.com/ACINQ/phoenix/assets/5765435/a63c3b18-1d0b-47c4-8599-9b6d8ec96520)
