### PR TITLE
(ios) Apple's "advanced data protection" + seed backups

### DIFF
--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -12074,6 +12074,9 @@
         }
       }
     },
+    "I have enabled \"Advanced Data Protection\" for iCloud." : {
+
+    },
     "I have saved my recovery phrase somewhere safe." : {
       "localizations" : {
         "ar" : {
@@ -14052,6 +14055,12 @@
           }
         }
       }
+    },
+    "Legal: Option 1" : {
+
+    },
+    "Legal: Option 2" : {
+
     },
     "Less options" : {
       "localizations" : {

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -12074,9 +12074,6 @@
         }
       }
     },
-    "I have enabled \"Advanced Data Protection\" for iCloud." : {
-
-    },
     "I have saved my recovery phrase somewhere safe." : {
       "localizations" : {
         "ar" : {
@@ -12618,6 +12615,9 @@
           }
         }
       }
+    },
+    "If you enable [Advanced Data Protection](https://support.apple.com/en-us/108756) for iCloud, your recovery phrase will be encrypted end-to-end, and Apple cannot access it." : {
+
     },
     "If you enable background payments, then you can receive payments as long as your device is connected to the internet." : {
       "localizations" : {
@@ -14055,12 +14055,6 @@
           }
         }
       }
-    },
-    "Legal: Option 1" : {
-
-    },
-    "Legal: Option 2" : {
-
     },
     "Less options" : {
       "localizations" : {

--- a/phoenix-ios/phoenix-ios/extensions/Task+Sleep.swift
+++ b/phoenix-ios/phoenix-ios/extensions/Task+Sleep.swift
@@ -10,4 +10,8 @@ extension Task where Success == Never, Failure == Never {
 			try await Task.sleep(nanoseconds: nanoseconds)
 		}
 	}
+	
+	static func sleep(hours: Int) async throws {
+		try await sleep(seconds: TimeInterval(hours) * 60 * 60)
+	}
 }

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Other.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Other.swift
@@ -244,7 +244,7 @@ extension Array where Element == LocalChannelInfo {
 		return LocalChannelInfo.companion.canRequestLiquidity(channels: self)
 	}
 	
-	func inFlightPaymentsCount() -> Int {
+	func inFlightPaymentsCount() -> Int32 {
 		return LocalChannelInfo.companion.inFlightPaymentsCount(channels: self)
 	}
 }

