### PR TITLE
(ios) Keep-alive integration

### DIFF
--- a/phoenix-ios/phoenix-ios/kotlin/KotlinIdentifiable.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinIdentifiable.swift
@@ -55,3 +55,10 @@ extension Lightning_kmpWalletState.Utxo: Identifiable {
 		return "\(previousTx.txid.toHex()):\(outputIndex):\(blockHeight)"
 	}
 }
+
+extension Lightning_kmpSensitiveTaskEventsTaskIdentifier.InteractiveTx: Identifiable {
+	
+	public var id: String {
+		return "\(self.channelId.toHex()):\(self.fundingTxIndex)"
+	}
+}

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers+Lightning.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers+Lightning.swift
@@ -12,6 +12,27 @@ fileprivate var log = Logger(
 fileprivate var log = Logger(OSLog.disabled)
 #endif
 
+extension Lightning_kmpPeer {
+	
+	fileprivate struct _Key {
+		static var eventsFlowPublisher = 0
+	}
+	
+	func eventsFlowPublisher() -> AnyPublisher<Lightning_kmpPeerEvent, Never> {
+		
+		self.getSetAssociatedObject(storageKey: &_Key.eventsFlowPublisher) {
+			
+			/// Transforming from Kotlin:
+			/// `eventsFlow: SharedFlow<PeerEvent>`
+			///
+			KotlinPassthroughSubject<Lightning_kmpPeerEvent>(
+				self.eventsFlow
+			)
+			.compactMap { $0 }
+			.eraseToAnyPublisher()
+		}
+	}
+}
 
 extension Lightning_kmpElectrumClient {
 	

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers+Phoenix.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers+Phoenix.swift
@@ -288,7 +288,6 @@ extension PaymentsManager {
 		static var paymentsCountPublisher = 0
 		static var lastCompletedPaymentPublisher = 0
 		static var lastIncomingPaymentPublisher = 0
-		static var inFlightOutgoingPaymentsPublisher = 0
 	}
 	
 	func paymentsCountPublisher() -> AnyPublisher<Int64, Never> {
@@ -332,22 +331,6 @@ extension PaymentsManager {
 				self.lastCompletedPayment
 			)
 			.compactMap { $0 as? Lightning_kmpIncomingPayment }
-			.eraseToAnyPublisher()
-		}
-	}
-	
-	func inFlightOutgoingPaymentsPublisher() -> AnyPublisher<Int, Never> {
-		
-		self.getSetAssociatedObject(storageKey: &_Key.inFlightOutgoingPaymentsPublisher) {
-			
-			// Transforming from Kotlin:
-			// `inFlightOutgoingPayments: StateFlow<Set<UUID>>`
-			//
-			KotlinCurrentValueSubject<NSSet>(
-				self.inFlightOutgoingPayments
-			)
-			.compactMap { $0 as? Set<Lightning_kmpUUID> }
-			.map { $0.count }
 			.eraseToAnyPublisher()
 		}
 	}

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
@@ -5,6 +5,7 @@ import fr.acinq.lightning.ChannelEvents
 import fr.acinq.lightning.DefaultSwapInParams
 import fr.acinq.lightning.LiquidityEvents
 import fr.acinq.lightning.NodeEvents
+import fr.acinq.lightning.SensitiveTaskEvents
 import fr.acinq.lightning.SwapInParams
 import fr.acinq.lightning.blockchain.electrum.ElectrumClient
 import fr.acinq.lightning.blockchain.electrum.ElectrumMiniWallet
@@ -19,6 +20,10 @@ import fr.acinq.lightning.channel.states.Offline
 import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.db.LightningOutgoingPayment
 import fr.acinq.lightning.io.NativeSocketException
+import fr.acinq.lightning.io.PaymentNotSent
+import fr.acinq.lightning.io.PaymentProgress
+import fr.acinq.lightning.io.PaymentSent
+import fr.acinq.lightning.io.PeerEvent
 import fr.acinq.lightning.io.TcpSocket
 import fr.acinq.lightning.payment.LiquidityPolicy
 import fr.acinq.lightning.utils.Connection
@@ -274,4 +279,34 @@ fun defaultSwapInParams(): SwapInParams {
         maxConfirmations = DefaultSwapInParams.MaxConfirmations,
         refundDelay = DefaultSwapInParams.RefundDelay
     )
+}
+
+fun SensitiveTaskEvents.asTaskStarted(): SensitiveTaskEvents.TaskStarted? = when (this) {
+    is SensitiveTaskEvents.TaskStarted -> this
+    else -> null
+}
+
+fun SensitiveTaskEvents.asTaskEnded(): SensitiveTaskEvents.TaskEnded? = when (this) {
+    is SensitiveTaskEvents.TaskEnded -> this
+    else -> null
+}
+
+fun SensitiveTaskEvents.TaskIdentifier.asInteractiveTx(): SensitiveTaskEvents.TaskIdentifier.InteractiveTx? = when (this) {
+    is SensitiveTaskEvents.TaskIdentifier.InteractiveTx -> this
+    else -> null
+}
+
+fun PeerEvent.asPaymentProgress(): PaymentProgress? = when (this) {
+    is PaymentProgress -> this
+    else -> null
+}
+
+fun PeerEvent.asPaymentSent(): PaymentSent? = when (this) {
+    is PaymentSent -> this
+    else -> null
+}
+
+fun PeerEvent.asPaymentNotSent(): PaymentNotSent? = when (this) {
+    is PaymentNotSent -> this
+    else -> null
 }


### PR DESCRIPTION
This integrates the keep-alive mechanism from [lightning-kmp #550](https://github.com/ACINQ/lightning-kmp/pull/550).

* when we receive a `SensitiveTaskEvents.TaskStarted` we call `beingLongLivedTask`
* when we receive a `SensitiveTaskEvents.TaskEnded` we call `endLongLivedTask`

Each call uses a unique identifier that is extracted from the parameters in `TaskStarted`/`TaskEnded`. So if these events are broadcast multiple times, the system can easily ignore them.

In addition, iOS will "punish" our app if we abuse the longLivedTask system. That is, if we always ask for background execution time. Which would happen if the lightning-kmp library didn't always emit a `TaskEnded` in every situation. So to protect against this we've also added a backup call to `endLongLivedTask` that will be executed automatically after a timeout.

This updated architecture is now also used for payments, which are driven by the PeerEvent's: `PaymentProgress`, `PaymentSent`, `PaymentNotSent`.


