### PR TITLE
iOS fixes for v2.0.8

### DIFF
--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -8230,6 +8230,12 @@
         }
       }
     },
+    "Feerate below minimum allowed by mempool: %@" : {
+
+    },
+    "Feerate below minimum allowed by mempool." : {
+
+    },
     "Fees" : {
       "comment" : "Label in SummaryInfoGrid",
       "localizations" : {

--- a/phoenix-ios/phoenix-ios/views/inspect/CpfpView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/CpfpView.swift
@@ -638,7 +638,7 @@ struct CpfpView: View {
 		
 		Task { @MainActor in
 			
-			var pair: KotlinPair<Lightning_kmpFeeratePerKw, Bitcoin_kmpSatoshi>? = nil
+			var pair: KotlinPair<Lightning_kmpFeeratePerKw, Lightning_kmpChannelCommand.CommitmentSpliceFees>? = nil
 			do {
 				pair = try await peer.estimateFeeForSpliceCpfp(
 					channelId: onChainPayment.channelId,
@@ -658,7 +658,8 @@ struct CpfpView: View {
 				let cpfpFeeratePerKw: Lightning_kmpFeeratePerKw = pair.first!
 				let cpfpFeerate = Lightning_kmpFeeratePerByte(feeratePerKw: cpfpFeeratePerKw)
 				
-				let minerFee: Bitcoin_kmpSatoshi = pair.second!
+				let spliceFees: Lightning_kmpChannelCommand.CommitmentSpliceFees = pair.second!
+				let minerFee: Bitcoin_kmpSatoshi = spliceFees.miningFee
 					
 				// From the docs (in lightning-kmp):
 				//

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
@@ -324,7 +324,7 @@ struct SummaryView: View {
 					}
 				} // </confirmationDialog>
 				
-				if confirmations == 0 {
+				if confirmations == 0 && supportsBumpFee(onChainPayment) {
 					NavigationLink(destination: cpfpView(onChainPayment)) {
 						Label {
 							Text("Accelerate transaction")
@@ -648,6 +648,15 @@ struct SummaryView: View {
 			return location
 		case .embedded(_):
 			return .embedded(popTo: popToWrapper)
+		}
+	}
+	
+	func supportsBumpFee(_ onChainPayment: Lightning_kmpOnChainOutgoingPayment) -> Bool {
+		
+		switch onChainPayment {
+			case is Lightning_kmpSpliceOutgoingPayment     : return true
+			case is Lightning_kmpSpliceCpfpOutgoingPayment : return true
+			default                                        : return false
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/send/MinerFeeSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/send/MinerFeeSheet.swift
@@ -467,13 +467,13 @@ struct MinerFeeSheet: View {
 				
 				if let pair = pair,
 				   let updatedFeePerKw: Lightning_kmpFeeratePerKw = pair.first,
-				   let fee: Bitcoin_kmpSatoshi = pair.second
+				   let fees: Lightning_kmpChannelCommand.CommitmentSpliceFees = pair.second
 				{
 					if self.satsPerByte == originalSatsPerByte {
 						self.minerFeeInfo = MinerFeeInfo(
 							pubKeyScript: scriptVector,
 							feerate: updatedFeePerKw,
-							minerFee: fee
+							minerFee: fees.miningFee
 						)
 					}
 				} else {

--- a/phoenix-ios/phoenix-ios/views/send/MinerFeeSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/send/MinerFeeSheet.swift
@@ -24,6 +24,7 @@ struct MinerFeeSheet: View {
 	@Binding var mempoolRecommendedResponse: MempoolRecommendedResponse?
 	
 	@State var explicitlySelectedPriority: MinerFeePriority? = nil
+	@State var feeBelowMinimum: Bool = false
 	
 	@Environment(\.colorScheme) var colorScheme: ColorScheme
 	@EnvironmentObject var smartModalState: SmartModalState
@@ -296,8 +297,8 @@ struct MinerFeeSheet: View {
 	@ViewBuilder
 	func footer() -> some View {
 		
-		HStack(alignment: VerticalAlignment.center, spacing: 0) {
-			Spacer()
+		VStack(alignment: HorizontalAlignment.center, spacing: 10) {
+			
 			Button {
 				reviewTransactionButtonTapped()
 			} label: {
@@ -305,7 +306,19 @@ struct MinerFeeSheet: View {
 			}
 			.font(.title3)
 			.disabled(minerFeeInfo == nil)
-			Spacer()
+			
+			if feeBelowMinimum {
+				Group {
+					if let mrr = mempoolRecommendedResponse {
+						Text("Feerate below minimum allowed by mempool: \(satsPerByteString(mrr.minimumFee))")
+					} else {
+						Text("Feerate below minimum allowed by mempool.")
+					}
+				}
+				.font(.callout)
+				.foregroundColor(.appNegative)
+				.multilineTextAlignment(.center)
+			}
 		}
 		.padding()
 		.padding(.top)
@@ -348,15 +361,19 @@ struct MinerFeeSheet: View {
 		}
 		
 		let doubleValue = mempoolRecommendedResponse.feeForPriority(priority)
-			
+		let stringValue = satsPerByteString(doubleValue)
+		
+		return (doubleValue, stringValue)
+	}
+	
+	func satsPerByteString(_ value: Double) -> String {
+		
 		let nf = NumberFormatter()
 		nf.numberStyle = .decimal
 		nf.minimumFractionDigits = 0
 		nf.maximumFractionDigits = 1
 		
-		let stringValue = nf.string(from: NSNumber(value: doubleValue)) ?? "?"
-		
-		return (doubleValue, stringValue)
+		return nf.string(from: NSNumber(value: value)) ?? "?"
 	}
 	
 	func satsPerByteString(_ priority: MinerFeePriority) -> String {
@@ -440,13 +457,20 @@ struct MinerFeeSheet: View {
 	func satsPerByteChanged() {
 		log.trace("satsPerByteChanged(): \(satsPerByte)")
 		
+		minerFeeInfo = nil
 		guard
 			let satsPerByte_number = try? parsedSatsPerByte.get(),
 			let peer = Biz.business.peerManager.peerStateValue(),
 			let scriptBytes = Parser.shared.addressToPublicKeyScript(chain: Biz.business.chain, address: btcAddress)
 		else {
-			minerFeeInfo = nil
 			return
+		}
+		
+		if let mrr = mempoolRecommendedResponse, mrr.minimumFee > satsPerByte_number.doubleValue {
+			feeBelowMinimum = true
+			return
+		} else {
+			feeBelowMinimum = false
 		}
 		
 		let originalSatsPerByte = satsPerByte
@@ -456,7 +480,6 @@ struct MinerFeeSheet: View {
 		let feePerByte = Lightning_kmpFeeratePerByte(feerate: satsPerByte_satoshi)
 		let feePerKw = Lightning_kmpFeeratePerKw(feeratePerByte: feePerByte)
 		
-		minerFeeInfo = nil
 		Task { @MainActor in
 			do {
 				let pair = try await peer.estimateFeeForSpliceOut(
@@ -492,6 +515,9 @@ struct MinerFeeSheet: View {
 		
 		// The UI will change, so we need to reset the geometry measurements
 		priorityBoxWidth = nil
+		
+		// Might need to display an error (if minimumFee increased)
+		satsPerByteChanged()
 	}
 	
 	func closeButtonTapped() {


### PR DESCRIPTION
This PR includes 3 fixes:

1) update the calls to `estimateFeeForSpliceOut` and `estimateFeeForSpliceCpfp` which changed with liquidity ads.
2) a fix for issue #488 
3) prevent the user from entering a fee lower than the minimumFee when doing a splice-out/cpfp


For issue 488, the "Accelerate transaction" button is no longer available for channel-closing operations:

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/56116a2b-7110-4468-9991-1cebb9b961f4"/>

but is still available for normal operations, such as a splice-out:

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/678811aa-17f8-42e7-800d-8187f2ef4a91"/>

And the additional checks for the miner fees look like this:

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/30660015-bdd0-47f8-b8cc-80c4fc882ba1"/>

<img height="450" src="https://github.com/ACINQ/phoenix/assets/304604/5fc6c652-3988-4f1d-81bf-68e16755cc45"/>



