### PR TITLE
(ios) Bug fix for issue #463

### DIFF
--- a/phoenix-ios/phoenix-ios/utils/Utils.swift
+++ b/phoenix-ios/phoenix-ios/utils/Utils.swift
@@ -58,7 +58,7 @@ class Utils {
 			default/*.bitcoin*/: msat = amount * Millisatoshis_Per_Bitcoin
 		}
 		
-		if let result = Int64(exactly: msat.rounded(.towardZero)) {
+		if let result = Int64(exactly: msat.rounded(.toNearestOrAwayFromZero)) {
 			return result
 		} else {
 			return (msat > 0) ? Int64.max : Int64.min


### PR DESCRIPTION
From issue #463:

What's happening here is a floating-point issue when converting from BTC to millisatoshis:
`0.00_060_387 * 100_000_000_000 = 60386999.99999999`

This was getting truncated to 60,386 sats, thus the error message.
The obvious fix is that we should be rounding to the nearest whole msat value.

Another possible fix here would be to use Apple's [Decimal](https://developer.apple.com/documentation/foundation/decimal) math system (which works in base-10 as opposed to base-2). Since converting between bitcoin units is all base-10 powers, we're just shifting decimal places in a true base-10 system... But I'm not sure if Decimal is really needed here, or any better than using a 64-bit Double with proper rounding.