### PR TITLE
(ios) lnurl-withdraws should not display the lightning fee

### DIFF
--- a/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
@@ -840,6 +840,8 @@ struct ValidateView: View {
 		let lightningFeeMsat: Int64
 		if mvi.model is Scan.Model_OnChainFlow {
 			lightningFeeMsat = 0
+		} else if let _ = lnurlWithdraw() {
+			lightningFeeMsat = 0
 		} else if let trampolineFees = defaultTrampolineFees() {
 			let p1 = Utils.toMsat(sat: trampolineFees.feeBase)
 			let f2 = Double(trampolineFees.feeProportional) / 1_000_000


### PR DESCRIPTION
Previously: Attempting to receive money via a lnurl-withdraw would display the lightning fee. Which was incorrect and confusing.

See [ticket 68297032](https://phoenix.jitbit.com/helpdesk/Ticket/68297032)

This PR fixes the bug.