### PR TITLE
(android) Skip TLS check for onion Electrum servers

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/ScanDataView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/ScanDataView.kt
@@ -232,7 +232,7 @@ fun ReadDataView(
         }
 
         if (model is Scan.Model.LnurlServiceFetch) {
-            Card(modifier = Modifier.align(Alignment.Center), internalPadding = PaddingValues(24.dp)) {
+            Card(modifier = Modifier.align(Alignment.Center), internalPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp)) {
                 ProgressView(text = stringResource(R.string.scan_lnurl_fetching))
             }
         }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/ElectrumDialogViewModel.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/ElectrumDialogViewModel.kt
@@ -90,7 +90,7 @@ class ElectrumDialogViewModel : ViewModel() {
 
     sealed class CertificateCheckState {
         object Init : CertificateCheckState()
-        object Checking : CertificateCheckState()q
+        object Checking : CertificateCheckState()
         data class Rejected(val host: String, val port: Int, val certificate: Certificate) : CertificateCheckState()
         data class Failure(val e: Throwable) : CertificateCheckState()
     }

--- a/phoenix-android/src/main/res/values-cs/strings.xml
+++ b/phoenix-android/src/main/res/values-cs/strings.xml
@@ -534,9 +534,6 @@
     <string name="electrum_title">Electrum server</string>
     <string name="electrum_about">K zabezpečení vašich platebních kanálů Phoenix monitoruje Bitcoinový blockchain skrz Electrum servery.\n\nVe výchozím nastavení se používají náhodné servery. Phoenix můžete také nakonfigurovat tak, aby se připojoval pouze k vašemu vlastnímu serveru.</string>
     <string name="electrum_block_height_label">Výška bloku</string>
-    <string name="electrum_tip_label">Časové razítko tipu</string>
-    <string name="electrum_fee_rate_next_label">Poplatky za 1 blok</string>
-    <string name="electrum_fee_rate_funding_label">Poplatky za 144 bloků</string>
     <string name="electrum_connection_label">Server</string>
 
     <string name="electrum_connection_closed_with_random">Odpojeno od Electrum</string>
@@ -553,7 +550,7 @@
     <string name="electrum_dialog_invalid_input">Tato adresa je neplatná.</string>
     <string name="electrum_dialog_cert_check_button">Připojit</string>
     <string name="electrum_dialog_cert_checking">Kontrola certifikátu…</string>
-    <string name="electrum_dialog_cert_failure">Nepodařilo se připojit:\n%1$s</string>
+    <string name="electrum_dialog_cert_failure">Nepodařilo se připojit</string>
     <string name="electrum_dialog_cert_unresolved">Adresu se nepodařilo přeložit.</string>
     <string name="electrum_dialog_cert_header">Nedůvěryhodný certifikát</string>
     <string name="electrum_dialog_cert_sha1">SHA1 Fingerprint</string>

--- a/phoenix-android/src/main/res/values-de/strings.xml
+++ b/phoenix-android/src/main/res/values-de/strings.xml
@@ -506,8 +506,6 @@
     <string name="electrum_title">Electrum-Server</string>
     <string name="electrum_about">Um Ihre Zahlungskanäle zu sichern, überwacht Phoenix die Bitcoin-Blockchain über Electrum-Server.\n\nStandardmäßig werden zufällige Server verwendet. Sie können Phoenix auch so konfigurieren, dass es sich nur mit Ihrem eigenen Server verbindet.</string>
     <string name="electrum_block_height_label">Blockhöhe</string>
-    <string name="electrum_fee_rate_next_label">Gebührenrate 1 Block</string>
-    <string name="electrum_fee_rate_funding_label">Gebührenrate 144 Blöcke</string>
     <string name="electrum_connection_label">Server</string>
 
     <string name="electrum_connection_closed_with_random">Keine Verbindung zu Electrum</string>
@@ -524,7 +522,7 @@
     <string name="electrum_dialog_invalid_input">Diese Adresse ist ungültig.</string>
     <string name="electrum_dialog_cert_check_button">Verbinden</string>
     <string name="electrum_dialog_cert_checking">Prüfe Zertifikat…</string>
-    <string name="electrum_dialog_cert_failure">Verbindung fehlgeschlagen:\n%1$s</string>
+    <string name="electrum_dialog_cert_failure">Verbindung fehlgeschlagen</string>
     <string name="electrum_dialog_cert_unresolved">Diese Adresse konnte nicht aufgelöst werden.</string>
     <string name="electrum_dialog_cert_header">Nicht vertrauenswürdiges Zertifikat</string>
     <string name="electrum_dialog_cert_sha1">SHA1 Fingerabdruck</string>

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -576,10 +576,9 @@
     <string name="electrum_title">Electrum server</string>
     <string name="electrum_about">To secure your payment channels Phoenix monitors the Bitcoin blockchain through Electrum servers.\n\nBy default, random servers are used. You can also configure Phoenix to connect only to your own server.</string>
     <string name="electrum_block_height_label">Block height</string>
-    <string name="electrum_tip_label">Tip timestamp</string>
-    <string name="electrum_fee_rate_next_label">Feerate 1 block</string>
-    <string name="electrum_fee_rate_funding_label">Feerate 144 blocks</string>
     <string name="electrum_connection_label">Server</string>
+    <string name="electrum_connection_dialog_tls_port">Use the TLS port (default 50002).</string>
+    <string name="electrum_connection_dialog_onion_port">Use the plain TCP port, not the TLS one, since this is an onion service.</string>
 
     <string name="electrum_connection_closed_with_random">Disconnected from Electrum</string>
     <string name="electrum_connection_closed_with_custom">Disconnected from %1$s</string>
@@ -595,7 +594,7 @@
     <string name="electrum_dialog_invalid_input">This address is invalid.</string>
     <string name="electrum_dialog_cert_check_button">Connect</string>
     <string name="electrum_dialog_cert_checking">Checking certificate…</string>
-    <string name="electrum_dialog_cert_failure">Failed to connect:\n%1$s</string>
+    <string name="electrum_dialog_cert_failure">Failed to connect</string>
     <string name="electrum_dialog_cert_unresolved">This address cannot be resolved.</string>
     <string name="electrum_dialog_cert_header">Untrusted certificate</string>
     <string name="electrum_dialog_cert_sha1">SHA1 Fingerprint</string>

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConnectionsDaemon.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConnectionsDaemon.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import org.kodein.log.Logger
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import kotlin.time.Duration
@@ -36,13 +35,7 @@ class AppConnectionsDaemon(
     private val tcpSocketBuilder: suspend () -> TcpSocket.Builder,
     private val tor: Tor,
     private val electrumClient: ElectrumClient,
-//) : CoroutineScope by MainScope() {
-) : CoroutineScope by CoroutineScope(CoroutineName("appconndaemon") + SupervisorJob() + Dispatchers.Main + CoroutineExceptionHandler { _, e ->
-    println("error in AppConnectionDaemon coroutine scope: ${e.message}")
-    val logger = loggerFactory.newLogger(Logger.Tag(AppConnectionsDaemon::class))
-    logger.error(e) { "error in AppConnectionDaemon coroutine scope: " }
-}) {
-
+) : CoroutineScope by MainScope() {
 
     constructor(business: PhoenixBusiness) : this(
         loggerFactory = business.loggerFactory,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConnectionsDaemon.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConnectionsDaemon.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import org.kodein.log.Logger
 import org.kodein.log.LoggerFactory
 import org.kodein.log.newLogger
 import kotlin.time.Duration
@@ -35,7 +36,13 @@ class AppConnectionsDaemon(
     private val tcpSocketBuilder: suspend () -> TcpSocket.Builder,
     private val tor: Tor,
     private val electrumClient: ElectrumClient,
-) : CoroutineScope by MainScope() {
+//) : CoroutineScope by MainScope() {
+) : CoroutineScope by CoroutineScope(CoroutineName("appconndaemon") + SupervisorJob() + Dispatchers.Main + CoroutineExceptionHandler { _, e ->
+    println("error in AppConnectionDaemon coroutine scope: ${e.message}")
+    val logger = loggerFactory.newLogger(Logger.Tag(AppConnectionsDaemon::class))
+    logger.error(e) { "error in AppConnectionDaemon coroutine scope: " }
+}) {
+
 
     constructor(business: PhoenixBusiness) : this(
         loggerFactory = business.loggerFactory,


### PR DESCRIPTION
This PR fixes an issue where Phoenix was checking the TLS certificates even for onion servers. This check is redundant so by default, should be skipped.

There's also a bug (maybe in lightning-kmp) that makes the TLS connection fail for onion addresses. This issue needs further investigation and it will be fixed in a later PR.

Additionally this PR adds a notice in the dialog for connecting to a custom Electrum server to help users know what port they should use (for onion address, use the plain TCP port, otherwise always use the TLS port).

![image](https://github.com/ACINQ/phoenix/assets/5765435/ced53084-6e7a-43fb-9c2e-eb5664f7a139)

@robbiehanson I've only updated the Android app, but I think this will also need a fix on iOS.