### PR TITLE
 Add warning when splicing-out with low feerate 

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/FeerateSlider.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/FeerateSlider.kt
@@ -75,16 +75,13 @@ fun FeerateSlider(
                         Text(text = stringResource(id = R.string.mempool_fastest), maxLines = 1)
                     }
                     feerate >= mempoolFeerate.halfHour.feerate -> {
-                        Text(text = stringResource(id = R.string.mempool_halfhour))
+                        Text(text = stringResource(id = R.string.mempool_halfhour), maxLines = 1)
                     }
                     feerate >= mempoolFeerate.hour.feerate -> {
-                        Text(text = stringResource(id = R.string.mempool_hour))
-                    }
-                    feerate >= mempoolFeerate.economy.feerate -> {
-                        Text(text = stringResource(id = R.string.mempool_eco))
+                        Text(text = stringResource(id = R.string.mempool_hour), maxLines = 1)
                     }
                     else -> {
-                        TextWithIcon(text = stringResource(id = R.string.mempool_slow), icon = R.drawable.ic_alert_triangle, iconTint = MaterialTheme.colors.onSurface, space = 4.dp)
+                        TextWithIcon(text = stringResource(id = R.string.mempool_slow), icon = R.drawable.ic_alert_triangle, iconTint = MaterialTheme.colors.onSurface, space = 4.dp, maxLines = 1)
                     }
                 }
             }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/ScanDataView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/ScanDataView.kt
@@ -54,6 +54,7 @@ import fr.acinq.phoenix.android.components.*
 import fr.acinq.phoenix.android.components.mvi.MVIControllerViewModel
 import fr.acinq.phoenix.android.components.mvi.MVIView
 import fr.acinq.phoenix.android.databinding.ScanViewBinding
+import fr.acinq.phoenix.android.payments.spliceout.SendSpliceOutView
 import fr.acinq.phoenix.android.utils.*
 import fr.acinq.phoenix.controllers.ControllerFactory
 import fr.acinq.phoenix.controllers.ScanController

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/cpfp/CpfpView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/cpfp/CpfpView.kt
@@ -50,7 +50,7 @@ import fr.acinq.phoenix.android.components.ProgressView
 import fr.acinq.phoenix.android.components.SplashLabelRow
 import fr.acinq.phoenix.android.components.TextWithIcon
 import fr.acinq.phoenix.android.components.feedback.ErrorMessage
-import fr.acinq.phoenix.android.payments.spliceFailureDetails
+import fr.acinq.phoenix.android.payments.spliceout.spliceFailureDetails
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 import fr.acinq.phoenix.android.utils.annotatedStringResource
 import fr.acinq.phoenix.android.utils.logger

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/liquidity/RequestLiquidityView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/liquidity/RequestLiquidityView.kt
@@ -66,7 +66,7 @@ import fr.acinq.phoenix.android.components.SplashLayout
 import fr.acinq.phoenix.android.components.feedback.ErrorMessage
 import fr.acinq.phoenix.android.components.feedback.InfoMessage
 import fr.acinq.phoenix.android.components.feedback.SuccessMessage
