### PR TITLE
Display LNURL Error Reason

### DIFF
--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -18280,8 +18280,12 @@
         }
       }
     },
+    "The invoice is not for (chainMismatch.expected.name)" : {
+      "comment" : "Error message - scanning lightning invoice"
+    },
     "The invoice is not for (reason.expected.name)" : {
       "comment" : "Error message - scanning lightning invoice",
+      "extractionState" : "stale",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -18443,6 +18447,12 @@
           }
         }
       }
+    },
+    "The service ((origin)) returned error code: (rfCode.code.value)" : {
+      "comment" : "Error message - scanning lightning invoice"
+    },
+    "The service ((origin)) returned error message: (rfDetailed.reason)" : {
+      "comment" : "Error message - scanning lightning invoice"
     },
     "The simulator cannot access the camera. Please use the clipboard." : {
       "comment" : "Warning for iOS Simulator (only for devs)",


### PR DESCRIPTION
Fixes issue #468 

Initially this looked like a bug specific to iOS. But I found another problem in the shared kotlin layer:

The error returned from the referenced [lnurl](https://legend.lnbits.com/withdraw/api/v1/lnurl/ir3XFcCH6wQD8xPeA3EcXq):
* is `LnurlError.RemoteFailure.Code(code = 404)`
* but it should be `LnurlError.RemoteFailure.Detailed(reason = "Withdraw is spent.")`

The problem is that we weren't properly following the [LUD-01](https://github.com/lnurl/luds/blob/luds/01.md) spec:

> HTTP Status Codes and Content-Type:
> 
> Neither status codes or any HTTP Header has any meaning. Servers may use whatever they want. Clients should ignore them (and be careful when using libraries that treat responses differently based on headers and status codes) and just parse the response body as JSON, then interpret it accordingly.

So even though the server returns a 404, since it also returns a valid JSON (that matches the spec with `status=error` & `reason=string`), we should be returning the given reason as a `RemoteFailure.Detailed`.