### PR TITLE
(ios) Use TxId and TxHash instead of raw ByteVectors

### DIFF
--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Bitcoin.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Bitcoin.swift
@@ -3,6 +3,13 @@ import PhoenixShared
 import CryptoKit
 
 
+extension Bitcoin_kmpTxId {
+	
+	func toHex() -> String {
+		return self.value.toHex()
+	}
+}
+
 extension Bitcoin_kmpByteVector32 {
 	
 	static func random() -> Bitcoin_kmpByteVector32 {

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/channels/ChannelInfoPopup.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/channels/ChannelInfoPopup.swift
@@ -403,7 +403,7 @@ fileprivate struct ChannelInfoPopup_Summary: InfoGridView, ViewName {
 				showBlockchainExplorerOptions = true
 			} label: {
 				HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 4) {
-					Text(txId).lineLimit(1).truncationMode(.middle)
+					Text(txId.toHex()).lineLimit(1).truncationMode(.middle)
 					Image(systemName: "link").imageScale(.small)
 				}
 			}
@@ -479,7 +479,7 @@ fileprivate struct ChannelInfoPopup_Summary: InfoGridView, ViewName {
 	// MARK: Actions
 	// --------------------------------------------------
 	
-	func exploreTx(_ txId: String, website: BlockchainExplorer.Website) {
+	func exploreTx(_ txId: Bitcoin_kmpTxId, website: BlockchainExplorer.Website) {
 		log.trace("exploreTX()")
 		
 		let txUrlStr = Biz.business.blockchainExplorer.txUrl(txId: txId, website: website)
@@ -488,10 +488,10 @@ fileprivate struct ChannelInfoPopup_Summary: InfoGridView, ViewName {
 		}
 	}
 	
-	func copyTxId(_ txId: String) {
+	func copyTxId(_ txId: Bitcoin_kmpTxId) {
 		log.trace("copyTxId()")
 		
-		UIPasteboard.general.string = txId
+		UIPasteboard.general.string = txId.toHex()
 	}
 	
 	// --------------------------------------------------

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/FinalWalletDetails.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/FinalWalletDetails.swift
@@ -17,7 +17,7 @@ struct FinalWalletDetails: View {
 	@State var finalWallet = Biz.business.peerManager.finalWalletValue()
 	let finalWalletPublisher = Biz.business.peerManager.finalWalletPublisher()
 	
-	@State var blockchainExplorerTxid: String? = nil
+	@State var blockchainExplorerTxid: Bitcoin_kmpTxId? = nil
 	
 	@EnvironmentObject var currencyPrefs: CurrencyPrefs
 	
@@ -87,7 +87,7 @@ struct FinalWalletDetails: View {
 				ForEach(utxos) { utxo in
 					HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
 						
-						Text(utxo.txid)
+						Text(utxo.txid.toHex())
 							.font(.subheadline)
 							.foregroundColor(.secondary)
 							.lineLimit(1)
@@ -122,24 +122,25 @@ struct FinalWalletDetails: View {
 			isPresented: confirmationDialogBinding(),
 			titleVisibility: .automatic
 		) {
-			let txid = blockchainExplorerTxid ?? ""
-			Button {
-				exploreTx(txid, website: BlockchainExplorer.WebsiteMempoolSpace())
-			} label: {
-				Text(verbatim: "Mempool.space") // no localization needed
-					.textCase(.none)
-			}
-			Button {
-				exploreTx(txid, website: BlockchainExplorer.WebsiteBlockstreamInfo())
-			} label: {
-				Text(verbatim: "Blockstream.info") // no localization needed
-					.textCase(.none)
-			}
-			Button {
-				copyTxId(txid)
-			} label: {
-				Text("Copy transaction id")
-					.textCase(.none)
+			if let txid = blockchainExplorerTxid {
+				Button {
+					exploreTx(txid, website: BlockchainExplorer.WebsiteMempoolSpace())
+				} label: {
+					Text(verbatim: "Mempool.space") // no localization needed
+						.textCase(.none)
+				}
+				Button {
+					exploreTx(txid, website: BlockchainExplorer.WebsiteBlockstreamInfo())
+				} label: {
+					Text(verbatim: "Blockstream.info") // no localization needed
+						.textCase(.none)
+				}
+				Button {
+					copyTxId(txid)
+				} label: {
+					Text("Copy transaction id")
+						.textCase(.none)
+				}
 			}
 		} // </confirmationDialog>
 	}
@@ -203,7 +204,7 @@ struct FinalWalletDetails: View {
 	// MARK: Actions
 	// --------------------------------------------------
 	
-	func exploreTx(_ txid: String, website: BlockchainExplorer.Website) {
+	func exploreTx(_ txid: Bitcoin_kmpTxId, website: BlockchainExplorer.Website) {
 		log.trace("exploreTX()")
 		
 		let txUrlStr = Biz.business.blockchainExplorer.txUrl(txId: txid, website: website)
@@ -212,9 +213,9 @@ struct FinalWalletDetails: View {
 		}
 	}
 	
-	func copyTxId(_ txid: String) {
+	func copyTxId(_ txid: Bitcoin_kmpTxId) {
 		log.trace("copyTxId()")
 		
-		UIPasteboard.general.string = txid
+		UIPasteboard.general.string = txid.toHex()
 	}
 }

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/SwapInWalletDetails.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/SwapInWalletDetails.swift
@@ -29,7 +29,7 @@ struct SwapInWalletDetails: View {
 	let swapInRejectedPublisher = Biz.swapInRejectedPublisher
 	@State var swapInRejected: Lightning_kmpLiquidityEventsRejected? = nil
 	
-	@State var blockchainExplorerTxid: String? = nil
+	@State var blockchainExplorerTxid: Bitcoin_kmpTxId? = nil
 	
 	@Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 	
@@ -221,24 +221,25 @@ struct SwapInWalletDetails: View {
 			isPresented: confirmationDialogBinding(),
 			titleVisibility: .automatic
 		) {
-			let txid = blockchainExplorerTxid ?? ""
-			Button {
-				exploreTx(txid, website: BlockchainExplorer.WebsiteMempoolSpace())
-			} label: {
-				Text(verbatim: "Mempool.space") // no localization needed
-					.textCase(.none)
-			}
-			Button {
-				exploreTx(txid, website: BlockchainExplorer.WebsiteBlockstreamInfo())
-			} label: {
-				Text(verbatim: "Blockstream.info") // no localization needed
-					.textCase(.none)
-			}
-			Button {
-				copyTxId(txid)
-			} label: {
-				Text("Copy transaction id")
-					.textCase(.none)
+			if let txid = blockchainExplorerTxid {
+				Button {
+					exploreTx(txid, website: BlockchainExplorer.WebsiteMempoolSpace())
+				} label: {
+					Text(verbatim: "Mempool.space") // no localization needed
+						.textCase(.none)
+				}
+				Button {
+					exploreTx(txid, website: BlockchainExplorer.WebsiteBlockstreamInfo())
+				} label: {
+					Text(verbatim: "Blockstream.info") // no localization needed
+						.textCase(.none)
+				}
+				Button {
+					copyTxId(txid)
+				} label: {
+					Text("Copy transaction id")
+						.textCase(.none)
+				}
 			}
 		} // </confirmationDialog>
 	}
@@ -519,7 +520,7 @@ struct SwapInWalletDetails: View {
 	// MARK: Actions
 	// --------------------------------------------------
 	
-	func exploreTx(_ txid: String, website: BlockchainExplorer.Website) {
+	func exploreTx(_ txid: Bitcoin_kmpTxId, website: BlockchainExplorer.Website) {
 		log.trace("exploreTX()")
 		
 		let txUrlStr = Biz.business.blockchainExplorer.txUrl(txId: txid, website: website)
@@ -528,10 +529,10 @@ struct SwapInWalletDetails: View {
 		}
 	}
 	
-	func copyTxId(_ txid: String) {
+	func copyTxId(_ txid: Bitcoin_kmpTxId) {
 		log.trace("copyTxId()")
 		
-		UIPasteboard.general.string = txid
+		UIPasteboard.general.string = txid.toHex()
 	}
 	
 	func navigateToLiquiditySettings() {

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/UtxoWrapper.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/UtxoWrapper.swift
@@ -9,8 +9,8 @@ struct UtxoWrapper: Identifiable {
 		return utxo.amount
 	}
 	
-	var txid: String {
-		return utxo.previousTx.txid.toHex()
+	var txid: Bitcoin_kmpTxId {
+		return utxo.previousTx.txid
 	}
 	
 	var id: String {

--- a/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
@@ -716,12 +716,12 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 						titleVisibility: .automatic
 					) {
 						Button {
-							exploreTx(txIdStr, website: BlockchainExplorer.WebsiteMempoolSpace())
+							exploreTx(txId, website: BlockchainExplorer.WebsiteMempoolSpace())
 						} label: {
 							Text(verbatim: "Mempool.space") // no localization needed
 						}
 						Button {
-							exploreTx(txIdStr, website: BlockchainExplorer.WebsiteBlockstreamInfo())
+							exploreTx(txId, website: BlockchainExplorer.WebsiteBlockstreamInfo())
 						} label: {
 							Text(verbatim: "Blockstream.info") // no localization needed
 						}
@@ -1580,7 +1580,7 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 		return nil
 	}
 	
-	func txId(receivedWith: Lightning_kmpIncomingPayment.ReceivedWith) -> Bitcoin_kmpByteVector32? {
+	func txId(receivedWith: Lightning_kmpIncomingPayment.ReceivedWith) -> Bitcoin_kmpTxId? {
 		
 		if let newChannel = receivedWith.asNewChannel() {
 			
@@ -1615,7 +1615,7 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 	// MARK: Actions
 	// --------------------------------------------------
 	
-	func exploreTx(_ txId: String, website: BlockchainExplorer.Website) {
+	func exploreTx(_ txId: Bitcoin_kmpTxId, website: BlockchainExplorer.Website) {
 		log.trace("exploreTX()")
 		
 		let txUrlStr = Biz.business.blockchainExplorer.txUrl(txId: txId, website: website)

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
@@ -808,17 +808,16 @@ struct SummaryView: View {
 		}
 	}
 	
-	func exploreTx(_ txId: Bitcoin_kmpByteVector32, website: BlockchainExplorer.Website) {
+	func exploreTx(_ txId: Bitcoin_kmpTxId, website: BlockchainExplorer.Website) {
 		log.trace("exploreTX()")
 		
-		let txIdStr = txId.toHex()
-		let txUrlStr = Biz.business.blockchainExplorer.txUrl(txId: txIdStr, website: website)
+		let txUrlStr = Biz.business.blockchainExplorer.txUrl(txId: txId, website: website)
 		if let txUrl = URL(string: txUrlStr) {
 			UIApplication.shared.open(txUrl)
 		}
 	}
 	
-	func copyTxId(_ txId: Bitcoin_kmpByteVector32) {
+	func copyTxId(_ txId: Bitcoin_kmpTxId) {
 		log.trace("copyTxId()")
 		
 		UIPasteboard.general.string = txId.toHex()

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
@@ -1,6 +1,7 @@
 package fr.acinq.phoenix.utils
 
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.ChannelEvents
 import fr.acinq.lightning.DefaultSwapInParams
 import fr.acinq.lightning.LiquidityEvents
@@ -269,7 +270,7 @@ fun ChannelCommand.Commitment.Splice.Response.Failure.asDisconnected(): ChannelC
     else -> null
 }
 
-suspend fun ElectrumClient.kotlin_getConfirmations(txid: ByteVector32): Int? {
+suspend fun ElectrumClient.kotlin_getConfirmations(txid: TxId): Int? {
     return this.getConfirmations(txid)
 }
 


### PR DESCRIPTION
Updates to match changes from a72317615f1f89634c764c49b6ea401c92f6516d