-import fr.acinq.phoenix.android.payments.spliceFailureDetails
+import fr.acinq.phoenix.android.payments.spliceout.spliceFailureDetails
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 
 object LiquidityLimits {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/NodeService.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/NodeService.kt
@@ -87,7 +87,7 @@ class NodeService : Service() {
     private fun refreshFcmToken() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
             if (!task.isSuccessful) {
-                log.warn("fetching FCM registration token failed: ${task.exception}")
+                log.warn("fetching FCM registration token failed: ${task.exception?.localizedMessage}")
                 return@OnCompleteListener
             }
             task.result?.let { serviceScope.launch { internalData.saveFcmToken(it) } }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/NodeService.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/NodeService.kt
@@ -87,7 +87,7 @@ class NodeService : Service() {
     private fun refreshFcmToken() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
             if (!task.isSuccessful) {
-                log.warn("fetching FCM registration token failed: ", task.exception)
+                log.warn("fetching FCM registration token failed: ${task.exception}")
                 return@OnCompleteListener
             }
             task.result?.let { serviceScope.launch { internalData.saveFcmToken(it) } }

--- a/phoenix-android/src/main/res/values-b+es+419/important_strings.xml
+++ b/phoenix-android/src/main/res/values-b+es+419/important_strings.xml
@@ -345,4 +345,11 @@
     <string name="outgoing_finalfailure_alreadypaid">Esta factura ya ha sido pagada.</string>
     <string name="outgoing_finalfailure_noroutefound">El destinatario no está localizable o no tiene suficiente liquidez entrante.</string>
 
+    <!-- low feerate disclaimer -->
+
+    <string name="send_low_feerate_dialog_title">¡Baja comisión!</string>
+    <string name="send_low_feerate_dialog_body1">Los pagos con comisiones bajas pueden pasar días o semanas sin confirmarse.</string>
+    <string name="send_low_feerate_dialog_body2">La selección de comisiones es su responsabilidad. Una vez enviado, este pago no puede ser cancelado, sólo acelerado con comisiones más altas.</string>
+    <string name="send_low_feerate_dialog_body3">¿Está seguro de que desea continuar?</string>
+
 </resources>

--- a/phoenix-android/src/main/res/values-b+es+419/strings.xml
+++ b/phoenix-android/src/main/res/values-b+es+419/strings.xml
@@ -693,8 +693,7 @@
     <string name="mempool_fastest">≈ Próximo bloque</string>
     <string name="mempool_halfhour">≈ 30 minutos</string>
     <string name="mempool_hour">≈ 1 hora</string>
-    <string name="mempool_eco">Más de 1 hora</string>
-    <string name="mempool_slow">Sin prioridad</string>
+    <string name="mempool_slow">Baja comisión</string>
 
     <!-- splice errors -->
 

--- a/phoenix-android/src/main/res/values-cs/important_strings.xml
+++ b/phoenix-android/src/main/res/values-cs/important_strings.xml
@@ -357,4 +357,11 @@
     <string name="outgoing_finalfailure_alreadypaid">Tato platba již byla uhrazena.</string>
     <string name="outgoing_finalfailure_noroutefound">Příjemce není dosažitelný nebo nemá dostatečnou příchozí likviditu.</string>
 
+    <!-- low feerate disclaimer -->
+
+    <string name="send_low_feerate_dialog_title">Nízké poplatky!</string>
+    <string name="send_low_feerate_dialog_body1">Platby za nízké poplatky mohou trvat několik dní nebo týdnů bez potvrzení.</string>
+    <string name="send_low_feerate_dialog_body2">Výběr poplatků je na vaši zodpovědnost. Po odeslání nelze tuto platbu zrušit, pouze urychlit vyššími poplatky.</string>
+    <string name="send_low_feerate_dialog_body3">Jste si jisti, že chcete pokračovat?</string>
+
 </resources>

--- a/phoenix-android/src/main/res/values-cs/strings.xml
+++ b/phoenix-android/src/main/res/values-cs/strings.xml
@@ -652,8 +652,7 @@
     <string name="mempool_fastest">≈ Další blok</string>
     <string name="mempool_halfhour">≈ 30 minut</string>
     <string name="mempool_hour">≈ 1 hodina</string>
-    <string name="mempool_eco">Více než 1 hodina</string>
-    <string name="mempool_slow">Bez priority</string>
+    <string name="mempool_slow">Nízký poplatek</string>
 
     <!-- splice errors -->
 

--- a/phoenix-android/src/main/res/values-de/important_strings.xml
+++ b/phoenix-android/src/main/res/values-de/important_strings.xml
@@ -358,4 +358,11 @@
     <string name="outgoing_finalfailure_alreadypaid">Diese Zahlung wurde bereits getätigt.</string>
     <string name="outgoing_finalfailure_noroutefound">Der Empfänger ist nicht erreichbar oder hat nicht genügend Liquidität im Eingang.</string>
 
+    <!-- low feerate disclaimer -->
+
+    <string name="send_low_feerate_dialog_title">Niedrige Gebühren!</string>
+    <string name="send_low_feerate_dialog_body1">Zahlungen mit niedrigen Gebühren können sich über Tage oder Wochen hinziehen, ohne bestätigt zu werden.</string>
+    <string name="send_low_feerate_dialog_body2">Die Auswahl der Gebühren liegt in Ihrer Verantwortung. Einmal abgeschickt, kann diese Zahlung nicht mehr storniert, sondern nur noch mit höheren Gebühren beschleunigt werden.</string>
+    <string name="send_low_feerate_dialog_body3">Sind Sie sicher, dass Sie fortfahren möchten?</string>
+
 </resources>

--- a/phoenix-android/src/main/res/values-de/strings.xml
+++ b/phoenix-android/src/main/res/values-de/strings.xml
@@ -640,8 +640,7 @@
     <string name="mempool_fastest">≈ Nächster Block</string>
     <string name="mempool_halfhour">≈ 30 Minuten</string>
     <string name="mempool_hour">≈ 1 Stunde</string>
-    <string name="mempool_eco">Mehr als 1 Stunde</string>
-    <string name="mempool_slow">Keine Priorität</string>
+    <string name="mempool_slow">Niedrige Gebührenrate</string>
 
     <!-- splice errors -->
 

--- a/phoenix-android/src/main/res/values-es/important_strings.xml
+++ b/phoenix-android/src/main/res/values-es/important_strings.xml
@@ -357,4 +357,11 @@
     <string name="outgoing_finalfailure_alreadypaid">Esta factura ya ha sido pagada.</string>
     <string name="outgoing_finalfailure_noroutefound">El destinatario no está localizable o no tiene suficiente liquidez entrante.</string>
 
+    <!-- low feerate disclaimer -->
+
+    <string name="send_low_feerate_dialog_title">¡Baja tasa!</string>
+    <string name="send_low_feerate_dialog_body1">Los pagos con tasas bajas pueden pasar días o semanas sin confirmarse.</string>
+    <string name="send_low_feerate_dialog_body2">La selección de comisiones es su responsabilidad. Una vez enviado, este pago no puede ser cancelado, sólo acelerado con tasas más altas.</string>
+    <string name="send_low_feerate_dialog_body3">¿Está seguro de que desea continuar?</string>
+
 </resources>

--- a/phoenix-android/src/main/res/values-fr/important_strings.xml
+++ b/phoenix-android/src/main/res/values-fr/important_strings.xml
@@ -357,4 +357,11 @@
     <string name="outgoing_finalfailure_alreadypaid">Ce paiement a déjà été réglé.</string>
     <string name="outgoing_finalfailure_noroutefound">Le destinataire de ce paiement n\'est pas joignable, ou bien ne dispose pas de suffisamment de liquidité entrante.</string>
 
+    <!-- low feerate disclaimer -->
+
+    <string name="send_low_feerate_dialog_title">Frais faibles!</string>
+    <string name="send_low_feerate_dialog_body1">Les transactions utilisant des frais trop faibles peuvent rester en attente de confirmation pendant des jours, voire des semaines.</string>
+    <string name="send_low_feerate_dialog_body2">Le choix des frais est de votre responsabilité. Une fois envoyé, ce paiement ne pourra pas être annulé, seulement accéléré en utilisant des frais plus élevés.</string>
+    <string name="send_low_feerate_dialog_body3">Êtes-vous sûr de vouloir continuer ?</string>
+
 </resources>

--- a/phoenix-android/src/main/res/values-fr/strings.xml
+++ b/phoenix-android/src/main/res/values-fr/strings.xml
@@ -420,4 +420,13 @@
     <string name="accessctrl_screen_lock_switch">Verrouillage écran</string>
     <string name="accessctrl_screen_lock_switch_desc">Contrôle l\'accès à l\'application via le système de verrouillage système d\'Android.</string>
 
+    <!-- mempool -->
+
+    <string name="mempool_unknown_feerate_title">Frais mempool introuvables</string>
+    <string name="mempool_unknown_feerate_details">Phoenix n\'a pas pu vérifier l\'état actuel du mempool Bitcoin, et ne peut donc pas estimer la rapidité des transactions.\n\nVérifiez le mempool manuellement via un explorateur, et utilisez une valeur pertinente.</string>
+    <string name="mempool_fastest">≈ 10 minutes</string>
+    <string name="mempool_halfhour">≈ 30 minutes</string>`
+    <string name="mempool_hour">≈ 1 heure</string>
+    <string name="mempool_slow">Frais bas</string>
+
 </resources>

--- a/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
+++ b/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
@@ -358,4 +358,11 @@
     <string name="outgoing_finalfailure_alreadypaid">Este pagamento já foi pago.</string>
     <string name="outgoing_finalfailure_noroutefound">O destinatário não está contactável ou não tem liquidez de entrada suficiente.</string>
 
+    <!-- low feerate disclaimer -->
+
+    <string name="send_low_feerate_dialog_title">Taxas baixas!</string>
+    <string name="send_low_feerate_dialog_body1">Os pagamentos com taxas baixas podem permanecer por dias ou semanas sem confirmação.</string>
+    <string name="send_low_feerate_dialog_body2">É sua responsabilidade selecionar a taxa. Uma vez enviado, esse pagamento não pode ser cancelado, somente acelerado com taxas mais altas.</string>
+    <string name="send_low_feerate_dialog_body3">Tem certeza de que deseja prosseguir?</string>
+
 </resources>

--- a/phoenix-android/src/main/res/values/important_strings.xml
+++ b/phoenix-android/src/main/res/values/important_strings.xml
@@ -358,4 +358,11 @@
     <string name="outgoing_finalfailure_alreadypaid">This invoice has already been paid.</string>
     <string name="outgoing_finalfailure_noroutefound">Recipient is not reachable, or does not have enough inbound liquidity.</string>
 
+    <!-- low feerate disclaimer -->
+
+    <string name="send_low_feerate_dialog_title">Low feerate!</string>
+    <string name="send_low_feerate_dialog_body1">Transactions with insufficient feerate may linger for days or weeks without confirming.</string>
+    <string name="send_low_feerate_dialog_body2">Choosing the feerate is your responsibility. Once sent, this transaction cannot be cancelled, only accelerated with higher fees.</string>
+    <string name="send_low_feerate_dialog_body3">Are you sure you want to proceed?</string>
+
 </resources>

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -714,11 +714,10 @@
 
     <string name="mempool_unknown_feerate_title">Unknown mempool state</string>
     <string name="mempool_unknown_feerate_details">Phoenix was unable to retrieve the current state of the mempool and cannot estimate the speed of your transactions.\n\nCheck the mempool manually on an explorer, and use a adequate value!</string>
-    <string name="mempool_fastest">≈ Next block</string>
-    <string name="mempool_halfhour">≈ 30 minutes</string>
+    <string name="mempool_fastest">≈ 10 minutes</string>
+    <string name="mempool_halfhour">≈ 30 minutes</string>`
     <string name="mempool_hour">≈ 1 hour</string>
-    <string name="mempool_eco">More than 1 hour</string>
-    <string name="mempool_slow">No priority</string>
+    <string name="mempool_slow">Low feerate</string>
 
     <!-- splice errors -->
 

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -14653,6 +14653,9 @@
         }
       }
     },
