### PR TITLE
(ios) App Access Control: Device passcode fallback

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -149,6 +149,8 @@
 		DC67654E25655D93004D4263 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC67654D25655D93004D4263 /* Colors.xcassets */; };
 		DC67E40B27F3798600496C04 /* AnimatedMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC67E40A27F3798600496C04 /* AnimatedMenu.swift */; };
 		DC682FE8258175CE00CA1114 /* Popover.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC682FE7258175CE00CA1114 /* Popover.swift */; };
+		DC6ACC582B10F0220079179B /* RecoveryPhrase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6ACC572B10F0220079179B /* RecoveryPhrase.swift */; };
+		DC6ACC592B10F4FE0079179B /* RecoveryPhrase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6ACC572B10F0220079179B /* RecoveryPhrase.swift */; };
 		DC6CF35B2938F32E001837EE /* ListBackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6CF35A2938F32E001837EE /* ListBackgroundColor.swift */; };
 		DC6D26E329E76557006A7814 /* AnimatedClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6D26E229E76557006A7814 /* AnimatedClock.swift */; };
 		DC6D68252AC1DD5C0099929F /* Currencies.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DC6D68242AC1DD5C0099929F /* Currencies.xcstrings */; };
@@ -483,6 +485,7 @@
 		DC67654D25655D93004D4263 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		DC67E40A27F3798600496C04 /* AnimatedMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedMenu.swift; sourceTree = "<group>"; };
 		DC682FE7258175CE00CA1114 /* Popover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Popover.swift; sourceTree = "<group>"; };
+		DC6ACC572B10F0220079179B /* RecoveryPhrase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryPhrase.swift; sourceTree = "<group>"; };
 		DC6CF35A2938F32E001837EE /* ListBackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListBackgroundColor.swift; sourceTree = "<group>"; };
 		DC6D26E229E76557006A7814 /* AnimatedClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedClock.swift; sourceTree = "<group>"; };
 		DC6D68242AC1DD5C0099929F /* Currencies.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Currencies.xcstrings; sourceTree = "<group>"; };
@@ -1137,6 +1140,7 @@
 				DCACF6F92566D0BA0009B01E /* GenericPasswordConvertible.swift */,
 				DCACF6F52566D0BA0009B01E /* KeyStoreError.swift */,
 				DCE77A5527C5240500F0FA24 /* TLSConnectionCheck.swift */,
+				DC6ACC572B10F0220079179B /* RecoveryPhrase.swift */,
 			);
 			path = security;
 			sourceTree = "<group>";
@@ -1711,6 +1715,7 @@
 				DCAEF8F727628BEB00015993 /* Either.swift in Sources */,
 				DCA6DECC282AAA740073C658 /* SharedSecurity.swift in Sources */,
 				DC5CA4EF28F842F10048A737 /* MVI+Extensions.swift in Sources */,
+				DC6ACC582B10F0220079179B /* RecoveryPhrase.swift in Sources */,
 				DCD7E0F128ED89A0009C30E5 /* GlobalEnvironment.swift in Sources */,
 				DC09086325B626B300A46136 /* AppStatusPopover.swift in Sources */,
 				DC0732EC263CA6C3004CB88D /* PaymentOptionsView.swift in Sources */,
@@ -1811,6 +1816,7 @@
 				DC32FB3529A3D3FE009912AC /* XpcManager.swift in Sources */,
 				DC9545C429490321008FCEF4 /* NotificationContent.swift in Sources */,
 				DC49FE9C2AC49E0400D8D2E2 /* KotlinExtensions+Lightning.swift in Sources */,
