### PR TITLE
(ios) Scan lnurl-withdraw from Receive screen

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		DC9473FA261270B4008D7242 /* MVI+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9473F9261270B4008D7242 /* MVI+Mock.swift */; };
 		DC9545C429490321008FCEF4 /* NotificationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9545C329490321008FCEF4 /* NotificationContent.swift */; };
 		DC9545C5294905FB008FCEF4 /* NotificationContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9545C329490321008FCEF4 /* NotificationContent.swift */; };
+		DC98D3962AF170AC005BD177 /* PaymentWarningPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC98D3952AF170AC005BD177 /* PaymentWarningPopover.swift */; };
 		DC99E90925B78FA800FB20F7 /* EnabledSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC99E90825B78FA800FB20F7 /* EnabledSecurity.swift */; };
 		DC99E94025BA141000FB20F7 /* LocalWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC99E93F25BA141000FB20F7 /* LocalWebView.swift */; };
 		DC99E94D25BA258C00FB20F7 /* about.html in Resources */ = {isa = PBXBuildFile; fileRef = DC99E94825BA258C00FB20F7 /* about.html */; };
@@ -503,6 +504,7 @@
 		DC89857E25914747007B253F /* UIApplicationState+Phoenix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplicationState+Phoenix.swift"; sourceTree = "<group>"; };
 		DC9473F9261270B4008D7242 /* MVI+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MVI+Mock.swift"; sourceTree = "<group>"; };
 		DC9545C329490321008FCEF4 /* NotificationContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContent.swift; sourceTree = "<group>"; };
+		DC98D3952AF170AC005BD177 /* PaymentWarningPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentWarningPopover.swift; sourceTree = "<group>"; };
 		DC99E90825B78FA800FB20F7 /* EnabledSecurity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnabledSecurity.swift; sourceTree = "<group>"; };
 		DC99E93F25BA141000FB20F7 /* LocalWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalWebView.swift; sourceTree = "<group>"; };
 		DC99E94925BA258C00FB20F7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = Base; path = Base.lproj/about.html; sourceTree = "<group>"; };
@@ -846,6 +848,7 @@
 				DCEAE5B82943D64B00320C46 /* MsatRange.swift */,
 				DCB62F482A5E09F900912A71 /* SpliceOutProblem.swift */,
 				DC1771B32ABC99CE00B286C7 /* WebsiteLinkPopover.swift */,
+				DC98D3952AF170AC005BD177 /* PaymentWarningPopover.swift */,
 			);
 			path = send;
 			sourceTree = "<group>";
@@ -1613,6 +1616,7 @@
 				DC118C0427B454720080BBAC /* PaymentInFlightView.swift in Sources */,
 				DCB5D2DF280879460020B8F5 /* DeviceInfo.swift in Sources */,
 				DCACF6FB2566D0BA0009B01E /* GenericPasswordStore.swift in Sources */,
