### PR TITLE
[Android] - Disable editing amount when paying an invoice with a defined amount

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/SendLightningView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/SendLightningView.kt
@@ -61,6 +61,7 @@ fun SendBolt11PaymentView(
         topContent = {
             AmountHeroInput(
                 initialAmount = amount,
+                enabled = amount == null,
                 onAmountChange = { newAmount ->
                     amountErrorMessage = ""
                     when {

--- a/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
@@ -238,6 +238,7 @@ struct ValidateView: View {
 				.disableAutocorrection(true)
 				.fixedSize()
 				.font(.title)
+                .disabled(paymentRequest()?.amount != nil)
 				.multilineTextAlignment(.trailing)
 				.minimumScaleFactor(0.95) // SwiftUI bugs: truncating text in RTL
 				.foregroundColor(isInvalidAmount() ? Color.appNegative : Color.primaryForeground)


### PR DESCRIPTION
This PR resolves issue #533.

I added a simple check where if the invoice amount is null, the input will be enabled and editable when paying the invoice.