### PR TITLE
(ui-android) Enable redacted balance mode in payments

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Layout.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Layout.kt
@@ -31,7 +31,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -49,7 +48,6 @@ import fr.acinq.phoenix.android.utils.datastore.HomeAmountDisplayMode
 import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.android.utils.mutedTextColor
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.launch
 
 
 /** Button for navigation purpose, with the back arrow. */

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Layout.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Layout.kt
@@ -29,11 +29,15 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.FirstBaseline
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -41,7 +45,11 @@ import androidx.compose.ui.unit.sp
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.utils.borderColor
+import fr.acinq.phoenix.android.utils.datastore.HomeAmountDisplayMode
+import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.android.utils.mutedTextColor
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 
 
 /** Button for navigation purpose, with the back arrow. */
@@ -77,6 +85,9 @@ fun BackButtonWithBalance(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
+        val context = LocalContext.current
+        val balanceDisplayMode by UserPrefs.getHomeAmountDisplayMode(context).collectAsState(initial = HomeAmountDisplayMode.REDACTED)
+
         BackButton(onClick = onBackClick)
         Row(modifier = Modifier.padding(horizontal = 16.dp)) {
             Text(
@@ -86,7 +97,17 @@ fun BackButtonWithBalance(
             )
             Spacer(modifier = Modifier.width(4.dp))
             balance?.let {
-                AmountView(amount = it, modifier = Modifier.alignBy(FirstBaseline))
+                AmountView(amount = it, modifier = Modifier.alignBy(FirstBaseline), isRedacted = balanceDisplayMode==HomeAmountDisplayMode.REDACTED,
+                    onClick = { context, inFiat ->
+                        val mode = UserPrefs.getHomeAmountDisplayMode(context).firstOrNull()
+                        when {
+                            inFiat && mode == HomeAmountDisplayMode.BTC -> UserPrefs.saveHomeAmountDisplayMode(context, HomeAmountDisplayMode.REDACTED)
+                            mode == HomeAmountDisplayMode.BTC -> UserPrefs.saveHomeAmountDisplayMode(context, HomeAmountDisplayMode.FIAT)
+                            mode == HomeAmountDisplayMode.FIAT -> UserPrefs.saveHomeAmountDisplayMode(context, HomeAmountDisplayMode.REDACTED)
+                            mode == HomeAmountDisplayMode.REDACTED -> UserPrefs.saveHomeAmountDisplayMode(context, HomeAmountDisplayMode.BTC)
+                            else -> Unit
+                        }
+                    })
             }
         }
     }


### PR DESCRIPTION
Resolves #438 

When a user is sending a payment, their balance is displayed on the top right in fiat or sats. This commit adds redacted mode which shows **** if the user desires. Clicking on the balance toggles the display modes. This functionality is similar and in **sync** with the home account balance view.

![20240306123714-ezgif com-crop](https://github.com/ACINQ/phoenix/assets/38168632/8d7118f4-3117-41a9-a95f-88c49a4ad9bb)