+				DC98D3962AF170AC005BD177 /* PaymentWarningPopover.swift in Sources */,
 				DC48D2C42593DE30008D138C /* TextFieldCurrencyStyler.swift in Sources */,
 				DC18C41D256FF91100A2D083 /* Utils.swift in Sources */,
 				53BEFF4EDB40975C2123C63D /* ui.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -15713,6 +15713,9 @@
         }
       }
     },
+    "Scan withdraw" : {
+
+    },
     "Security" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -15949,6 +15952,9 @@
           }
         }
       }
+    },
+    "Send Money" : {
+
     },
     "Send payment" : {
       "localizations" : {
@@ -18751,6 +18757,9 @@
           }
         }
       }
+    },
+    "This is not a withdraw request. Do you want to **send money** to somebody?" : {
+
     },
     "This is your new address. Do not reuse your old Bitcoin address from before migration." : {
       "localizations" : {

--- a/phoenix-ios/phoenix-ios/views/configuration/ConfigurationView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/ConfigurationView.swift
@@ -371,7 +371,7 @@ fileprivate struct ConfigurationList: View {
 			case .DisplayConfiguration  : DisplayConfigurationView()
 			case .PaymentOptions        : PaymentOptionsView()
 			case .ChannelManagement     : LiquidityPolicyView()
-			case .Notifications         : NotificationsView(type: .embedded)
+			case .Notifications         : NotificationsView(location: .embedded)
 		// Privacy & Security
 			case .AppAccess             : AppAccessView()
 			case .RecoveryPhrase        : RecoveryPhraseView()

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/SwapInWalletDetails.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/SwapInWalletDetails.swift
@@ -13,12 +13,12 @@ fileprivate var log = Logger(OSLog.disabled)
 
 struct SwapInWalletDetails: View {
 	
-	enum ViewLocation {
+	enum Location {
 		case popover
 		case embedded
 	}
 	
-	let location: ViewLocation
+	let location: Location
 	let popTo: (PopToDestination) -> Void
 	
 	@State var liquidityPolicy: LiquidityPolicy = GroupPrefs.shared.liquidityPolicy

--- a/phoenix-ios/phoenix-ios/views/configuration/danger zone/reset wallet/ResetWalletView_Confirm.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/danger zone/reset wallet/ResetWalletView_Confirm.swift
@@ -11,7 +11,7 @@ fileprivate var log = Logger(
 fileprivate var log = Logger(OSLog.disabled)
 #endif
 
-struct ResetWalletView_Confirm: MVISubView, ViewName {
+struct ResetWalletView_Confirm: MVISubView {
 	
 	@ObservedObject var mvi: MVIState<CloseChannelsConfiguration.Model, CloseChannelsConfiguration.Intent>
 	
@@ -416,7 +416,7 @@ struct ResetWalletView_Confirm: MVISubView, ViewName {
 	// --------------------------------------------------
 	
 	func deleteWallet() {
-		log.trace("[\(viewName)] deleteWallet()")
+		log.trace("deleteWallet()")
 		
 		if let scene = UIApplication.shared.connectedScenes.first,
 			let sceneDelegate = scene.delegate as? UIWindowSceneDelegate,

--- a/phoenix-ios/phoenix-ios/views/content/ContentView.swift
+++ b/phoenix-ios/phoenix-ios/views/content/ContentView.swift
@@ -88,7 +88,7 @@ struct ContentView: View {
 		switch lockState.walletExistence {
 		case .exists:
 			if !hasMergedChannelsForSplicing {
-				MergeChannelsView(type: .standalone)
+				MergeChannelsView(location: .standalone)
 			} else {
 				MainView()
 			}

--- a/phoenix-ios/phoenix-ios/views/inspect/CpfpView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/CpfpView.swift
@@ -35,7 +35,7 @@ enum CpfpError: Error {
 
 struct CpfpView: View {
 	
-	let type: PaymentViewType
+	let location: PaymentView.Location
 	let onChainPayment: Lightning_kmpOnChainOutgoingPayment
 	
 	@State var minerFeeInfo: MinerFeeCPFP?
@@ -79,7 +79,7 @@ struct CpfpView: View {
 	@ViewBuilder
 	var body: some View {
 		
-		switch type {
+		switch location {
 		case .sheet:
 			main()
 				.navigationTitle(NSLocalizedString("Accelerate Transactions", comment: "Navigation bar title"))
@@ -123,7 +123,7 @@ struct CpfpView: View {
 	@ViewBuilder
 	func header() -> some View {
 		
-		if case .sheet(let closeAction) = type {
+		if case .sheet(let closeAction) = location {
 			HStack(alignment: VerticalAlignment.center, spacing: 0) {
 				Button {
 					presentationMode.wrappedValue.dismiss()
@@ -723,7 +723,7 @@ struct CpfpView: View {
 				if let problem = SpliceOutProblem.fromResponse(response) {
 					self.cpfpError = .executeError(problem: problem)
 				} else {
-					switch type {
+					switch location {
 					case .sheet(let closeAction):
 						closeAction()
 					case .embedded(let popTo):

--- a/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
@@ -14,7 +14,7 @@ fileprivate var log = Logger(OSLog.disabled)
 
 struct DetailsView: View {
 	
-	let type: PaymentViewType
+	let location: PaymentView.Location
 	@Binding var paymentInfo: WalletPaymentInfo
 	
 	@Binding var showOriginalFiatValue: Bool
@@ -25,7 +25,7 @@ struct DetailsView: View {
 	@ViewBuilder
 	var body: some View {
 		
-		switch type {
+		switch location {
 		case .sheet:
 			content()
 				.navigationTitle(NSLocalizedString("Details", comment: "Navigation bar title"))
@@ -62,7 +62,7 @@ struct DetailsView: View {
 	@ViewBuilder
 	func header() -> some View {
 		
-		if case .sheet(let closeAction) = type {
+		if case .sheet(let closeAction) = location {
 			HStack(alignment: VerticalAlignment.center, spacing: 0) {
 				Button {
 					presentationMode.wrappedValue.dismiss()

--- a/phoenix-ios/phoenix-ios/views/inspect/EditInfoView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/EditInfoView.swift
@@ -14,7 +14,7 @@ fileprivate var log = Logger(OSLog.disabled)
 
 struct EditInfoView: View {
 	
-	let type: PaymentViewType
+	let location: PaymentView.Location
 	@Binding var paymentInfo: WalletPaymentInfo
 	
 	let defaultDescText: String
@@ -34,9 +34,9 @@ struct EditInfoView: View {
 	
 	@Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 	
-	init(type: PaymentViewType, paymentInfo: Binding<WalletPaymentInfo>) {
+	init(location: PaymentView.Location, paymentInfo: Binding<WalletPaymentInfo>) {
 		
-		self.type = type
+		self.location = location
 		_paymentInfo = paymentInfo
 		
 		let pi = paymentInfo.wrappedValue
@@ -68,7 +68,7 @@ struct EditInfoView: View {
 	@ViewBuilder
 	var body: some View {
 		
-		switch type {
+		switch location {
 		case .sheet:
 			main()
 				.navigationTitle(NSLocalizedString("Edit Info", comment: "Navigation bar title"))
@@ -92,7 +92,7 @@ struct EditInfoView: View {
 		
 		VStack(alignment: HorizontalAlignment.center, spacing: 0) {
 		
-			switch type {
+			switch location {
 			case .sheet:
 				HStack(alignment: VerticalAlignment.center, spacing: 0) {
 					saveButton()

--- a/phoenix-ios/phoenix-ios/views/inspect/PaymentView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/PaymentView.swift
@@ -11,40 +11,41 @@ fileprivate var log = Logger(
 fileprivate var log = Logger(OSLog.disabled)
 #endif
 
-enum PaymentViewType {
-	
-	/// We need an explicit close operation here because:
-	/// - we're going to use a NavigationView
-	/// - we need to programmatically close the sheet from any layer in the navigation stack
-	/// - the general API to pop a view from the nav stack is `presentationMode.wrappedValue.dismiss()`
-	/// - the general API to dismiss a sheet is `presentationMode.wrappedValue.dismiss()`
-	/// - thus we cannot use the general API
-	case sheet(closeAction: () -> Void)
-	
-	case embedded(popTo: (PopToDestination) -> Void)
-}
 
 struct PaymentView: View {
-
-	let type: PaymentViewType
+	
+	enum Location {
+	 
+		/// We need an explicit close operation here because:
+		/// - we're going to use a NavigationView
+		/// - we need to programmatically close the sheet from any layer in the navigation stack
+		/// - the general API to pop a view from the nav stack is `presentationMode.wrappedValue.dismiss()`
+		/// - the general API to dismiss a sheet is `presentationMode.wrappedValue.dismiss()`
+		/// - thus we cannot use the general API
+		case sheet(closeAction: () -> Void)
+		
+		case embedded(popTo: (PopToDestination) -> Void)
+	}
+	
+	let location: Location
 	let paymentInfo: WalletPaymentInfo
 	
 	@ViewBuilder
 	var body: some View {
 		
-		switch type {
+		switch location {
 		case .sheet:
-			PaymentViewSheet(type: type, paymentInfo: paymentInfo)
+			PaymentViewSheet(location: location, paymentInfo: paymentInfo)
 			
 		case .embedded:
-			SummaryView(type: type, paymentInfo: paymentInfo)
+			SummaryView(location: location, paymentInfo: paymentInfo)
 		}
 	}
 }
 
 fileprivate struct PaymentViewSheet: View {
 	
-	let type: PaymentViewType
+	let location: PaymentView.Location
 	let paymentInfo: WalletPaymentInfo
 	
 	@EnvironmentObject var shortSheetState: ShortSheetState
@@ -59,7 +60,7 @@ fileprivate struct PaymentViewSheet: View {
 		ZStack {
 			
 			NavigationWrapper {
-				SummaryView(type: type, paymentInfo: paymentInfo)
+				SummaryView(location: location, paymentInfo: paymentInfo)
 			}
 			.edgesIgnoringSafeArea(.all)
 			.zIndex(0) // needed for proper animation

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
@@ -14,7 +14,7 @@ fileprivate var log = Logger(OSLog.disabled)
 
 struct SummaryView: View {
 	
-	let type: PaymentViewType
+	let location: PaymentView.Location
 	
 	@State var paymentInfo: WalletPaymentInfo
 	@State var paymentInfoIsStale: Bool
@@ -51,9 +51,9 @@ struct SummaryView: View {
 	)
 	@State var buttonHeight: CGFloat? = nil
 	
-	init(type: PaymentViewType, paymentInfo: WalletPaymentInfo) {
+	init(location: PaymentView.Location, paymentInfo: WalletPaymentInfo) {
 		
-		self.type = type
+		self.location = location
 		
 		// Try to optimize by using the in-memory cache.
 		// If we get a cache hit, we can skip the UI refresh/flicker.
@@ -85,7 +85,7 @@ struct SummaryView: View {
 	@ViewBuilder
 	var body: some View {
 		
-		switch type {
+		switch location {
 		case .sheet:
 			main()
 				.navigationTitle("")
@@ -118,7 +118,7 @@ struct SummaryView: View {
 			}
 
 			// Close button in upper right-hand corner
-			if case .sheet(let closeAction) = type {
+			if case .sheet(let closeAction) = location {
 				VStack {
 					HStack {
 						Spacer()
@@ -585,7 +585,7 @@ struct SummaryView: View {
 	@ViewBuilder
 	func detailsView() -> some View {
 		DetailsView(
-			type: wrappedType(),
+			location: wrappedLocation(),
 			paymentInfo: $paymentInfo,
 			showOriginalFiatValue: $showOriginalFiatValue,
 			showFiatValueExplanation: $showFiatValueExplanation
@@ -595,7 +595,7 @@ struct SummaryView: View {
 	@ViewBuilder
 	func editInfoView() -> some View {
 		EditInfoView(
-			type: wrappedType(),
+			location: wrappedLocation(),
 			paymentInfo: $paymentInfo
 		)
 	}
@@ -603,7 +603,7 @@ struct SummaryView: View {
 	@ViewBuilder
 	func cpfpView(_ onChainPayment: Lightning_kmpOnChainOutgoingPayment) -> some View {
 		CpfpView(
-			type: wrappedType(),
+			location: wrappedLocation(),
 			onChainPayment: onChainPayment
 		)
 	}
@@ -641,11 +641,11 @@ struct SummaryView: View {
 		}
 	}
 	
-	func wrappedType() -> PaymentViewType {
+	func wrappedLocation() -> PaymentView.Location {
 		
-		switch type {
+		switch location {
 		case .sheet(_):
-			return type
+			return location
 		case .embedded(_):
 			return .embedded(popTo: popToWrapper)
 		}
@@ -803,7 +803,7 @@ struct SummaryView: View {
 		log.trace("popToWrapper(\(destination))")
 		
 		popToDestination = destination
-		if case .embedded(let popTo) = type {
+		if case .embedded(let popTo) = location {
 			popTo(destination)
 		}
 	}
@@ -841,7 +841,7 @@ struct SummaryView: View {
 			})
 		}
 		
-		switch type {
+		switch location {
 		case .sheet(let closeAction):
 			closeAction()
 		case .embedded:

--- a/phoenix-ios/phoenix-ios/views/main/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/main/HomeView.swift
@@ -151,7 +151,7 @@ struct HomeView : MVIView {
 			case .paymentView(let selectedPayment):
 				
 				PaymentView(
-					type: .sheet(closeAction: { self.activeSheet = nil }),
+					location: .sheet(closeAction: { self.activeSheet = nil }),
 					paymentInfo: selectedPayment
 				)
 				.modifier(GlobalEnvironment.sheetInstance())

--- a/phoenix-ios/phoenix-ios/views/main/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/main/HomeView.swift
@@ -159,7 +159,7 @@ struct HomeView : MVIView {
 			case .notificationsView:
 				
 				NotificationsView(
-					type: .sheet
+					location: .sheet
 				)
 				.modifier(GlobalEnvironment.sheetInstance())
 			}

--- a/phoenix-ios/phoenix-ios/views/main/MainView_BigPrimary.swift
+++ b/phoenix-ios/phoenix-ios/views/main/MainView_BigPrimary.swift
@@ -56,7 +56,7 @@ struct MainView_BigPrimary: View {
 				.navigationBarHidden(true)
 		}
 		.sheet(isPresented: $showingMergeChannelsView) {
-			MergeChannelsView(type: .sheet)
+			MergeChannelsView(location: .sheet)
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/main/MainView_BigPrimary.swift
+++ b/phoenix-ios/phoenix-ios/views/main/MainView_BigPrimary.swift
@@ -184,7 +184,7 @@ struct MainView_BigPrimary: View {
 		if let tag = navLinkTag {
 			switch tag {
 				case .ReceiveView : ReceiveView()
-				case .SendView    : SendView(controller: externalLightningRequest)
+				case .SendView    : SendView(location: .MainView, controller: externalLightningRequest)
 			}
 		} else {
 			EmptyView()

--- a/phoenix-ios/phoenix-ios/views/main/MainView_Small.swift
+++ b/phoenix-ios/phoenix-ios/views/main/MainView_Small.swift
@@ -502,7 +502,7 @@ struct MainView_Small: View {
 			case .ConfigurationView   : ConfigurationView()
 			case .TransactionsView    : TransactionsView()
 			case .ReceiveView         : ReceiveView()
-			case .SendView            : SendView(controller: externalLightningRequest)
+			case .SendView            : SendView(location: .MainView, controller: externalLightningRequest)
 			case .CurrencyConverter   : CurrencyConverterView()
 			case .SwapInWalletDetails : SwapInWalletDetails(location: .embedded, popTo: popTo)
 		}

--- a/phoenix-ios/phoenix-ios/views/main/MainView_Small.swift
+++ b/phoenix-ios/phoenix-ios/views/main/MainView_Small.swift
@@ -92,7 +92,7 @@ struct MainView_Small: View {
 				.navigationBarHidden(true)
 		}
 		.sheet(isPresented: $showingMergeChannelsView) {
-			MergeChannelsView(type: .sheet)
+			MergeChannelsView(location: .sheet)
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/notifications/NotificationsView.swift
+++ b/phoenix-ios/phoenix-ios/views/notifications/NotificationsView.swift
@@ -11,15 +11,15 @@ fileprivate var log = Logger(
 fileprivate var log = Logger(OSLog.disabled)
 #endif
 
-enum NotificationsViewType {
-	
-	case sheet
-	case embedded
-}
 
 struct NotificationsView : View {
 	
-	let type: NotificationsViewType
+	enum Location {
+		case sheet
+		case embedded
+	}
+	
+	let location: NotificationsView.Location
 	
 	@StateObject var noticeMonitor = NoticeMonitor()
 	
@@ -42,7 +42,7 @@ struct NotificationsView : View {
 	var body: some View {
 		
 		Group {
-			switch type {
+			switch location {
 			case .sheet:
 				body_sheet()
 				

--- a/phoenix-ios/phoenix-ios/views/receive/ReceiveLightningView.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/ReceiveLightningView.swift
@@ -23,6 +23,7 @@ struct ReceiveLightningView: View {
 	@ObservedObject var toast: Toast
 	
 	@Binding var didAppear: Bool
+	@Binding var showSendView: Bool
 	
 	@StateObject var qrCode = QRCode()
 
@@ -182,19 +183,7 @@ struct ReceiveLightningView: View {
 	func mainPortrait() -> some View {
 		
 		VStack {
-			qrCodeView()
-				.frame(width: 200, height: 200)
-				.padding(.all, 20)
-				.background(Color.white)
-				.cornerRadius(20)
-				.overlay(
-					RoundedRectangle(cornerRadius: 20)
-						.strokeBorder(
-							ReceiveView.qrCodeBorderColor(colorScheme),
-							lineWidth: 1
-						)
-				)
-				.matchedGeometryEffect(id: "qrCodeView_outer", in: qrCodeAnimation_outer)
+			qrCodeWrapperView()
 				.padding(.top)
 			
 			VStack(alignment: .center) {
@@ -220,8 +209,16 @@ struct ReceiveLightningView: View {
 			}
 			.assignMaxPreference(for: maxButtonWidthReader.key, to: $maxButtonWidth)
 			
-			backgroundPaymentsDisabledWarning()
-			inboundFeeWarnings()
+			scanWithdrawButton()
+				.padding([.top, .bottom])
+				.padding(.top, 5) // a little extra
+			
+			if notificationPermissions == .disabled {
+				backgroundPaymentsDisabledWarning()
+			}
+			if let warning = inboundFeeWarning() {
+				inboundFeeInfo(warning)
+			}
 			
 			Spacer()
 			
@@ -233,19 +230,7 @@ struct ReceiveLightningView: View {
 		
 		HStack {
 			
-			qrCodeView()
-				.frame(width: 200, height: 200)
-				.padding(.all, 20)
-				.background(Color.white)
-				.cornerRadius(20)
-				.overlay(
-					RoundedRectangle(cornerRadius: 20)
-						.strokeBorder(
-							ReceiveView.qrCodeBorderColor(colorScheme),
-							lineWidth: 1
-						)
-				)
-				.matchedGeometryEffect(id: "qrCodeView_outer", in: qrCodeAnimation_outer)
+			qrCodeWrapperView()
 				.padding([.top, .bottom])
 			
 			VStack(alignment: HorizontalAlignment.center, spacing: 20) {
@@ -270,8 +255,17 @@ struct ReceiveLightningView: View {
 					.font(.footnote)
 					.foregroundColor(.secondary)
 				
-				backgroundPaymentsDisabledWarning(paddingTop: 8)
-				inboundFeeWarnings(paddingTop: 8)
+				scanWithdrawButton()
+					.padding(.top, 8)
+				
+				if notificationPermissions == .disabled {
+					backgroundPaymentsDisabledWarning()
+						.padding(.top, 8)
+				}
+				if let warning = inboundFeeWarning() {
+					inboundFeeInfo(warning)
+						.padding(.top, 8)
+				}
 				
 				Spacer()
 			}
@@ -318,6 +312,24 @@ struct ReceiveLightningView: View {
 				Spacer()
 			}
 		}
+	}
+	
+	@ViewBuilder
+	func qrCodeWrapperView() -> some View {
+		
+		qrCodeView()
+			.frame(width: 200, height: 200)
+			.padding(.all, 20)
+			.background(Color.white)
+			.cornerRadius(20)
+			.overlay(
+				RoundedRectangle(cornerRadius: 20)
+					.strokeBorder(
+						ReceiveView.qrCodeBorderColor(colorScheme),
+						lineWidth: 1
+					)
+			)
+			.matchedGeometryEffect(id: "qrCodeView_outer", in: qrCodeAnimation_outer)
 	}
 	
 	@ViewBuilder
@@ -522,59 +534,65 @@ struct ReceiveLightningView: View {
 	}
 	
 	@ViewBuilder
-	func backgroundPaymentsDisabledWarning(paddingTop: CGFloat? = nil) -> some View {
+	func scanWithdrawButton() -> some View {
 		
-		if notificationPermissions == .disabled {
-			
-			// The user has disabled "background payments"
-			
-			Button {
-				navigationToBackgroundPayments()
-			} label: {
-				Label {
-					Text("Background payments disabled")
-				} icon: {
-					Image(systemName: "exclamationmark.triangle")
-						.renderingMode(.template)
-				}
-				.foregroundColor(.appNegative)
+		Button {
+			withAnimation {
+				showSendView = true
 			}
-			.padding(.top, paddingTop)
-			.accessibilityLabel("Warning: background payments disabled")
-			.accessibilityHint("Tap for more info")
+		} label: {
+			Label {
+				Text("Scan withdraw")
+			} icon: {
+				Image(systemName: "qrcode.viewfinder")
+			}
 		}
 	}
 	
 	@ViewBuilder
-	func inboundFeeWarnings(paddingTop: CGFloat? = nil) -> some View {
+	func backgroundPaymentsDisabledWarning() -> some View {
 		
+		// The user has disabled "background payments"
+		Button {
+			navigationToBackgroundPayments()
+		} label: {
+			Label {
+				Text("Background payments disabled")
+			} icon: {
+				Image(systemName: "exclamationmark.triangle")
+					.renderingMode(.template)
+			}
+			.foregroundColor(.appNegative)
+		}
+		.accessibilityLabel("Warning: background payments disabled")
+		.accessibilityHint("Tap for more info")
+	}
+	
+	@ViewBuilder
+	func inboundFeeInfo(_ warning: InboundFeeWarning) -> some View {
 		
-		if let warning = inboundFeeWarning() {
+		VStack(alignment: HorizontalAlignment.center, spacing: 10) {
+			Label {
+				Text(warning.title)
+			} icon: {
+				Image(systemName: "info.circle").foregroundColor(.appAccent)
+			}
+			.font(.headline)
 			
-			VStack(alignment: HorizontalAlignment.center, spacing: 10) {
-				Label {
-					Text(warning.title)
-				} icon: {
-					Image(systemName: "info.circle").foregroundColor(.appAccent)
-				}
-				.font(.headline)
-				
-				Text(warning.message)
-					.multilineTextAlignment(.center)
-					.font(.callout)
-				
-				if warning.showButton {
-					Button {
-						navigateToLiquiditySettings()
-					} label: {
-						Text("Check fee settings")
-							.font(.callout)
-					}
+			Text(warning.message)
+				.multilineTextAlignment(.center)
+				.font(.callout)
+			
+			if warning.showButton {
+				Button {
+					navigateToLiquiditySettings()
+				} label: {
+					Text("Check fee settings")
+						.font(.callout)
 				}
 			}
-			.padding(.horizontal)
-			.padding(.top, paddingTop)
 		}
+		.padding(.horizontal)
 	}
 	
 	@ViewBuilder

--- a/phoenix-ios/phoenix-ios/views/receive/ReceiveView.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/ReceiveView.swift
@@ -29,6 +29,7 @@ struct ReceiveView: MVIView {
 	@State var lastAmount: Lightning_kmpMilliSatoshi? = nil
 	
 	@State var receiveLightningView_didAppear = false
+	@State var showSendView = false
 	
 	@State var swapIn_enabled = true
 	
@@ -68,7 +69,25 @@ struct ReceiveView: MVIView {
 					.accessibilityHidden(true)
 			}
 			
-			customTabView()
+			if showSendView {
+				SendView(location: .ReceiveView)
+					.zIndex(5) // needed for proper animation
+					.transition(
+						.asymmetric(
+							insertion: .move(edge: .bottom),
+							removal: .move(edge: .bottom)
+						)
+					)
+			} else {
+				customTabView()
+					.zIndex(4) // needed for proper animation
+					.transition(
+						.asymmetric(
+							insertion: .identity,
+							removal: .opacity
+						)
+					)
+			}
 			
 			toast.view()
 		}
@@ -87,7 +106,8 @@ struct ReceiveView: MVIView {
 				ReceiveLightningView(
 					mvi: mvi,
 					toast: toast,
-					didAppear: $receiveLightningView_didAppear
+					didAppear: $receiveLightningView_didAppear,
+					showSendView: $showSendView
 				)
 				
 			case .blockchain:

--- a/phoenix-ios/phoenix-ios/views/send/PaymentWarningPopover.swift
+++ b/phoenix-ios/phoenix-ios/views/send/PaymentWarningPopover.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import os.log
+
+#if DEBUG && true
+fileprivate var log = Logger(
+	subsystem: Bundle.main.bundleIdentifier!,
+	category: "PaymentWarningPopover"
+)
+#else
+fileprivate var log = Logger(OSLog.disabled)
+#endif
+
+struct PaymentWarningPopover: View {
+	
+	let cancelAction: ()->Void
+	let continueAction: ()->Void
+	
+	enum ButtonHeight: Preference {}
+	let buttonHeightReader = GeometryPreferenceReader(
+		key: AppendValue<ButtonHeight>.self,
+		value: { [$0.size.height] }
+	)
+	@State var buttonHeight: CGFloat? = nil
+	
+	@EnvironmentObject var popoverState: PopoverState
+	
+	@ViewBuilder
+	var body: some View {
+		
+		VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
+			
+			Text(
+				"""
+				This is not a withdraw request. Do you want to **send money** to somebody?
+				"""
+			)
+			.padding(.bottom, 15)
+			
+			HStack(alignment: VerticalAlignment.center, spacing: 10) {
+				Spacer(minLength: 0)
+				
+				Button {
+					cancelButtonTapped()
+				} label: {
+					Text("Cancel")
+				}
+				.font(.title3)
+				.read(buttonHeightReader)
+				
+				if let buttonHeight {
+					Divider()
+						.frame(width: 1, height: buttonHeight)
+						.background(Color.borderColor)
+				}
+				
+				Button {
+					continueButtonTapped()
+				} label: {
+					Text("Send Money")
+				}
+				.font(.title3)
+				.read(buttonHeightReader)
+			} // </HStack>
+			.assignMaxPreference(for: buttonHeightReader.key, to: $buttonHeight)
+			
+		} // </VStack>
+		.padding(.all, 20)
+	}
+	
+	func cancelButtonTapped() {
+		log.trace("cancelButtonTapped()")
+		
+		popoverState.close(animationCompletion: {
+			cancelAction()
+		})
+	}
+	
+	func continueButtonTapped() {
+		log.trace("continueButtonTapped()")
+		
+		popoverState.close(animationCompletion: {
+			continueAction()
+		})
+	}
+}

--- a/phoenix-ios/phoenix-ios/views/tools/MergeChannelsView.swift
+++ b/phoenix-ios/phoenix-ios/views/tools/MergeChannelsView.swift
@@ -12,14 +12,14 @@ fileprivate var log = Logger(
 fileprivate var log = Logger(OSLog.disabled)
 #endif
 
-enum MergeChannelsViewType {
-	case standalone
-	case sheet
-}
-
 struct MergeChannelsView: View {
 	
-	let type: MergeChannelsViewType
+	enum Location {
+		case standalone
+		case sheet
+	}
+	
+	let location: Location
 	
 	@State var selectedPage = 0
 	
@@ -609,7 +609,7 @@ struct MergeChannelsView: View {
 		log.trace("closeView()")
 		
 		Prefs.shared.hasMergedChannelsForSplicing = true
-		if type == .sheet {
+		if location == .sheet {
 			presentationMode.wrappedValue.dismiss()
 		}
 	}

--- a/phoenix-ios/phoenix-ios/views/transactions/TransactionsView.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/TransactionsView.swift
@@ -201,7 +201,7 @@ struct TransactionsView: View {
 		
 		if let selectedItem {
 			PaymentView(
-				type: .embedded(popTo: popTo),
+				location: .embedded(popTo: popTo),
 				paymentInfo: selectedItem
 			)
 			


### PR DESCRIPTION
New "scan withdraw" button:

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/0d36dd8a-0515-4d36-a972-0bbba0400aeb"/>

<br/><br/>
And, as added protection for the user, a prompt if they proceed to scan a payment request:

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/db5c1566-77e8-4cf9-b741-acc46afd5797"/>
