### PR TITLE
(ios) Background receive bug

### DIFF
--- a/phoenix-ios/phoenix-ios/SceneDelegate.swift
+++ b/phoenix-ios/phoenix-ios/SceneDelegate.swift
@@ -20,7 +20,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	var errorWindow: UIWindow?
 	
 	var isAppLaunch = true
-	var isInBackground = false
 	var firstUnlockAttempted = false
 
 	func scene(
@@ -72,7 +71,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		log.trace("sceneDidBecomeActive()")
 		
 		// Called when the scene has moved from an inactive state to an active state.
-		// Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+		// Use this method to restart any tasks that were paused (or not yet started)
+		// when the scene was inactive.
 	}
 
 	func sceneWillResignActive(_ scene: UIScene) {
@@ -84,20 +84,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 	func sceneWillEnterForeground(_ scene: UIScene) {
 		log.trace("sceneWillEnterForeground()")
-		
-		if isInBackground {
-			isInBackground = false
-			CrossProcessCommunication.shared.resume()
-		}
 	}
 
 	func sceneDidEnterBackground(_ scene: UIScene) {
 		log.trace("sceneDidEnterBackground()")
-		
-		if !isInBackground {
-			isInBackground = true
-			CrossProcessCommunication.shared.suspend()
-		}
 		
 		let currentSecurity = AppSecurity.shared.enabledSecurityPublisher.value
 		if !currentSecurity.isEmpty {

--- a/phoenix-ios/phoenix-ios/officers/BusinessManager.swift
+++ b/phoenix-ios/phoenix-ios/officers/BusinessManager.swift
@@ -93,10 +93,6 @@ class BusinessManager {
 		
 		let nc = NotificationCenter.default
 		
-		nc.publisher(for: UIApplication.didFinishLaunchingNotification).sink { _ in
-			self.applicationDidFinishLaunching()
-		}.store(in: &appCancellables)
-		
 		nc.publisher(for: UIApplication.didEnterBackgroundNotification).sink { _ in
 			self.applicationDidEnterBackground()
 		}.store(in: &appCancellables)
@@ -131,8 +127,7 @@ class BusinessManager {
 		)
 		business.start(startupParams: startupParams)
 		
-		registerForNotifications()
-		startTasks()
+		setup()
 	}
 
 	public func stop() {
@@ -156,11 +151,11 @@ class BusinessManager {
 	}
 	
 	// --------------------------------------------------
-	// MARK: Startup
+	// MARK: Setup
 	// --------------------------------------------------
 	
-	private func registerForNotifications() {
-		log.trace("registerForNotifications()")
+	private func setup() {
+		log.trace("setup()")
 		
 		// Connection status observer
 		cancellables.insert(
@@ -363,10 +358,6 @@ class BusinessManager {
 				}
 			}.autoCancellable()
 		)
-	}
-	
-	func startTasks() {
-		log.trace("startTasks()")
 		
 		cancellables.insert(
 			// Start watching the SwapIn wallet (once the channels are loaded from DB)
@@ -390,10 +381,6 @@ class BusinessManager {
 	// --------------------------------------------------
 	// MARK: Notifications
 	// --------------------------------------------------
-	
-	func applicationDidFinishLaunching() {
-		log.trace("### applicationDidFinishLaunching()")
-	}
 	
 	func applicationDidEnterBackground() {
 		log.trace("### applicationDidEnterBackground()")


### PR DESCRIPTION
# (ios) Backgroud receive bug

@dpad85 recently discovered a bug that affect's Phoenix's ability to receive payments via the background process (on iOS).

#### Steps to reproduce:

1. Using iOS 15 or 16 (not 17+)
2. Open the Phoenix app, create an invoice, and then **force-quit** the app
3. Pay the invoice with another wallet
4. Note that the payment succeeds
5. Open the Phoenix app again, create another invoice, and then **force-quit** the app
6. Attempt to pay the invoice with another wallet
7. Note that this time the payment fails immediately, and a Phoenix notification appears ("Missed incoming payment")

#### Analysis

On iOS we are forced to use a notification-service-extension to handle incoming payments when the Phoenix app is in the background, or not running. (See [#280](https://github.com/ACINQ/phoenix/pull/280) for details.) Since this is a completely separate process, there are various edge cases we have to protect against.

One of the edge cases is that the server only allows a single client to be connected at-a-time (for the same wallet). Which means:

* if the background process is launched when the foreground process is active, then the bg process should yield to the fg process.
* if the foreground process is launched while the background process is in the middle of receiving a payment, then the fg process should wait to connect until the bg process completes

As part of the architecture to implement these safety measures, we have a simple IPC channel where each process can send flags to the other (such as `ping`, `pong`, or `offline`).

#### The simple fix

On iOS 17, when you force-quit the app, the `SceneDelegate.sceneDidEnterBackground()` method is called. However, this does NOT occur on iOS 15 or 16. And because of this, the `offline` flag was not sent via the IPC channel. So what was happening:

* Phoenix app is launched, and a `ping_from_mainApp` message is sent on the IPC channel
* Phoenix app is force-closed (and no message is sent on IPC channel)
* Background app is launched to handle incoming payment
* Background app ignores existing IPC channel message, and sends `ping_from_bgApp`
* Background app finishes receiving payment, but iOS does NOT kill the process. It keeps the process running for a period of time in case another notification arrives. (Unless there is memory pressure, or a timeout occurs.)
* Phoenix app is launched again, and sends a `ping_from_mainApp` message on the IPC channel
* Phoenix app is force-killed
* Background app (which is still running) is invoked again to process the new incoming notification
* The background app sees the new `ping_from_mainApp` and interprets this to mean that the main app is running, and thus it immediately yields (stops).
* But since the interpretation was wrong, the payment is missed, and the corresponding notification is displayed.



So the simple fix is that the main Phoenix app should send the `offline_from_mainApp` when force-quit. I've implemented this change in the PR.



#### The harder fix

Even with the simple fix, there's still the edge-case where the main Phoenix app crashes. In which case it won't send the `offline_from_mainApp` message. So the background app still needs to be smarter about how it handles IPC messages. Especially since iOS may keep the background process open.



So now, when the background process isn't actively processing a notification, it closes the IPC channel. And everytime it opens a new IPC channel, it always ignores any existing message on the channel.



This change has also been implemented in the PR.