+    "Low feerate!" : {
+
+    },
     "Low Priority" : {
       "localizations" : {
         "cs" : {
@@ -25232,6 +25235,9 @@
           }
         }
       }
+    },
+    "Transactions with insufficient feerate may linger for days or weeks without confirming.\n\nChoosing the feerate is your responsibility. Once sent, this transaction cannot be cancelled, only accelerated with higer fees.\n\nAre you sure you want to proceed?" : {
+
     },
     "Trust certificate & pin public key" : {
       "localizations" : {

--- a/phoenix-ios/phoenix-ios/views/content/ContentView.swift
+++ b/phoenix-ios/phoenix-ios/views/content/ContentView.swift
@@ -40,14 +40,14 @@ struct ContentView: View {
 					.accessibilityHidden(shortSheetItem != nil || popoverItem != nil)
 
 				if let shortSheetItem = shortSheetItem {
-					ShortSheetWrapper(dismissable: shortSheetItem.dismissable) {
+					ShortSheetWrapper(dismissable: shortSheetState.dismissable) {
 						shortSheetItem.view
 					}
 					.zIndex(1) // needed for proper animation
 				}
 
 				if let popoverItem = popoverItem {
-					PopoverWrapper(dismissable: popoverItem.dismissable) {
+					PopoverWrapper(dismissable: popoverState.dismissable) {
 						popoverItem.view
 					}
 					.zIndex(2) // needed for proper animation
@@ -70,12 +70,12 @@ struct ContentView: View {
 		.onReceive(Prefs.shared.hasMergedChannelsForSplicingPublisher) { (newValue: Bool) in
 			hasMergedChannelsForSplicing = newValue
 		}
-		.onReceive(shortSheetState.publisher) { (item: ShortSheetItem?) in
+		.onReceive(shortSheetState.itemPublisher) { (item: ShortSheetItem?) in
 			withAnimation {
 				shortSheetItem = item
 			}
 		}
-		.onReceive(popoverState.publisher) { (item: PopoverItem?) in
+		.onReceive(popoverState.itemPublisher) { (item: PopoverItem?) in
 			withAnimation {
 				popoverItem = item
 			}

--- a/phoenix-ios/phoenix-ios/views/inspect/PaymentView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/PaymentView.swift
@@ -67,26 +67,26 @@ fileprivate struct PaymentViewSheet: View {
 			.accessibilityHidden(shortSheetItem != nil || popoverItem != nil)
 			
 			if let shortSheetItem = shortSheetItem {
-				ShortSheetWrapper(dismissable: shortSheetItem.dismissable) {
+				ShortSheetWrapper(dismissable: shortSheetState.dismissable) {
 					shortSheetItem.view
 				}
 				.zIndex(1) // needed for proper animation
 			}
 			
 			if let popoverItem = popoverItem {
-				PopoverWrapper(dismissable: popoverItem.dismissable) {
+				PopoverWrapper(dismissable: popoverState.dismissable) {
 					popoverItem.view
 				}
 				.zIndex(2) // needed for proper animation
 			}
 			
 		} // </ZStack>
-		.onReceive(shortSheetState.publisher) { (item: ShortSheetItem?) in
+		.onReceive(shortSheetState.itemPublisher) { (item: ShortSheetItem?) in
 			withAnimation {
 				shortSheetItem = item
 			}
 		}
-		.onReceive(popoverState.publisher) { (item: PopoverItem?) in
+		.onReceive(popoverState.itemPublisher) { (item: PopoverItem?) in
 			withAnimation {
 				popoverItem = item
 			}

--- a/phoenix-ios/phoenix-ios/views/layers/SmartModal.swift
+++ b/phoenix-ios/phoenix-ios/views/layers/SmartModal.swift
@@ -36,11 +36,27 @@ public class SmartModalState: ObservableObject {
 	}
 	
 	var currentItem: SmartModalItem? {
-		
 		if isIPad {
-			return popoverState.publisher.value
+			return popoverState.currentItem
 		} else {
-			return shortSheetState.publisher.value
+			return shortSheetState.currentItem
+		}
+	}
+	
+	var dismissable: Bool {
+		get {
+			if isIPad {
+				return popoverState.dismissable
+			} else {
+				return shortSheetState.dismissable
+			}
+		}
+		set {
+			if isIPad {
+				popoverState.dismissable = newValue
+			} else {
+				shortSheetState.dismissable = newValue
+			}
 		}
 	}
 	
@@ -97,8 +113,4 @@ public class SmartModalState: ObservableObject {
 	}
 }
 
-protocol SmartModalItem {
-	
-	/// Whether or not the item is dimissable by tapping outside the item's view.
-	var dismissable: Bool { get }
-}
+protocol SmartModalItem {}

--- a/phoenix-ios/phoenix-ios/views/send/CommentSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/send/CommentSheet.swift
@@ -51,7 +51,7 @@ struct CommentSheet: View {
 						.frame(width: 30, height: 30)
 				}
 				.accessibilityLabel("Close")
-				.accessibilityHidden(smartModalState.currentItem?.dismissable ?? false)
+				.accessibilityHidden(smartModalState.dismissable)
 			}
 			.padding(.horizontal)
 			.padding(.vertical, 8)

--- a/phoenix-ios/phoenix-ios/views/send/LnurlFlowErrorNotice.swift
+++ b/phoenix-ios/phoenix-ios/views/send/LnurlFlowErrorNotice.swift
@@ -46,7 +46,7 @@ struct LnurlFlowErrorNotice: View {
 						.frame(width: 30, height: 30)
 				}
 				.accessibilityLabel("Close")
-				.accessibilityHidden(popoverState.publisher.value?.dismissable ?? false)
+				.accessibilityHidden(popoverState.dismissable)
 			}
 			.padding(.horizontal)
 			.padding(.vertical, 8)

--- a/phoenix-ios/phoenix-ios/views/send/MetadataSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/send/MetadataSheet.swift
@@ -37,7 +37,7 @@ struct MetadataSheet: View {
 						.frame(width: 30, height: 30)
 				}
 				.accessibilityLabel("Close")
-				.accessibilityHidden(smartModalState.currentItem?.dismissable ?? false)
+				.accessibilityHidden(smartModalState.dismissable)
 			}
 			.padding(.horizontal)
 			.padding(.vertical, 8)

--- a/phoenix-ios/phoenix-ios/views/send/MinerFeeSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/send/MinerFeeSheet.swift
@@ -330,7 +330,7 @@ struct MinerFeeSheet: View {
 			
 			Group {
 				if let mrr = mempoolRecommendedResponse {
-					Text("Feerate below minimum allowed by mempool: \(satsPerByteString(mrr.minimumFee))")
+					Text("Feerate below minimum allowed by mempool: \(satsPerByteString(mrr.minimumFee)) sats/vByte")
 				} else {
 					Text("Feerate below minimum allowed by mempool.")
 				}
@@ -638,12 +638,12 @@ struct LowMinerFeeWarning: View {
 		HStack(alignment: .center, spacing: 0) {
 			Spacer()
 			
-			Button("Cancel") {
+			Button("Back") {
 				cancelButtonTapped()
 			}
 			.padding(.trailing)
 				
-			Button("Confirm") {
+			Button("I understand") {
 				confirmButtonTapped()
 			}
 		}

--- a/phoenix-ios/phoenix-ios/views/send/RangeSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/send/RangeSheet.swift
@@ -42,6 +42,7 @@ struct RangeSheet: View {
 	@ViewBuilder
 	func header() -> some View {
 		
+		let dismissable: Bool = smartModalState.dismissable
 		HStack(alignment: VerticalAlignment.center, spacing: 0) {
 			Text("Acceptable range")
 				.font(.title3)
@@ -56,7 +57,7 @@ struct RangeSheet: View {
 					.frame(width: 30, height: 30)
 			}
 			.accessibilityLabel("Close")
-			.accessibilityHidden(smartModalState.currentItem?.dismissable ?? false)
+			.accessibilityHidden(dismissable)
 		} // <HStack>
 		.padding(.horizontal)
 		.padding(.vertical, 8)

--- a/phoenix-ios/phoenix-ios/views/send/TipSliderSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/send/TipSliderSheet.swift
@@ -151,7 +151,7 @@ struct TipSliderSheet: View {
 					.frame(width: 30, height: 30)
 			}
 			.accessibilityLabel("Close")
-			.accessibilityHidden(smartModalState.currentItem?.dismissable ?? false)
+			.accessibilityHidden(smartModalState.dismissable)
 		}
 		.padding(.horizontal)
 		.padding(.vertical, 8)

--- a/phoenix-ios/phoenix-ios/views/tools/AppStatusPopover.swift
+++ b/phoenix-ios/phoenix-ios/views/tools/AppStatusPopover.swift
@@ -56,7 +56,7 @@ struct AppStatusPopover: View {
 					close()
 				}
 				.font(.title2)
-				.accessibilityHidden(popoverState.publisher.value?.dismissable ?? false)
+				.accessibilityHidden(popoverState.dismissable)
 				
 			}
 			.padding(.top, 10)

--- a/phoenix-ios/phoenix-ios/views/tools/UnlockErrorView.swift
+++ b/phoenix-ios/phoenix-ios/views/tools/UnlockErrorView.swift
@@ -27,7 +27,7 @@ struct UnlockErrorView: View {
 			main.zIndex(0) // needed for proper animation
 
 			if let popoverItem = popoverItem {
-				PopoverWrapper(dismissable: popoverItem.dismissable) {
+				PopoverWrapper(dismissable: popoverState.dismissable) {
 					popoverItem.view
 				}
 				.zIndex(1) // needed for proper animation
@@ -36,7 +36,7 @@ struct UnlockErrorView: View {
 			toast.view()
 		}
 		.frame(maxWidth: .infinity, maxHeight: .infinity)
-		.onReceive(popoverState.publisher) { (item: PopoverItem?) in
+		.onReceive(popoverState.itemPublisher) { (item: PopoverItem?) in
 			withAnimation {
 				popoverItem = item
 			}


### PR DESCRIPTION
This PR adds a warning when a low feerate (below mempool.hour) is used when paying on-chain, as a reminder that on-chain payments cannot be cancelled by Phoenix, only accelerated. They may stay unconfirmed for a long time when the mempool is full.

**On android**

<img width="326" alt="image" src="https://github.com/ACINQ/phoenix/assets/5765435/58664239-a2ef-4b44-acb4-4cf1acbcb492" />

<br />

<img width="326" alt="image" src="https://github.com/ACINQ/phoenix/assets/5765435/78a88bbe-e2c2-4aa4-a936-947dd565fde4" />