--- a/phoenix-ios/phoenix-ios/prefs/Prefs.swift
+++ b/phoenix-ios/phoenix-ios/prefs/Prefs.swift
@@ -21,6 +21,7 @@ fileprivate enum Key: String {
 	case recentPaymentsConfig
 	case hasMergedChannelsForSplicing
 	case swapInAddressIndex
+	case hasUpgradedSeedCloudBackups
 }
 
 fileprivate enum KeyDeprecated: String {
@@ -131,6 +132,11 @@ class Prefs {
 		set { defaults.hasMergedChannelsForSplicing = newValue }
 	}
 	
+	var hasUpgradedSeedCloudBackups: Bool {
+		get { defaults.hasUpgradedSeedCloudBackups }
+		set { defaults.hasUpgradedSeedCloudBackups = newValue }
+	}
+	
 	// --------------------------------------------------
 	// MARK: Wallet State
 	// --------------------------------------------------
@@ -214,6 +220,7 @@ class Prefs {
 		defaults.removeObject(forKey: Key.recentPaymentsConfig.rawValue)
 		defaults.removeObject(forKey: Key.hasMergedChannelsForSplicing.rawValue)
 		defaults.removeObject(forKey: Key.swapInAddressIndex.rawValue)
+		defaults.removeObject(forKey: Key.hasUpgradedSeedCloudBackups.rawValue)
 		
 		self.backupTransactions.resetWallet(encryptedNodeId: encryptedNodeId)
 		self.backupSeed.resetWallet(encryptedNodeId: encryptedNodeId)
@@ -312,5 +319,10 @@ extension UserDefaults {
 	@objc fileprivate var swapInAddressIndex: Int {
 		get { integer(forKey: Key.swapInAddressIndex.rawValue) }
 		set { set(newValue, forKey: Key.swapInAddressIndex.rawValue) }
+	}
+
+	@objc fileprivate var hasUpgradedSeedCloudBackups: Bool {
+		get { bool(forKey: Key.hasUpgradedSeedCloudBackups.rawValue) }
+		set { set(newValue, forKey: Key.hasUpgradedSeedCloudBackups.rawValue) }
 	}
 }

--- a/phoenix-ios/phoenix-ios/prefs/Prefs.swift
+++ b/phoenix-ios/phoenix-ios/prefs/Prefs.swift
@@ -22,6 +22,7 @@ fileprivate enum Key: String {
 	case hasMergedChannelsForSplicing
 	case swapInAddressIndex
 	case hasUpgradedSeedCloudBackups
+	case advancedDataProtectionEnabled
 }
 
 fileprivate enum KeyDeprecated: String {
@@ -137,6 +138,11 @@ class Prefs {
 		set { defaults.hasUpgradedSeedCloudBackups = newValue }
 	}
 	
+	var advancedDataProtectionEnabled: Bool {
+		get { defaults.advancedDataProtectionEnabled }
+		set { defaults.advancedDataProtectionEnabled = newValue }
+	}
+	
 	// --------------------------------------------------
 	// MARK: Wallet State
 	// --------------------------------------------------
@@ -221,6 +227,7 @@ class Prefs {
 		defaults.removeObject(forKey: Key.hasMergedChannelsForSplicing.rawValue)
 		defaults.removeObject(forKey: Key.swapInAddressIndex.rawValue)
 		defaults.removeObject(forKey: Key.hasUpgradedSeedCloudBackups.rawValue)
+		defaults.removeObject(forKey: Key.advancedDataProtectionEnabled.rawValue)
 		
 		self.backupTransactions.resetWallet(encryptedNodeId: encryptedNodeId)
 		self.backupSeed.resetWallet(encryptedNodeId: encryptedNodeId)
@@ -324,5 +331,10 @@ extension UserDefaults {
 	@objc fileprivate var hasUpgradedSeedCloudBackups: Bool {
 		get { bool(forKey: Key.hasUpgradedSeedCloudBackups.rawValue) }
 		set { set(newValue, forKey: Key.hasUpgradedSeedCloudBackups.rawValue) }
+	}
+	
+	@objc fileprivate var advancedDataProtectionEnabled: Bool {
+		get { bool(forKey: Key.advancedDataProtectionEnabled.rawValue) }
+		set { set(newValue, forKey: Key.advancedDataProtectionEnabled.rawValue) }
 	}
 }

--- a/phoenix-ios/phoenix-ios/prefs/Prefs.swift
+++ b/phoenix-ios/phoenix-ios/prefs/Prefs.swift
@@ -22,7 +22,6 @@ fileprivate enum Key: String {
 	case hasMergedChannelsForSplicing
 	case swapInAddressIndex
 	case hasUpgradedSeedCloudBackups
-	case advancedDataProtectionEnabled
 }
 
 fileprivate enum KeyDeprecated: String {
@@ -138,11 +137,6 @@ class Prefs {
 		set { defaults.hasUpgradedSeedCloudBackups = newValue }
 	}
 	
-	var advancedDataProtectionEnabled: Bool {
-		get { defaults.advancedDataProtectionEnabled }
-		set { defaults.advancedDataProtectionEnabled = newValue }
-	}
-	
 	// --------------------------------------------------
 	// MARK: Wallet State
 	// --------------------------------------------------
@@ -227,7 +221,6 @@ class Prefs {
 		defaults.removeObject(forKey: Key.hasMergedChannelsForSplicing.rawValue)
 		defaults.removeObject(forKey: Key.swapInAddressIndex.rawValue)
 		defaults.removeObject(forKey: Key.hasUpgradedSeedCloudBackups.rawValue)
-		defaults.removeObject(forKey: Key.advancedDataProtectionEnabled.rawValue)
 		
 		self.backupTransactions.resetWallet(encryptedNodeId: encryptedNodeId)
 		self.backupSeed.resetWallet(encryptedNodeId: encryptedNodeId)
@@ -331,10 +324,5 @@ extension UserDefaults {
 	@objc fileprivate var hasUpgradedSeedCloudBackups: Bool {
 		get { bool(forKey: Key.hasUpgradedSeedCloudBackups.rawValue) }
 		set { set(newValue, forKey: Key.hasUpgradedSeedCloudBackups.rawValue) }
-	}
-	
-	@objc fileprivate var advancedDataProtectionEnabled: Bool {
-		get { bool(forKey: Key.advancedDataProtectionEnabled.rawValue) }
-		set { set(newValue, forKey: Key.advancedDataProtectionEnabled.rawValue) }
 	}
 }

--- a/phoenix-ios/phoenix-ios/sync/SyncSeedManager.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncSeedManager.swift
@@ -73,6 +73,7 @@ class SyncSeedManager: SyncManagerProtcol {
 	private var consecutiveErrorCount = 0
 	
 	private var cancellables = Set<AnyCancellable>()
+	private var upgradeTask: Task<Void, Error>? = nil
 	
 	init(chain: Bitcoin_kmpChain, recoveryPhrase: RecoveryPhrase, encryptedNodeId: String) {
 		log.trace("init()")
@@ -89,6 +90,8 @@ class SyncSeedManager: SyncManagerProtcol {
 		
 		startPreferencesMonitor()
 		startNameMonitor()
+		
+		startUpgradeTask()
 	}
 	
 	// ----------------------------------------
@@ -188,6 +191,222 @@ class SyncSeedManager: SyncManagerProtcol {
 		} // </Task>
 		
 		return publisher
+	}
+	
+	// ----------------------------------------
+	// MARK: Upgrade Seeds
+	// ----------------------------------------
+	
+	private func startUpgradeTask() {
+		
+		let chain = self.chain
+		upgradeTask = Task { @MainActor in
+			
+			if Prefs.shared.hasUpgradedSeedCloudBackups {
+				return
+			}
+			
+			// Give priority to other tasks during app launch
+			try await Task.sleep(seconds: 4.0)
+			
+			let container = CKContainer.default()
+			let zoneID = CKRecordZone.default().zoneID
+			
+			let configuration = CKOperation.Configuration()
+			configuration.allowsCellularAccess = true
+			
+			// Step 1 of 2:
+			// Find all the records that need to be upgraded
+			
+			var needsUpgrade: [String: SeedBackup] = [:]
+			
+			var fetchDone = false
+			repeat {
+				do {
+					needsUpgrade = try await SyncSeedManager.upgradeSeeds_fetch(
+						container, zoneID, configuration, chain
+					)
+					fetchDone = true
+					
+				} catch {
+					log.debug("upgradeSeeds(): fetch.error = \(error)")
+					try await Task.sleep(hours: 4)
+				}
+			} while !fetchDone
+			
+			// Step 2 of 2:
+			// Upgrade all outdated records
+			
+			log.debug("upgradeSeeds(): \(needsUpgrade.count) upgrades needed")
+			
+			while let (recordName, seedBackup) = needsUpgrade.randomElement() {
+				do {
+					let didUpgrade = try await SyncSeedManager.upgradeSeeds_modify(
+						container, zoneID, configuration, chain, recordName, seedBackup
+					)
+					if didUpgrade {
+						needsUpgrade.removeValue(forKey: recordName)
+						log.debug("upgradeSeeds(): \(needsUpgrade.count) upgrades needed")
+					}
+					
+				} catch {
+					log.debug("upgradeSeeds(): modify.error = \(error)")
+					try await Task.sleep(hours: 4)
+				}
+			}
+			
+			log.debug("upgradeSeeds(): Done!")
+			Prefs.shared.hasUpgradedSeedCloudBackups = true
+		}
+	}
+	
+	private class func upgradeSeeds_fetch(
+		_ container: CKContainer,
+		_ zoneID: CKRecordZone.ID,
+		_ configuration: CKOperation.Configuration,
+		_ chain: Lightning_kmpNodeParams.Chain
+	) async throws -> [String: SeedBackup] {
+		
+		log.trace("upgradeSeeds_fetch()")
+		
+		return try await container.privateCloudDatabase.configuredWith(configuration: configuration) { database in
+				
+			log.debug("upgradeSeeds_fetch(): configured")
+			
+			let query = CKQuery(
+				recordType: record_table_name(chain: chain),
+				predicate: NSPredicate(format: "TRUEPREDICATE")
+			)
+			query.sortDescriptors = [
+				NSSortDescriptor(key: "creationDate", ascending: false)
+			]
+			
+			// ^ It would be more efficient if we could query for "mnemonics_deprecated != nil",
+			//   but that would require adding an index on a deprecated property.
+			//   I don't think that's worth it, especially when most users have very few backups.
+			
+			var needsUpgrade: [String: SeedBackup] = [:]
+			
+			var done = false
+			var cursor: CKQueryOperation.Cursor? = nil
+			
+			while !done {
+				do {
+					
+					log.debug("upgradeSeeds_fetch(): sending query...")
+					
+					let results: [(CKRecord.ID, Result<CKRecord, Error>)]
+					if let prvCursor = cursor {
+						(results, cursor) = try await database.records(continuingMatchFrom: prvCursor)
+					} else {
+						(results, cursor) = try await database.records(matching: query, inZoneWith: zoneID)
+					}
+					
+					for (recordID, result) in results {
+						
+						if case .success(let record) = result {
+							
+							if let mnemonics = record[record_column_mnemonics_deprecated] as? String,
+								let name = record[record_column_name] as? String?,
+								let language = record[record_column_language] as? String
+							{
+								let item = SeedBackup(
+									recordID: recordID,
+									created: record.creationDate ?? Date.distantPast,
+									name: name,
+									language: language,
+									mnemonics: mnemonics
+								)
+								
+								needsUpgrade[recordID.recordName] = item
+							}
+						}
+					}
+					
+					if cursor == nil {
+						log.debug("upgradeSeeds_fetch(): moreInCloud = false")
+						done = true
+						
+					} else {
+						log.debug("upgradeSeeds_fetch(): moreInCloud = true")
+					}
+					
+				} catch {
+					
+					if let ckerror = error as? CKError,
+						let retryAfterSeconds = ckerror.retryAfterSeconds,
+						(ckerror.code == CKError.Code.requestRateLimited || ckerror.code == CKError.Code.zoneBusy)
+					{
+						log.debug("upgradeSeeds_fetch(): CKError.retryAfterSeconds = \(retryAfterSeconds)")
+						try await Task.sleep(seconds: retryAfterSeconds)
+						
+					} else {
+						throw error
+					}
+				}
+				
+			} // </while !done>
+			
+			return needsUpgrade
+		} // </configuredWith>
+	}
+	
+	private class func upgradeSeeds_modify(
+		_ container: CKContainer,
+		_ zoneID: CKRecordZone.ID,
+		_ configuration: CKOperation.Configuration,
+		_ chain: Lightning_kmpNodeParams.Chain,
+		_ recordName: String,
+		_ seedBackup: SeedBackup
+	) async throws -> Bool {
+		
+		log.trace("upgradeSeeds_modify()")
+		
+		return try await container.privateCloudDatabase.configuredWith(configuration: configuration) { database in
+			do {
+				log.debug("upgradeSeeds_modify(): sending query...")
+				
+				let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
+				let record = CKRecord(
+					recordType: SyncSeedManager.record_table_name(chain: chain),
+					recordID: recordID
+				)
+				
+				record[record_column_name] = seedBackup.name ?? ""
+				record[record_column_language] = seedBackup.language
+				record.encryptedValues[record_column_mnemonics_encrypted] = seedBackup.mnemonics
+				
+				let (saveResults, _) = try await database.modifyRecords(
+					saving: [record],
+					deleting: [],
+					savePolicy: .changedKeys
+				)
+				
+				let result = saveResults[recordID]!
+				
+				if case let .failure(error) = result {
+					log.debug("upgradeSeeds_modify(): perRecordResult: failure")
+					throw error
+				} else {
+					log.debug("upgradeSeeds_modify(): perRecordResult: success")
+					return true
+				}
+				
+			} catch {
+				
+				if let ckerror = error as? CKError,
+					let retryAfterSeconds = ckerror.retryAfterSeconds,
+					(ckerror.code == CKError.Code.requestRateLimited || ckerror.code == CKError.Code.zoneBusy)
+				{
+					log.debug("upgradeSeeds_modify(): CKError.retryAfterSeconds = \(retryAfterSeconds)")
+					try await Task.sleep(seconds: retryAfterSeconds)
+					return false
+					
+				} else {
+					throw error
+				}
+			}
+		} // </configuredWith>
 	}
 	
 	// ----------------------------------------
@@ -309,6 +528,8 @@ class SyncSeedManager: SyncManagerProtcol {
 		}
 		
 		cancellables.removeAll()
+		upgradeTask?.cancel()
+		upgradeTask = nil
 	}
 	
 	// ----------------------------------------

--- a/phoenix-ios/phoenix-ios/sync/SyncSeedManager.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncSeedManager.swift
@@ -264,7 +264,7 @@ class SyncSeedManager: SyncManagerProtcol {
 		_ container: CKContainer,
 		_ zoneID: CKRecordZone.ID,
 		_ configuration: CKOperation.Configuration,
-		_ chain: Lightning_kmpNodeParams.Chain
+		_ chain: Bitcoin_kmpChain
 	) async throws -> [String: SeedBackup] {
 		
 		log.trace("upgradeSeeds_fetch()")
@@ -355,7 +355,7 @@ class SyncSeedManager: SyncManagerProtcol {
 		_ container: CKContainer,
 		_ zoneID: CKRecordZone.ID,
 		_ configuration: CKOperation.Configuration,
-		_ chain: Lightning_kmpNodeParams.Chain,
+		_ chain: Bitcoin_kmpChain,
 		_ recordName: String,
 		_ seedBackup: SeedBackup
 	) async throws -> Bool {


### PR DESCRIPTION
Apple recently added end-to-end encrypted data for iCloud via [Advanced Data Protection](https://support.apple.com/guide/security/advanced-data-protection-for-icloud-sec973254c5f/web):

<img height="500" src="https://github.com/ACINQ/phoenix/assets/304604/bd11c073-ec66-4b4a-a074-571cf86daa19"/>

<br/><br/>
When I first heard about this, I was under the impression that **ALL** iCloud data would be encrypted E2E (except mail, calendar & contacts). However, this is false. When enabled, all of Apple's **own** apps get E2E protection, but 3rd party apps ... **nope**! They have to opt-in themselves:

> Advanced Data Protection also automatically protects CloudKit fields that third-party developers choose to mark as encrypted, and all CloudKit assets.

> CloudKit Record fields must be explicitly declared as “encrypted” in the container’s schema to be protected, and reading and writing encrypted fields requires the use of dedicated [APIs](https://developer.apple.com/documentation/cloudkit/ckrecord/3746821-encryptedvalues).

So with this PR, we are opting in.

### Ramifications

Advanced data protection is not enabled by default. It's opt-in, and it's a relatively hidden setting. To enable it requires the user to setup either a "recovery key" or "recovery contact".

The recovery key option is similar to backing up a bitcoin seed. The user is given a 28-character hexadecimal string, and are told they're responsible for saving it.

The recovery contact option allows them to choose 1 or more trusted contacts:

> A recovery contact can generate a code from their Apple device to help you get your data back.

The user can pick multiple options (e.g. recovery key plus multiple recovery contacts).

But throughout the setup process, the user is regularly reminded about data loss.

![advancedDataProtection-iOS](https://github.com/ACINQ/phoenix/assets/304604/c59749a5-80f1-49aa-aea9-0b5a2e244f5d)

So if the user loses access to their Apple account, and they lose all their recovery options, then they've basically lost all their iCloud data (photos, files, notes, etc).

Apple can help the user regain access to their account, but only the non-encrypted data would be available. Such as email, calendar, contacts ... and unencrypted CloudKit records. 

In my opinion, if a user explicitly enables "advanced data protection", they would probably assume that an iCloud backup of their recovery phrase (via Phoenix, or any other wallet) would be E2E encrypted. They might be wrong. But they would be excused for believing so, because most people do.

_In fact, if you watch any tutorial on setting up Advanced Data Protection, most people say something like "all your iCloud data is E2E encrypted, except mail, calendar & contacts." ([example](https://www.youtube.com/watch?v=HxoAwnRFwJ0)) So the confusion is common._

For this reason (and others) I think the responsible choice is to opt-in to E2E encryption.

### Technical notes

The record we're now backing up in the cloud looks like this:

```json
{
  "name": "Optional backup name user can enter",
  "language": "en",
  "encrypted": {
    "mnemonics": "indoor fox shiver ..."
  }
}
```

In other words, in it's current state, this PR encrypts just the recovery phrase, and not the other metadata. Requesting feedback about this.