+				DC6ACC592B10F4FE0079179B /* RecoveryPhrase.swift in Sources */,
 				DCA6DEC72829BFD70073C658 /* CrossProcessCommunication.swift in Sources */,
 				DC641C7428208BD600862DCD /* String+VersionComparison.swift in Sources */,
 				DCA6DEC92829C3180073C658 /* GenericPasswordConvertible.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -743,6 +743,18 @@
         }
       }
     },
+    "* Face ID stops working due to hardware damage" : {
+
+    },
+    "* Touch ID stops working due to hardware damage" : {
+
+    },
+    "* Your phone is lost or stolen" : {
+
+    },
+    "* Your phone stops working" : {
+
+    },
     "**Do not lose this seed.** Save it somewhere safe (not on this phone). If you lose your seed and your phone, you've lost your funds." : {
       "comment" : "RecoverySeedView",
       "localizations" : {
@@ -3464,6 +3476,9 @@
           }
         }
       }
+    },
+    "Backup Now" : {
+
     },
     "Backup your recovery phrase to prevent losing your funds." : {
       "localizations" : {
@@ -21865,6 +21880,9 @@
           }
         }
       }
+    },
+    "You will **lose your funds** if:" : {
+
     },
     "You will pay %@ (≈ %@) to the Bitcoin miners." : {
       "localizations" : {

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -2191,7 +2191,11 @@
         }
       }
     },
+    "Access to Phoenix is protected" : {
+
+    },
     "Access to Phoenix is protected by biometrics." : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -2427,6 +2431,9 @@
           }
         }
       }
+    },
+    "Allow passcode fallback" : {
+
     },
     "Already paid" : {
       "comment" : "Error title",
@@ -9648,6 +9655,9 @@
         }
       }
     },
+    "If Face ID fails, you can enter your iOS passcode to access Phoenix." : {
+
+    },
     "If the problem persists, please contact support at **phoenix@acinq.co**." : {
       "comment" : "ErrorView",
       "localizations" : {
@@ -9676,6 +9686,9 @@
           }
         }
       }
+    },
+    "If Touch ID fails, you can enter your iOS passcode to access Phoenix." : {
+
     },
     "If you do not back it up and you lose access to Phoenix you will **lose your funds**!" : {
       "comment" : "BackupView",
@@ -18794,6 +18807,12 @@
           }
         }
       }
+    },
+    "This is less secure, but more durable. Face ID can stop working due to hardware damage." : {
+
+    },
+    "This is less secure, but more durable. Touch ID can stop working due to hardware damage." : {
+
     },
     "This is not a withdraw request. Do you want to **send money** to somebody?" : {
 

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -743,18 +743,6 @@
         }
       }
     },
-    "* Face ID stops working due to hardware damage" : {
-
-    },
-    "* Touch ID stops working due to hardware damage" : {
-
-    },
-    "* Your phone is lost or stolen" : {
-
-    },
-    "* Your phone stops working" : {
-
-    },
     "**Do not lose this seed.** Save it somewhere safe (not on this phone). If you lose your seed and your phone, you've lost your funds." : {
       "comment" : "RecoverySeedView",
       "localizations" : {
@@ -3476,9 +3464,6 @@
           }
         }
       }
-    },
-    "Backup Now" : {
-
     },
     "Backup your recovery phrase to prevent losing your funds." : {
       "localizations" : {
@@ -21880,9 +21865,6 @@
           }
         }
       }
-    },
-    "You will **lose your funds** if:" : {
-
     },
     "You will pay %@ (≈ %@) to the Bitcoin miners." : {
       "localizations" : {

--- a/phoenix-ios/phoenix-ios/SceneDelegate.swift
+++ b/phoenix-ios/phoenix-ios/SceneDelegate.swift
@@ -263,20 +263,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		firstUnlockAttempted = true
 		
 		AppSecurity.shared.tryUnlockWithKeychain {
-			(mnemonics: [String]?, enabledSecurity: EnabledSecurity, error: UnlockError?) in
+			(recoveryPhrase: RecoveryPhrase?, enabledSecurity: EnabledSecurity, error: UnlockError?) in
 
 			// There are multiple potential configurations:
 			//
-			// - no wallet         => mnemoncis == nil, enabledSecurity is empty
-			// - no security       => mnemonics != nil, enabledSecurity is empty
-			// - standard security => mnemonics != nil, enabledSecurity is non-empty
-			// - advanced security => mnemonics == nil, enabledSecurity is non-empty
+			// - no wallet         => recoveryPhrase == nil, enabledSecurity is empty
+			// - no security       => recoveryPhrase != nil, enabledSecurity is empty
+			// - standard security => recoveryPhrase != nil, enabledSecurity is non-empty
+			// - advanced security => recoveryPhrase == nil, enabledSecurity is non-empty
 			//
 			// Another way to think about it:
 			// - standard security => biometrics only protect the UI, wallet can immediately be loaded
 			// - advanced security => biometrics required to unlock both the UI and the seed
 
-			if mnemonics == nil && enabledSecurity.isEmpty && error == nil {
+			if recoveryPhrase == nil && enabledSecurity.isEmpty && error == nil {
+
 				// The user doesn't have a wallet yet.
 				LockState.shared.walletExistence = .doesNotExist
 				
@@ -290,9 +291,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 				LockState.shared.walletExistence = .exists
 			}
 			
-			if let mnemonics = mnemonics {
+			if let recoveryPhrase {
 				// Load wallet into memory. (UI may or may not be locked.)
-				Biz.loadWallet(mnemonics: mnemonics)
+				Biz.loadWallet(recoveryPhrase: recoveryPhrase)
 			}
 		
 			if let error = error {

--- a/phoenix-ios/phoenix-ios/officers/BusinessManager.swift
+++ b/phoenix-ios/phoenix-ios/officers/BusinessManager.swift
@@ -354,7 +354,7 @@ class BusinessManager {
 	///
 	@discardableResult
 	func loadWallet(
-		mnemonics: [String],
+		recoveryPhrase: RecoveryPhrase,
 		seed knownSeed: KotlinByteArray? = nil,
 		walletRestoreType: WalletRestoreType? = nil
 	) -> Bool {
@@ -370,7 +370,10 @@ class BusinessManager {
 			return false
 		}
 		
-		let seed = knownSeed ?? business.walletManager.mnemonicsToSeed(mnemonics: mnemonics, passphrase: "")
+		let seed = knownSeed ?? business.walletManager.mnemonicsToSeed(
+			mnemonics  : recoveryPhrase.mnemonicsArray,
+			passphrase : ""
+		)
 		let _walletInfo = business.walletManager.loadWallet(seed: seed)
 		
 		self.walletInfo = _walletInfo
@@ -411,7 +414,7 @@ class BusinessManager {
 
 		self.syncManager = SyncManager(
 			chain: business.chain,
-			mnemonics: mnemonics,
+			recoveryPhrase: recoveryPhrase,
 			cloudKey: cloudKey,
 			encryptedNodeId: encryptedNodeId
 		)

--- a/phoenix-ios/phoenix-ios/security/AppSecurity.swift
+++ b/phoenix-ios/phoenix-ios/security/AppSecurity.swift
@@ -39,10 +39,24 @@ enum BiometricSupport {
 struct UnlockError {
 	let readSecurityFileError: ReadSecurityFileError?
 	let readKeychainError: ReadKeychainError?
+	let readRecoveryPhraseError: ReadRecoveryPhraseError?
 	
-	init(_ readSecurityFileError: ReadSecurityFileError?, _ readKeychainError: ReadKeychainError?) {
+	init(_ readSecurityFileError: ReadSecurityFileError?) {
 		self.readSecurityFileError = readSecurityFileError
+		self.readKeychainError = nil
+		self.readRecoveryPhraseError = nil
+	}
+	
+	init(_ readKeychainError: ReadKeychainError?) {
+		self.readSecurityFileError = nil
 		self.readKeychainError = readKeychainError
+		self.readRecoveryPhraseError = nil
+	}
+	
+	init(_ readRecoveryPhraseError: ReadRecoveryPhraseError?) {
+		self.readSecurityFileError = nil
+		self.readKeychainError = nil
+		self.readRecoveryPhraseError = readRecoveryPhraseError
 	}
 }
 
@@ -109,24 +123,8 @@ class AppSecurity {
 			
 		} catch {
 			// Don't throw from this error as it's an optimization
-			log.error("Error excluding \(url.lastPathComponent) from backup \(String(describing: error))")
+			log.error("Error excluding \(url.lastPathComponent) from backup \(error)")
 		}
-	}
-	
-	private func validateParameter(mnemonics: [String]) -> Data {
-		
-		precondition(mnemonics.count == 12, "Invalid parameter: mnemonics.count")
-		
-		let space = " "
-		precondition(mnemonics.allSatisfy { !$0.contains(space) },
-		  "Invalid parameter: mnemonics.word")
-		
-		let mnemonicsData = mnemonics.joined(separator: space).data(using: .utf8)
-		
-		precondition(mnemonicsData != nil,
-		  "Invalid parameter: mnemonics.work contains non-utf8 characters")
-		
-		return mnemonicsData!
 	}
 	
 	private func calculateEnabledSecurity(_ securityFile: SecurityFile) -> EnabledSecurity {
@@ -221,37 +219,25 @@ class AppSecurity {
 	///
 	public func tryUnlockWithKeychain(
 		completion: @escaping (
-			_ mnemonics: [String]?,
+			_ recoveryPhrase: RecoveryPhrase?,
 			_ configuration: EnabledSecurity,
 			_ error: UnlockError?
 		) -> Void
 	) {
 		
-		let finish = {(mnemonics: [String]?, configuration: EnabledSecurity) -> Void in
+		let finish = {(recoveryPhrase: RecoveryPhrase?, configuration: EnabledSecurity) -> Void in
 			
 			DispatchQueue.main.async {
 				self.publishEnabledSecurity(configuration)
-				completion(mnemonics, configuration, nil)
+				completion(recoveryPhrase, configuration, nil)
 			}
 		}
 		
-		let dangerZone1 = {(error: ReadSecurityFileError, configuration: EnabledSecurity) -> Void in
-			
-			let danger = UnlockError(error, nil)
+		let dangerZone = {(error: UnlockError, configuration: EnabledSecurity) -> Void in
 			
 			DispatchQueue.main.async {
 				self.publishEnabledSecurity(configuration)
-				completion(nil, configuration, danger)
-			}
-		}
-		
-		let dangerZone2 = {(error: ReadKeychainError, configuration: EnabledSecurity) -> Void in
-			
-			let danger = UnlockError(nil, error)
-			
-			DispatchQueue.main.async {
-				self.publishEnabledSecurity(configuration)
-				completion(nil, configuration, danger)
+				completion(nil, configuration, error)
 			}
 		}
 		
@@ -264,45 +250,53 @@ class AppSecurity {
 			let diskResult = SharedSecurity.shared.readSecurityJsonFromDisk()
 			
 			switch diskResult {
+			case .failure(let reason):
+				
+				let securityFile = SecurityFile()
+				let configuration = self.calculateEnabledSecurity(securityFile)
+				
+				switch reason {
+				case .fileNotFound:
+					return finish(nil, configuration)
+					
+				case .errorReadingFile: fallthrough
+				case .errorDecodingFile:
+					return dangerZone(UnlockError(reason), configuration)
+				}
+				
+			case .success(let securityFile):
+					
+				let configuration = self.calculateEnabledSecurity(securityFile)
+					
+				let keychainResult = SharedSecurity.shared.readKeychainEntry(securityFile)
+				switch keychainResult {
 				case .failure(let reason):
-					
-					let securityFile = SecurityFile()
-					let configuration = self.calculateEnabledSecurity(securityFile)
-					
+							
 					switch reason {
-						case .fileNotFound:
-							return finish(nil, configuration)
-							
-						case .errorReadingFile: fallthrough
-						case .errorDecodingFile:
-							return dangerZone1(reason, configuration)
+					case .keychainOptionNotEnabled:
+						return finish(nil, configuration)
+						
+					case .keychainBoxCorrupted: fallthrough
+					case .errorReadingKey: fallthrough
+					case .keyNotFound: fallthrough
+					case .errorOpeningBox:
+						return dangerZone(UnlockError(reason), configuration)
 					}
 					
-				case .success(let securityFile):
+				case .success(let cleartextData):
 					
-					let configuration = self.calculateEnabledSecurity(securityFile)
-					
-					let keychainResult = SharedSecurity.shared.readKeychainEntry(securityFile)
-					switch keychainResult {
-						case .failure(let reason):
-							
-							switch reason {
-								case .keychainOptionNotEnabled:
-									return finish(nil, configuration)
-									
-								case .keychainBoxCorrupted: fallthrough
-								case .errorReadingKey: fallthrough
-								case .keyNotFound: fallthrough
-								case .errorOpeningBox: fallthrough
-								case .invalidMnemonics:
-									return dangerZone2(reason, configuration)
-							}
-							
-						case .success(let mnemonics):
-							return finish(mnemonics, configuration)
-					}
-			}
-		}
+					let decodeResult = SharedSecurity.shared.decodeRecoveryPhrase(cleartextData)
+					switch decodeResult {
+					case .failure(let reason):
+						return dangerZone(UnlockError(reason), configuration)
+						
+					case .success(let recoveryPhrase):
+						return finish(recoveryPhrase, configuration)
+						
+					} // </switch decodeResult>
+				} // </switch keychainResult>
+			} // </switch diskResult>
+		} // </queue.async>
 	}
 	
 	/// Updates the keychain & security file to include a keychain entry.
@@ -314,10 +308,9 @@ class AppSecurity {
 	/// - the user is explicitly disabling existing security options
 	///
 	public func addKeychainEntry(
-		mnemonics  : [String],
-		completion : @escaping (_ error: Error?) -> Void
+		recoveryPhrase : RecoveryPhrase,
+		completion     : @escaping (_ error: Error?) -> Void
 	) {
-		let mnemonicsData = validateParameter(mnemonics: mnemonics)
 		
 		let succeed = {(securityFile: SecurityFile) -> Void in
 			DispatchQueue.main.async {
@@ -333,6 +326,14 @@ class AppSecurity {
 			}
 		}
 		
+		let recoveryPhraseData: Data
+		do {
+			recoveryPhraseData = try JSONEncoder().encode(recoveryPhrase)
+		} catch {
+			log.error("recoveryPhrase.jsonEncoding error")
+			return fail(error)
+		}
+		
 		// Disk IO ahead - get off the main thread.
 		// Also - go thru the serial queue for proper thread safety.
 		queue.async {
@@ -341,7 +342,7 @@ class AppSecurity {
 			
 			let sealedBox: ChaChaPoly.SealedBox
 			do {
-				sealedBox = try ChaChaPoly.seal(mnemonicsData, using: lockingKey)
+				sealedBox = try ChaChaPoly.seal(recoveryPhraseData, using: lockingKey)
 			} catch {
 				return fail(error)
 			}
@@ -359,22 +360,21 @@ class AppSecurity {
 			//    The security.json file doesn't exist.
 			//
 			// 2. User has existing security options, but is choosing to disable them.
-			//    The given databaseKey corresponds to the existing database file.
 			//    There are existing entries in the keychain.
 			//    The security.json file exists, and contains entries.
 			//
 			// 3. Something bad happened during app launch.
-			//    We discovered a corrupt database, a corrupt security.json,
+			//    We discovered a corrupt security.json file,
 			//    or necessary keychain entries have gone missing.
 			//    When this occurs, the system invokes the various `backup` functions.
-			//    This creates a copy of the database, security.json file & keychain entries.
+			//    This creates a copy of the security.json file & keychain entries.
 			//    Afterwards this function is called.
 			//    And we can treat this scenario as the equivalent of a first app launch.
 			//
 			// So situation #2 is the dangerous one.
 			// Consider what happens if:
 			//
-			// - we delete the touchID entry from the database
+			// - we delete the existing entry from the OS keychain
 			// - then the app crashes
 			//
 			// Answer => we just lost the user's data ! :(
@@ -408,18 +408,18 @@ class AppSecurity {
 				          accessGroup: self.sharedAccessGroup(),
 				               mixins: query)
 			} catch {
-				log.error("keychain.storeKey(account: keychain): error: \(String(describing: error))")
+				log.error("keychain.storeKey(account: keychain): error: \(error)")
 				return fail(error)
 			}
 			
 			do {
 				try self.writeToDisk(securityFile: securityFile)
 			} catch {
-				log.error("writeToDisk(securityFile): error: \(String(describing: error))")
+				log.error("writeToDisk(securityFile): error: \(error)")
 				return fail(error)
 			}
 			
-			// Now we can safely delete the biometric entry in the database (if it exists)
+			// Now we can safely delete the previous entry in the OS keychain (if it exists)
 			do {
 				try keychain.deleteKey(
 					account     : keychain_accountName_biometrics,
@@ -470,7 +470,7 @@ class AppSecurity {
 					               mixins: query)
 					
 				} catch {
-					log.error("keychain.storeKey(account: softBiometrics): error: \(String(describing: error))")
+					log.error("keychain.storeKey(account: softBiometrics): error: \(error)")
 					return fail(error)
 				}
 				
@@ -482,7 +482,7 @@ class AppSecurity {
 					)
 				
 				} catch {
-					log.error("keychain.deleteKey(account: softBiometrics): error: \(String(describing: error))")
+					log.error("keychain.deleteKey(account: softBiometrics): error: \(error)")
 					return fail(error)
 				}
 			}
@@ -506,7 +506,7 @@ class AppSecurity {
 			enabled = value != nil
 			
 		} catch {
-			log.error("keychain.readKey(account: softBiometrics): error: \(String(describing: error))")
+			log.error("keychain.readKey(account: softBiometrics): error: \(error)")
 		}
 		
 		return enabled
@@ -527,11 +527,11 @@ class AppSecurity {
 	///
 	public func tryUnlockWithBiometrics(
 		prompt: String? = nil,
-		completion: @escaping (_ result: Result<[String], Error>) -> Void
+		completion: @escaping (_ result: Result<RecoveryPhrase, Error>) -> Void
 	) {
-		let succeed = {(_ mnemonics: [String]) in
+		let succeed = {(_ recoveryPhrase: RecoveryPhrase) in
 			DispatchQueue.main.async {
-				completion(Result.success(mnemonics))
+				completion(Result.success(recoveryPhrase))
 			}
 		}
 		
@@ -545,29 +545,37 @@ class AppSecurity {
 		// Replaced with notification-service-extension,
 		// with ability to receive payments when app is running in the background.
 		// 
-		let disableAdvancedSecurityAndSucceed = {(_ mnemonics: [String]) in
+		let disableAdvancedSecurityAndSucceed = {(_ recoveryPhrase: RecoveryPhrase) in
 			
-			self.addKeychainEntry(mnemonics: mnemonics) { _ in
-				succeed(mnemonics)
+			self.addKeychainEntry(recoveryPhrase: recoveryPhrase) { _ in
+				succeed(recoveryPhrase)
 			}
 		}
 		
 		let trySoftBiometrics = {(_ securityFile: SecurityFile) -> Void in
 			
-			let result = SharedSecurity.shared.readKeychainEntry(securityFile)
-			switch result {
+			let keychainResult = SharedSecurity.shared.readKeychainEntry(securityFile)
+			switch keychainResult {
 			case .failure(let error):
 				fail(error)
 			
-			case .success(let mnemonics):
-				self.tryGenericBiometrics { (success, error) in
-					if success {
-						succeed(mnemonics)
-					} else {
-						fail(error ?? genericError(401, "Biometrics prompt failed / cancelled"))
+			case .success(let cleartextData):
+				
+				let decodeResult = SharedSecurity.shared.decodeRecoveryPhrase(cleartextData)
+				switch decodeResult {
+				case .failure(let error):
+					fail(error)
+					
+				case .success(let recoveryPhrase):
+					self.tryGenericBiometrics { (success, error) in
+						if success {
+							succeed(recoveryPhrase)
+						} else {
+							fail(error ?? genericError(401, "Biometrics prompt failed / cancelled"))
+						}
 					}
-				}
-			}
+				} // </switch decodeResult>
+			} // </switch keychainResult>
 		}
 		
 		// Disk IO ahead - get off the main thread.
@@ -578,8 +586,8 @@ class AppSecurity {
 			// If the file doesn't exist, an empty SecurityFile is returned.
 			let securityFile = self.readFromDisk()
 			
-			// The file tells us which security options have been enabled.
-			// If there isn't a keychain entry, then we cannot unlock the seed.
+			// The security.json file tells us which security options have been enabled.
+			// If this file doesn't have a `keychain` entry, then we cannot unlock the seed.
 			guard
 				let keyInfo_biometrics = securityFile.biometrics as? KeyInfo_ChaChaPoly,
 				let sealedBox_biometrics = try? keyInfo_biometrics.toSealedBox()
@@ -617,17 +625,19 @@ class AppSecurity {
 			}
 		
 			// Decrypt the databaseKey using the lockingKey
-			let mnemonicsData: Data
+			let cleartextData: Data
 			do {
-				mnemonicsData = try ChaChaPoly.open(sealedBox_biometrics, using: lockingKey)
+				cleartextData = try ChaChaPoly.open(sealedBox_biometrics, using: lockingKey)
 			} catch {
 				return fail(error)
 			}
 			
-			guard let mnemonicsString = String(data: mnemonicsData, encoding: .utf8) else {
-				return fail(genericError(500, "Keychain data is invalid"))
+			let recoveryPhrase: RecoveryPhrase
+			do {
+				recoveryPhrase = try SharedSecurity.shared.decodeRecoveryPhrase(cleartextData).get()
+			} catch {
+				return fail(error)
 			}
-			let mnemonics = mnemonicsString.split(separator: " ").map { String($0) }
 			
 		#if targetEnvironment(simulator)
 			
@@ -657,13 +667,13 @@ class AppSecurity {
 				if let error = error {
 					fail(error)
 				} else {
-					disableAdvancedSecurityAndSucceed(mnemonics)
+					disableAdvancedSecurityAndSucceed(recoveryPhrase)
 				}
 			}
 		#else
 		
 			// iOS device
-			disableAdvancedSecurityAndSucceed(mnemonics)
+			disableAdvancedSecurityAndSucceed(recoveryPhrase)
 		
 		#endif
 		}
@@ -845,7 +855,7 @@ class AppSecurity {
 				accessGroup : privateAccessGroup() // <- old location
 			)
 		} catch {
-			log.error("keychain.readKey(account: keychain, group: nil): error: \(String(describing: error))")
+			log.error("keychain.readKey(account: keychain, group: nil): error: \(error)")
 		}
 		
 		if let lockingKey = savedKey {
@@ -861,7 +871,7 @@ class AppSecurity {
 					accessGroup : sharedAccessGroup() // <- new location
 				)
 			} catch {
-				log.error("keychain.deleteKey(account: keychain, group: shared): error: \(String(describing: error))")
+				log.error("keychain.deleteKey(account: keychain, group: shared): error: \(error)")
 			}
 			do {
 				var query = [String: Any]()
@@ -887,9 +897,9 @@ class AppSecurity {
 				
 			} catch {
 				if !migrated {
-					log.error("keychain.storeKey(account: keychain, group: shared): error: \(String(describing: error))")
+					log.error("keychain.storeKey(account: keychain, group: shared): error: \(error)")
 				} else {
-					log.error("keychain.deleteKey(account: keychain, group: private): error: \(String(describing: error))")
+					log.error("keychain.deleteKey(account: keychain, group: private): error: \(error)")
 				}
 			}
 		}

--- a/phoenix-ios/phoenix-ios/security/EnabledSecurity.swift
+++ b/phoenix-ios/phoenix-ios/security/EnabledSecurity.swift
@@ -7,22 +7,23 @@ struct EnabledSecurity: OptionSet, CustomStringConvertible {
 	let rawValue: Int
 
 	static let biometrics       = EnabledSecurity(rawValue: 1 << 0)
-	static let advancedSecurity = EnabledSecurity(rawValue: 1 << 1)
+	static let passcodeFallback = EnabledSecurity(rawValue: 1 << 1)
+	static let advancedSecurity = EnabledSecurity(rawValue: 1 << 2)
 
 	static let none: EnabledSecurity = []
 	
 	var description: String {
-		var str = "["
+		var items = [String]()
+		items.reserveCapacity(3)
 		if contains(.biometrics) {
-			str.append("biometrics")
+			items.append("biometrics")
+		}
+		if contains(.passcodeFallback) {
+			items.append("passcodeFallback")
 		}
 		if contains(.advancedSecurity) {
-			if str.count > 1 {
-				str.append(", ")
-			}
-			str.append("advancedSecurity")
+			items.append("advancedSecurity")
 		}
-		
-		return str.appending("]")
+		return "[\(items.joined(separator: ","))]"
 	}
 }

--- a/phoenix-ios/phoenix-ios/security/KeychainConstants.swift
+++ b/phoenix-ios/phoenix-ios/security/KeychainConstants.swift
@@ -2,3 +2,4 @@
 let keychain_accountName_keychain = "securityFile_keychain"
 let keychain_accountName_biometrics = "securityFile_biometrics"
 let keychain_accountName_softBiometrics = "biometrics"
+let keychain_accountName_passcodeFallback = "passcodeFallback"

--- a/phoenix-ios/phoenix-ios/security/RecoveryPhrase.swift
+++ b/phoenix-ios/phoenix-ios/security/RecoveryPhrase.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+
+struct RecoveryPhrase: Codable {
+	let mnemonics: String
+	let languageCode: String // ISO 639-1
+	
+	var mnemonicsArray: [String] {
+		return mnemonics.split(separator: " ").map { String($0) }
+	}
+	
+	private init(mnemonicsArray: [String], mnemonicsString: String, languageCode: String) {
+		
+		precondition(mnemonicsArray.count == 12, "Invalid parameter: mnemonics.count")
+		
+		let space = " "
+		precondition(mnemonicsArray.allSatisfy { !$0.contains(space) },
+		  "Invalid parameter: mnemonics.word contains space")
+		
+		let mnemonicsData = mnemonicsString.data(using: .utf8)
+		precondition(mnemonicsData != nil,
+		  "Invalid parameter: mnemonics.word contains non-utf8 characters")
+		
+		self.mnemonics = mnemonicsString
+		self.languageCode = languageCode
+	}
+	
+	init(mnemonics mnemonicsArray: [String], languageCode: String = "en") {
+		
+		let mnemonicsString = mnemonicsArray.joined(separator: " ")
+		self.init(mnemonicsArray: mnemonicsArray, mnemonicsString: mnemonicsString, languageCode: languageCode)
+	}
+	
+	init(mnemonics mnemonicsString: String, languageCode: String = "en") {
+		
+		let mnemonicsArray = mnemonicsString.split(separator: " ").map { String($0) }
+		self.init(mnemonicsArray: mnemonicsArray, mnemonicsString: mnemonicsString, languageCode: languageCode)
+	}
+}

--- a/phoenix-ios/phoenix-ios/sync/SyncManager.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncManager.swift
@@ -29,14 +29,14 @@ class SyncManager {
 	
 	init(
 		chain: Lightning_kmpNodeParams.Chain,
-		mnemonics: [String],
+		recoveryPhrase: RecoveryPhrase,
 		cloudKey: Bitcoin_kmpByteVector32,
 		encryptedNodeId: String
 	) {
 		
 		syncSeedManager = SyncSeedManager(
 			chain: chain,
-			mnemonics: mnemonics,
+			recoveryPhrase: recoveryPhrase,
 			encryptedNodeId: encryptedNodeId
 		)
 		syncTxManager = SyncTxManager(

--- a/phoenix-ios/phoenix-ios/sync/SyncSeedManager.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncSeedManager.swift
@@ -47,9 +47,9 @@ class SyncSeedManager: SyncManagerProtcol {
 	///
 	private let chain: Lightning_kmpNodeParams.Chain
 	
-	/// The 12-word seed phrase for the wallet.
+	/// The 12-word recovery phrase (and associated language) for the wallet.
 	///
-	private let mnemonics: String
+	private let recoveryPhrase: RecoveryPhrase
 	
 	/// The encryptedNodeId is created via: Hash(cloudKey + nodeID)
 	///
@@ -76,11 +76,11 @@ class SyncSeedManager: SyncManagerProtcol {
 	
 	private var cancellables = Set<AnyCancellable>()
 	
-	init(chain: Lightning_kmpNodeParams.Chain, mnemonics: [String], encryptedNodeId: String) {
+	init(chain: Lightning_kmpNodeParams.Chain, recoveryPhrase: RecoveryPhrase, encryptedNodeId: String) {
 		log.trace("init()")
 		
 		self.chain = chain
-		self.mnemonics = mnemonics.joined(separator: " ")
+		self.recoveryPhrase = recoveryPhrase
 		self.encryptedNodeId = encryptedNodeId
 		
 		actor = SyncSeedManager_Actor(
@@ -350,8 +350,8 @@ class SyncSeedManager: SyncManagerProtcol {
 						recordID: recordID()
 					)
 					
-					record[record_column_mnemonics] = mnemonics
-					record[record_column_language] = "en"
+					record[record_column_mnemonics] = recoveryPhrase.mnemonics
+					record[record_column_language] = recoveryPhrase.languageCode
 					record[record_column_name] = uploadedName
 					
 					let started = Date.now

--- a/phoenix-ios/phoenix-ios/views/content/LockView.swift
+++ b/phoenix-ios/phoenix-ios/views/content/LockView.swift
@@ -224,13 +224,13 @@ struct LockView: View {
 		}
 		biometricsAttemptInProgress = true
 		
-		AppSecurity.shared.tryUnlockWithBiometrics {(result: Result<[String], Error>) in
+		AppSecurity.shared.tryUnlockWithBiometrics {(result: Result<RecoveryPhrase, Error>) in
 			
 			biometricsAttemptInProgress = false
 			
 			switch result {
-				case .success(let mnemonics):
-					Biz.loadWallet(mnemonics: mnemonics)
+				case .success(let recoveryPhrase):
+					Biz.loadWallet(recoveryPhrase: recoveryPhrase)
 					withAnimation(.easeInOut) {
 						lockState.isUnlocked = true
 					}

--- a/phoenix-ios/phoenix-ios/views/onboarding/InitializationView.swift
+++ b/phoenix-ios/phoenix-ios/views/onboarding/InitializationView.swift
@@ -165,9 +165,11 @@ struct InitializationView: MVIView {
 	func createWallet(model: Initialization.ModelGeneratedWallet) -> Void {
 		log.trace("createWallet()")
 		
-		AppSecurity.shared.addKeychainEntry(mnemonics: model.mnemonics) { (error: Error?) in
+		let recoveryPhrase = RecoveryPhrase(mnemonics : model.mnemonics)
+		
+		AppSecurity.shared.addKeychainEntry(recoveryPhrase: recoveryPhrase) { (error: Error?) in
 			if error == nil {
-				Biz.loadWallet(mnemonics: model.mnemonics, seed: model.seed)
+				Biz.loadWallet(recoveryPhrase: recoveryPhrase, seed: model.seed)
 			}
 		}
 	}

--- a/phoenix-ios/phoenix-ios/views/onboarding/ManualRestoreView.swift
+++ b/phoenix-ios/phoenix-ios/views/onboarding/ManualRestoreView.swift
@@ -93,10 +93,12 @@ struct ManualRestoreView: MVIView {
 	func finishAndRestoreWallet(model: RestoreWallet.ModelValidMnemonics) -> Void {
 		log.trace("finishAndRestoreWallet()")
 		
-		AppSecurity.shared.addKeychainEntry(mnemonics: mnemonics) { (error: Error?) in
+		let recoveryPhrase = RecoveryPhrase(mnemonics : model.mnemonics)
+
+		AppSecurity.shared.addKeychainEntry(recoveryPhrase: recoveryPhrase) { (error: Error?) in
 			if error == nil {
 				Biz.loadWallet(
-					mnemonics: mnemonics,
+					recoveryPhrase: recoveryPhrase,
 					seed: model.seed,
 					walletRestoreType: .fromManualEntry
 				)

--- a/phoenix-ios/phoenix-ios/views/onboarding/RestoreView.swift
+++ b/phoenix-ios/phoenix-ios/views/onboarding/RestoreView.swift
@@ -192,12 +192,15 @@ struct RestoreView: View {
 	func didTapRow(_ seedBackup: SeedBackup) {
 		log.trace("didTapRow: \(seedBackup.name ?? "Wallet")")
 		
-		let mnemonics = seedBackup.mnemonics.components(separatedBy: " ")
+		let recoveryPhrase = RecoveryPhrase(
+			mnemonics    : seedBackup.mnemonics,
+			languageCode : seedBackup.language
+		)
 		
-		AppSecurity.shared.addKeychainEntry(mnemonics: mnemonics) { (error: Error?) in
+		AppSecurity.shared.addKeychainEntry(recoveryPhrase: recoveryPhrase) { (error: Error?) in
 			if error == nil {
 				Biz.loadWallet(
-					mnemonics: mnemonics,
+					recoveryPhrase: recoveryPhrase,
 					walletRestoreType: .fromCloudBackup(name: seedBackup.name)
 				)
 			}

--- a/phoenix-ios/phoenix-ios/views/tools/UnlockErrorView.swift
+++ b/phoenix-ios/phoenix-ios/views/tools/UnlockErrorView.swift
@@ -262,13 +262,25 @@ struct ErrorDetailsView: View, ViewName {
 					txt += "keyNotFound"
 				case .errorOpeningBox(let underlying):
 					txt += "errorOpeningBox:\n\(String(describing: underlying))"
-				case .invalidMnemonics:
-					txt += "invalidMnemonics"
 			}
 		} else {
 			txt += "none"
 		}
 		
+		txt += "\n\n"
+		
+		txt += "readRecoveryPhraseError: "
+		if let err = danger.readRecoveryPhraseError {
+			switch err {
+				case .invalidCiphertext:
+					txt += "invalidCiphertext"
+				case .invalidJSON:
+					txt += "invalidJSON"
+			}
+		} else {
+			txt += "none"
+		}
+
 		txt += "\n"
 		
 		return txt

--- a/phoenix-ios/phoenix-notifySrvExt/NotificationService.swift
+++ b/phoenix-ios/phoenix-notifySrvExt/NotificationService.swift
@@ -131,7 +131,7 @@ class NotificationService: UNNotificationServiceExtension {
 			repeats          : true
 		) {[weak self](_: Timer) in
 		
-			if let self = self {
+			if let _ = self {
 				log.debug("connectionsTimer.fire()")
 				log.debug("GroupPrefs.shared.srvExtConnection = now")
 				GroupPrefs.shared.srvExtConnection = Date.now


### PR DESCRIPTION
Partially addresses issue #441

> Phoenix should provide more options for app access control, each with their own trade-offs:
> 
> 1. biometrics authentication: the recommended option. It enables fine-grained control on a device that is shared between several users (e.g. a family), reasonably secure, but less private and prone to hardware malfunction
> 2. the device's PIN/password: no fine control and probably less secure, but it's robust 

Option 2 was missing from iOS, but fixed via this PR.

<img height="550" src="https://github.com/ACINQ/phoenix/assets/304604/c43ed80a-2726-4f41-af8d-fc17647d8fd2"/>&nbsp;<img height="550" src="https://github.com/ACINQ/phoenix/assets/304604/30da8598-eff3-45d4-89dd-e06fd234aa9e"/>

If the user:
* enables biometrics (Face ID / Touch ID)
* but does not enable the passcode fallback
* and has not backed up their recovery phrase

then we display this warning:

<img height="550" src="https://github.com/ACINQ/phoenix/assets/304604/95114263-ea8a-4733-afae-9d981c957ed5"/>


