### PR TITLE
(ios) Icon changes to better match Android

### DIFF
--- a/phoenix-ios/phoenix-ios/views/main/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/main/HomeView.swift
@@ -278,7 +278,7 @@ struct HomeView : MVIView {
 			
 			HStack(alignment: VerticalAlignment.center, spacing: 0) {
 			
-				if let _ = swapInWallet.expirationWarningInDays() { // less than 30 days away
+				if let days = swapInWallet.expirationWarningInDays(), days <= 1 {
 					Image(systemName: "exclamationmark.triangle")
 						.foregroundColor(.appNegative)
 						.padding(.trailing, 2)


### PR DESCRIPTION
Updated rules are:
- if a swap times out in less than 30 days: icon = ⚠️
- else if unconfirmed + weaklyConfirmed == 0: icon = 💤
- otherwise: icon = ⏱️