### PR TITLE
Add option to overpay LN payments

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/Ambients.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/Ambients.kt
@@ -25,6 +25,7 @@ import androidx.navigation.NavController
 import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.android.utils.UserTheme
 import fr.acinq.phoenix.android.utils.datastore.InternalDataRepository
+import fr.acinq.phoenix.android.utils.datastore.UserPrefsRepository
 import fr.acinq.phoenix.controllers.ControllerFactory
 import fr.acinq.phoenix.data.*
 
@@ -74,6 +75,10 @@ val fiatRate: ExchangeRate.BitcoinPriceRate?
 val internalData: InternalDataRepository
     @Composable
     get() = application.internalDataRepository
+
+val userPrefs: UserPrefsRepository
+    @Composable
+    get() = application.userPrefs
 
 val controllerFactory: ControllerFactory
     @Composable

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/AppView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/AppView.kt
@@ -89,7 +89,6 @@ import fr.acinq.phoenix.android.settings.walletinfo.WalletInfoView
 import fr.acinq.phoenix.android.startup.LegacySwitcherView
 import fr.acinq.phoenix.android.startup.StartupView
 import fr.acinq.phoenix.android.utils.appBackground
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.android.utils.logger
 import fr.acinq.phoenix.data.BitcoinUnit
 import fr.acinq.phoenix.data.FiatCurrency
@@ -124,9 +123,9 @@ fun AppView(
     log.debug("init app view composition")
 
     val context = LocalContext.current
-    val isAmountInFiat = UserPrefs.getIsAmountInFiat(context).collectAsState(false)
-    val fiatCurrency = UserPrefs.getFiatCurrency(context).collectAsState(initial = FiatCurrency.USD)
-    val bitcoinUnit = UserPrefs.getBitcoinUnit(context).collectAsState(initial = BitcoinUnit.Sat)
+    val isAmountInFiat = userPrefs.getIsAmountInFiat.collectAsState(false)
+    val fiatCurrency = userPrefs.getFiatCurrency.collectAsState(initial = FiatCurrency.USD)
+    val bitcoinUnit = userPrefs.getBitcoinUnit.collectAsState(initial = BitcoinUnit.Sat)
     val fiatRates by business.currencyManager.ratesFlow.collectAsState(emptyList())
 
     CompositionLocalProvider(
@@ -497,7 +496,8 @@ private fun MonitorNotices(
     vm: NoticesViewModel
 ) {
     val context = LocalContext.current
-    val internalData = application.internalDataRepository
+    val internalData = internalData
+    val userPrefs = userPrefs
 
     LaunchedEffect(Unit) {
         internalData.showSeedBackupNotice.collect {
@@ -513,7 +513,7 @@ private fun MonitorNotices(
         val notificationPermission = rememberPermissionState(permission = Manifest.permission.POST_NOTIFICATIONS)
         if (!notificationPermission.status.isGranted) {
             LaunchedEffect(Unit) {
-                if (UserPrefs.getShowNotificationPermissionReminder(context).first()) {
+                if (userPrefs.getShowNotificationPermissionReminder.first()) {
                     vm.addNotice(Notice.NotificationPermission)
                 }
             }
@@ -521,7 +521,7 @@ private fun MonitorNotices(
             vm.removeNotice<Notice.NotificationPermission>()
         }
         LaunchedEffect(Unit) {
-            UserPrefs.getShowNotificationPermissionReminder(context).collect {
+            userPrefs.getShowNotificationPermissionReminder.collect {
                 if (it && !notificationPermission.status.isGranted) {
                     vm.addNotice(Notice.NotificationPermission)
                 } else {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/PhoenixApplication.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/PhoenixApplication.kt
@@ -21,9 +21,10 @@ import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.android.utils.Logging
 import fr.acinq.phoenix.android.utils.SystemNotificationHelper
 import fr.acinq.phoenix.android.utils.datastore.InternalDataRepository
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
+import fr.acinq.phoenix.android.utils.datastore.UserPrefsRepository
 import fr.acinq.phoenix.legacy.AppContext
 import fr.acinq.phoenix.legacy.internalData
+import fr.acinq.phoenix.legacy.userPrefs
 import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
 import fr.acinq.phoenix.managers.AppConnectionsDaemon
 import fr.acinq.phoenix.utils.PlatformContext
@@ -32,10 +33,11 @@ import kotlinx.coroutines.flow.asStateFlow
 
 class PhoenixApplication : AppContext() {
 
-    private val _business = MutableStateFlow<PhoenixBusiness?>(null) // by lazy { MutableStateFlow(PhoenixBusiness(PlatformContext(applicationContext))) }
+    private val _business = MutableStateFlow<PhoenixBusiness?>(null)
     val business = _business.asStateFlow()
 
     lateinit var internalDataRepository: InternalDataRepository
+    lateinit var userPrefs: UserPrefsRepository
 
     override fun onCreate() {
         super.onCreate()
@@ -43,6 +45,7 @@ class PhoenixApplication : AppContext() {
         Logging.setupLogger(applicationContext)
         SystemNotificationHelper.registerNotificationChannels(applicationContext)
         internalDataRepository = InternalDataRepository(applicationContext.internalData)
+        userPrefs = UserPrefsRepository(applicationContext.userPrefs)
     }
 
     override fun onLegacyFinish() {
@@ -63,7 +66,7 @@ class PhoenixApplication : AppContext() {
 
     suspend fun clearPreferences() {
         internalDataRepository.clear()
-        UserPrefs.clear(applicationContext)
+        userPrefs.clear()
         LegacyPrefsDatastore.clear(applicationContext)
     }
 }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/AmountInput.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/AmountInput.kt
@@ -558,11 +558,12 @@ private fun UnitDropdown(
     Box(modifier = modifier.wrapContentSize(Alignment.TopStart)) {
         Button(
             text = units[selectedIndex].displayCode,
-            icon = R.drawable.ic_chevron_down,
+            icon = if (enabled) R.drawable.ic_chevron_down else null,
             onClick = { expanded = true },
             padding = internalPadding,
-            space = 8.dp,
+            space = if (enabled) 8.dp else 0.dp,
             enabled = enabled,
+            enabledEffect = false,
         )
         DropdownMenu(
             expanded = expanded,

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/AmountInput.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/AmountInput.kt
@@ -377,10 +377,9 @@ private enum class SlotsEnum { Input, Unit, DashedLine }
  * This input is designed to be in the center stage of a screen. It uses a customised basic input
  * instead of a standard, material-design input.
  */
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun AmountHeroInput(
-    initialAmount: MilliSatoshi?,
+    amount: MilliSatoshi?,
     onAmountChange: (ComplexAmount?) -> Unit,
     validationErrorMessage: String,
     modifier: Modifier = Modifier,
@@ -398,8 +397,8 @@ fun AmountHeroInput(
     val keyboardController = LocalSoftwareKeyboardController.current
 
     var unit: CurrencyUnit by remember { mutableStateOf(prefBitcoinUnit) }
-    var inputValue by remember { mutableStateOf(TextFieldValue(initialAmount?.toUnit(prefBitcoinUnit).toPlainString())) }
-    var convertedValue: String by remember { mutableStateOf(initialAmount?.toPrettyString(prefFiat, rate, withUnit = true) ?: "") }
+    var inputValue by remember(amount) { mutableStateOf(TextFieldValue(amount?.toUnit(prefBitcoinUnit).toPlainString())) }
+    var convertedValue: String by remember(amount) { mutableStateOf(amount?.toPrettyString(prefFiat, rate, withUnit = true) ?: "") }
 
     var internalErrorMessage: String by remember { mutableStateOf(validationErrorMessage) }
     val errorMessage = validationErrorMessage.ifBlank { internalErrorMessage.ifBlank { null } }
@@ -540,7 +539,6 @@ fun AmountHeroInput(
             )
         }
     }
-
 }
 
 @Composable

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/AmountView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/AmountView.kt
@@ -16,7 +16,6 @@
 
 package fr.acinq.phoenix.android.components
 
-import android.content.Context
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
@@ -28,7 +27,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.FirstBaseline
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
@@ -40,7 +38,7 @@ import fr.acinq.phoenix.android.*
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 import fr.acinq.phoenix.android.utils.MSatDisplayPolicy
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
+import fr.acinq.phoenix.android.utils.datastore.UserPrefsRepository
 import fr.acinq.phoenix.data.CurrencyUnit
 import fr.acinq.phoenix.data.FiatCurrency
 import kotlinx.coroutines.launch
@@ -57,10 +55,10 @@ fun AmountView(
     unitTextStyle: TextStyle = MaterialTheme.typography.body1,
     separatorSpace: Dp = 4.dp,
     mSatDisplayPolicy: MSatDisplayPolicy = MSatDisplayPolicy.HIDE,
-    onClick: (suspend (Context, Boolean) -> Unit)? = { context, inFiat -> UserPrefs.saveIsAmountInFiat(context, !inFiat) }
+    onClick: (suspend (UserPrefsRepository, Boolean) -> Unit)? = { userPrefs, inFiat -> userPrefs.saveIsAmountInFiat(!inFiat) }
 ) {
     val scope = rememberCoroutineScope()
-    val context = LocalContext.current
+    val userPrefs = userPrefs
     val unit = forceUnit ?: if (LocalShowInFiat.current) {
         LocalFiatCurrency.current
     } else {
@@ -76,7 +74,7 @@ fun AmountView(
                 interactionSource = interactionSource,
                 indication = null,
                 role = Role.Button,
-                onClick = { scope.launch { onClick(context, inFiat) } }
+                onClick = { scope.launch { onClick(userPrefs, inFiat) } }
             ) else Modifier)
     ) {
         if (!isRedacted && prefix != null && amount > MilliSatoshi(0)) {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Layout.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/Layout.kt
@@ -36,16 +36,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.FirstBaseline
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.phoenix.android.R
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.android.utils.borderColor
 import fr.acinq.phoenix.android.utils.datastore.HomeAmountDisplayMode
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.android.utils.mutedTextColor
 import kotlinx.coroutines.flow.firstOrNull
 
@@ -83,8 +82,7 @@ fun BackButtonWithBalance(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        val context = LocalContext.current
-        val balanceDisplayMode by UserPrefs.getHomeAmountDisplayMode(context).collectAsState(initial = HomeAmountDisplayMode.REDACTED)
+        val balanceDisplayMode by userPrefs.getHomeAmountDisplayMode.collectAsState(initial = HomeAmountDisplayMode.REDACTED)
 
         BackButton(onClick = onBackClick)
         Row(modifier = Modifier.padding(horizontal = 16.dp)) {
@@ -96,13 +94,13 @@ fun BackButtonWithBalance(
             Spacer(modifier = Modifier.width(4.dp))
             balance?.let {
                 AmountView(amount = it, modifier = Modifier.alignBy(FirstBaseline), isRedacted = balanceDisplayMode==HomeAmountDisplayMode.REDACTED,
-                    onClick = { context, inFiat ->
-                        val mode = UserPrefs.getHomeAmountDisplayMode(context).firstOrNull()
+                    onClick = { userPrefs, inFiat ->
+                        val mode = userPrefs.getHomeAmountDisplayMode.firstOrNull()
                         when {
-                            inFiat && mode == HomeAmountDisplayMode.BTC -> UserPrefs.saveHomeAmountDisplayMode(context, HomeAmountDisplayMode.REDACTED)
-                            mode == HomeAmountDisplayMode.BTC -> UserPrefs.saveHomeAmountDisplayMode(context, HomeAmountDisplayMode.FIAT)
-                            mode == HomeAmountDisplayMode.FIAT -> UserPrefs.saveHomeAmountDisplayMode(context, HomeAmountDisplayMode.REDACTED)
-                            mode == HomeAmountDisplayMode.REDACTED -> UserPrefs.saveHomeAmountDisplayMode(context, HomeAmountDisplayMode.BTC)
+                            inFiat && mode == HomeAmountDisplayMode.BTC -> userPrefs.saveHomeAmountDisplayMode(HomeAmountDisplayMode.REDACTED)
+                            mode == HomeAmountDisplayMode.BTC -> userPrefs.saveHomeAmountDisplayMode(HomeAmountDisplayMode.FIAT)
+                            mode == HomeAmountDisplayMode.FIAT -> userPrefs.saveHomeAmountDisplayMode(HomeAmountDisplayMode.REDACTED)
+                            mode == HomeAmountDisplayMode.REDACTED -> userPrefs.saveHomeAmountDisplayMode(HomeAmountDisplayMode.BTC)
                             else -> Unit
                         }
                     })

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/ConnectionDialog.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/ConnectionDialog.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
@@ -42,7 +41,7 @@ import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.components.Dialog
 import fr.acinq.phoenix.android.components.HSeparator
 import fr.acinq.phoenix.android.components.TextWithIcon
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.android.utils.isBadCertificate
 import fr.acinq.phoenix.android.utils.monoTypo
 import fr.acinq.phoenix.android.utils.negativeColor
@@ -59,8 +58,6 @@ fun ConnectionDialog(
     onTorClick: () -> Unit,
     onElectrumClick: () -> Unit,
 ) {
-    val context = LocalContext.current
-
     Dialog(title = stringResource(id = R.string.conndialog_title), onDismiss = onClose) {
         Column {
             if (connections.internet != Connection.ESTABLISHED) {
@@ -77,7 +74,7 @@ fun ConnectionDialog(
                 ConnectionDialogLine(label = stringResource(id = R.string.conndialog_internet), connection = connections.internet)
                 HSeparator()
 
-                val isTorEnabled = UserPrefs.getIsTorEnabled(context).collectAsState(initial = null).value
+                val isTorEnabled = userPrefs.getIsTorEnabled.collectAsState(initial = null).value
                 if (isTorEnabled != null && isTorEnabled) {
                     ConnectionDialogLine(label = stringResource(id = R.string.conndialog_tor), connection = connections.tor, onClick = onTorClick)
                     HSeparator()

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeBalance.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeBalance.kt
@@ -19,13 +19,11 @@ package fr.acinq.phoenix.android.home
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
@@ -42,9 +40,9 @@ import fr.acinq.phoenix.android.business
 import fr.acinq.phoenix.android.components.*
 import fr.acinq.phoenix.android.fiatRate
 import fr.acinq.phoenix.android.preferredAmountUnit
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 import fr.acinq.phoenix.android.utils.datastore.HomeAmountDisplayMode
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.managers.WalletBalance
 import kotlinx.coroutines.flow.firstOrNull
 
@@ -73,13 +71,13 @@ fun HomeBalance(
                 amountTextStyle = MaterialTheme.typography.body2.copy(fontSize = 40.sp),
                 unitTextStyle = MaterialTheme.typography.h3.copy(fontWeight = FontWeight.Light, color = MaterialTheme.colors.primary),
                 isRedacted = isAmountRedacted,
-                onClick = { context, inFiat ->
-                    val mode = UserPrefs.getHomeAmountDisplayMode(context).firstOrNull()
+                onClick = { userPrefs, inFiat ->
+                    val mode = userPrefs.getHomeAmountDisplayMode.firstOrNull()
                     when {
-                        inFiat && mode == HomeAmountDisplayMode.BTC -> UserPrefs.saveHomeAmountDisplayMode(context, HomeAmountDisplayMode.REDACTED)
-                        mode == HomeAmountDisplayMode.BTC -> UserPrefs.saveHomeAmountDisplayMode(context, HomeAmountDisplayMode.FIAT)
-                        mode == HomeAmountDisplayMode.FIAT -> UserPrefs.saveHomeAmountDisplayMode(context, HomeAmountDisplayMode.REDACTED)
-                        mode == HomeAmountDisplayMode.REDACTED -> UserPrefs.saveHomeAmountDisplayMode(context, HomeAmountDisplayMode.BTC)
+                        inFiat && mode == HomeAmountDisplayMode.BTC -> userPrefs.saveHomeAmountDisplayMode(HomeAmountDisplayMode.REDACTED)
+                        mode == HomeAmountDisplayMode.BTC -> userPrefs.saveHomeAmountDisplayMode(HomeAmountDisplayMode.FIAT)
+                        mode == HomeAmountDisplayMode.FIAT -> userPrefs.saveHomeAmountDisplayMode(HomeAmountDisplayMode.REDACTED)
+                        mode == HomeAmountDisplayMode.REDACTED -> userPrefs.saveHomeAmountDisplayMode(HomeAmountDisplayMode.BTC)
                         else -> Unit
                     }
                 }
@@ -133,7 +131,7 @@ private fun IncomingBalance(
                 )
 
                 if (showSwapInHelp) {
-                    val liquidityPolicyInPrefs by UserPrefs.getLiquidityPolicy(LocalContext.current).collectAsState(null)
+                    val liquidityPolicyInPrefs by userPrefs.getLiquidityPolicy.collectAsState(null)
                     val bitcoinUnit = LocalBitcoinUnit.current
                     PopupDialog(
                         onDismiss = { showSwapInHelp = false },

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
@@ -55,7 +55,6 @@ import fr.acinq.phoenix.android.components.PrimarySeparator
 import fr.acinq.phoenix.android.components.mvi.MVIView
 import fr.acinq.phoenix.android.utils.annotatedStringResource
 import fr.acinq.phoenix.android.utils.datastore.HomeAmountDisplayMode
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.android.utils.findActivity
 import fr.acinq.phoenix.data.WalletPaymentId
 import fr.acinq.phoenix.data.canRequestLiquidity
@@ -83,8 +82,9 @@ fun HomeView(
     val context = LocalContext.current
 
     val internalData = application.internalDataRepository
-    val torEnabledState = UserPrefs.getIsTorEnabled(context).collectAsState(initial = null)
-    val balanceDisplayMode by UserPrefs.getHomeAmountDisplayMode(context).collectAsState(initial = HomeAmountDisplayMode.REDACTED)
+    val userPrefs = application.userPrefs
+    val torEnabledState = userPrefs.getIsTorEnabled.collectAsState(initial = null)
+    val balanceDisplayMode by userPrefs.getHomeAmountDisplayMode.collectAsState(initial = HomeAmountDisplayMode.REDACTED)
 
     val connections by business.connectionsManager.connections.collectAsState()
     val electrumMessages by business.appConfigurationManager.electrumMessages.collectAsState()

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/init/CreateWalletView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/init/CreateWalletView.kt
@@ -41,6 +41,7 @@ import fr.acinq.phoenix.android.security.SeedManager
 import fr.acinq.phoenix.android.utils.logger
 import fr.acinq.phoenix.controllers.init.Initialization
 import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
+import fr.acinq.phoenix.utils.MnemonicLanguage
 
 
 @Composable
@@ -72,7 +73,7 @@ fun CreateWalletView(
                             val entropy = remember { Lightning.randomBytes(16) }
                             LaunchedEffect(key1 = entropy) {
                                 log.debug("generating new wallet...")
-                                postIntent(Initialization.Intent.GenerateWallet(entropy))
+                                postIntent(Initialization.Intent.GenerateWallet(entropy, MnemonicLanguage.English))
                             }
                         }
                         is Initialization.Model.GeneratedWallet -> {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/init/RestoreWalletView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/init/RestoreWalletView.kt
@@ -53,9 +53,9 @@ import fr.acinq.phoenix.android.controllerFactory
 import fr.acinq.phoenix.android.navController
 import fr.acinq.phoenix.android.security.SeedFileState
 import fr.acinq.phoenix.android.security.SeedManager
-import fr.acinq.phoenix.android.utils.logger
 import fr.acinq.phoenix.android.utils.negativeColor
 import fr.acinq.phoenix.controllers.init.RestoreWallet
+import fr.acinq.phoenix.utils.MnemonicLanguage
 
 sealed class RestoreWalletViewState {
     object Disclaimer : RestoreWalletViewState()
@@ -195,7 +195,7 @@ private fun SeedInputView(
                             WordInputView(
                                 wordIndex = enteredWords.size + 1,
                                 filteredWords = filteredWords,
-                                onInputChange = { postIntent(RestoreWallet.Intent.FilterWordList(it)) },
+                                onInputChange = { postIntent(RestoreWallet.Intent.FilterWordList(it, MnemonicLanguage.English)) },
                                 onWordSelected = { vm.appendWordToMnemonic(it) },
                             )
                         }
@@ -246,7 +246,7 @@ private fun SeedInputView(
                         icon = R.drawable.ic_check_circle,
                         onClick = {
                             focusManager.clearFocus()
-                            postIntent(RestoreWallet.Intent.Validate(vm.mnemonics.filterNotNull()))
+                            postIntent(RestoreWallet.Intent.Validate(vm.mnemonics.filterNotNull(), MnemonicLanguage.English))
                         },
                         enabled = isSeedValid == true,
                     )

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/LnurlAuthView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/LnurlAuthView.kt
@@ -24,14 +24,13 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.components.*
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.controllers.payments.Scan
 import fr.acinq.phoenix.data.lnurl.LnurlAuth
 
@@ -42,9 +41,8 @@ fun LnurlAuthView(
     onLoginClick: (Scan.Intent.LnurlAuthFlow) -> Unit,
     onAuthSchemeInfoClick: () -> Unit
 ) {
-    val context = LocalContext.current
     var showHowItWorks by remember { mutableStateOf(false) }
-    val prefAuthScheme by UserPrefs.getLnurlAuthScheme(context).collectAsState(initial = null)
+    val prefAuthScheme by userPrefs.getLnurlAuthScheme.collectAsState(initial = null)
     val isLegacyDomain = remember(model) { LnurlAuth.LegacyDomain.isEligible(model.auth.initialUrl) }
 
     Column(

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/LnurlPayView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/LnurlPayView.kt
@@ -69,7 +69,7 @@ fun LnurlPayView(
         header = { BackButtonWithBalance(onBackClick = onBackClick, balance = balance) },
         topContent = {
             AmountHeroInput(
-                initialAmount = amount,
+                amount = amount,
                 onAmountChange = { newAmount ->
                     amountErrorMessage = ""
                     when {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/LnurlWithdrawView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/LnurlWithdrawView.kt
@@ -58,7 +58,7 @@ fun LnurlWithdrawView(
             Text(text = annotatedStringResource(R.string.lnurl_withdraw_header, model.lnurlWithdraw.initialUrl.host), textAlign = TextAlign.Center)
             Spacer(modifier = Modifier.height(16.dp))
             AmountHeroInput(
-                initialAmount = amount,
+                amount = amount,
                 onAmountChange = { newAmount ->
                     amountErrorMessage = ""
                     when {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/SendLightningView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/SendLightningView.kt
@@ -36,6 +36,7 @@ import fr.acinq.phoenix.android.LocalBitcoinUnit
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.business
 import fr.acinq.phoenix.android.components.*
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 import fr.acinq.phoenix.android.utils.safeLet
 import fr.acinq.phoenix.controllers.payments.Scan
@@ -55,13 +56,14 @@ fun SendBolt11PaymentView(
     val requestedAmount = invoice.amount
     var amount by remember { mutableStateOf(requestedAmount) }
     var amountErrorMessage by remember { mutableStateOf("") }
+    val isOverpaymentEnabled by userPrefs.getIsOverpaymentEnabled.collectAsState(initial = false)
 
     SplashLayout(
         header = { BackButtonWithBalance(onBackClick = onBackClick, balance = balance) },
         topContent = {
             AmountHeroInput(
                 initialAmount = amount,
-                enabled = amount == null,
+                enabled = requestedAmount == null || isOverpaymentEnabled,
                 onAmountChange = { newAmount ->
                     amountErrorMessage = ""
                     when {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/receive/ReceiveBaseView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/receive/ReceiveBaseView.kt
@@ -21,27 +21,20 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -60,33 +53,12 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import fr.acinq.lightning.MilliSatoshi
-import fr.acinq.lightning.db.IncomingPayment
-import fr.acinq.lightning.payment.LiquidityPolicy
-import fr.acinq.lightning.payment.PaymentRequest
-import fr.acinq.lightning.utils.msat
-import fr.acinq.lightning.utils.sat
-import fr.acinq.lightning.utils.sum
-import fr.acinq.phoenix.android.LocalBitcoinUnit
-import fr.acinq.phoenix.android.LocalFiatCurrency
 import fr.acinq.phoenix.android.R
-import fr.acinq.phoenix.android.Screen
 import fr.acinq.phoenix.android.business
 import fr.acinq.phoenix.android.components.*
-import fr.acinq.phoenix.android.components.feedback.ErrorMessage
-import fr.acinq.phoenix.android.components.feedback.InfoMessage
-import fr.acinq.phoenix.android.fiatRate
-import fr.acinq.phoenix.android.navController
-import fr.acinq.phoenix.android.utils.Converter.toPrettyString
-import fr.acinq.phoenix.android.utils.borderColor
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.android.utils.copyToClipboard
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
-import fr.acinq.phoenix.android.utils.logger
 import fr.acinq.phoenix.android.utils.safeLet
-import fr.acinq.phoenix.android.utils.share
-import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
-import fr.acinq.phoenix.managers.WalletBalance
-import kotlinx.coroutines.launch
 
 @Composable
 fun ReceiveView(
@@ -95,11 +67,10 @@ fun ReceiveView(
     onFeeManagementClick: () -> Unit,
     onScanDataClick: () -> Unit,
 ) {
-    val context = LocalContext.current
 //    val balanceManager = business.balanceManager
     val vm: ReceiveViewModel = viewModel(factory = ReceiveViewModel.Factory(business.chain, business.peerManager, business.walletManager))
-    val defaultInvoiceExpiry by UserPrefs.getInvoiceDefaultExpiry(context).collectAsState(null)
-    val defaultInvoiceDesc by UserPrefs.getInvoiceDefaultDesc(context).collectAsState(null)
+    val defaultInvoiceExpiry by userPrefs.getInvoiceDefaultExpiry.collectAsState(null)
+    val defaultInvoiceDesc by userPrefs.getInvoiceDefaultDesc.collectAsState(null)
 
 //    // When a on-chain payment has been received, go back to the home screen (via the onSwapInReceived callback)
 //    LaunchedEffect(key1 = Unit) {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/receive/ReceiveLightningView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/receive/ReceiveLightningView.kt
@@ -64,7 +64,6 @@ import fr.acinq.lightning.MilliSatoshi
 import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.payment.Bolt11Invoice
 import fr.acinq.lightning.payment.LiquidityPolicy
-import fr.acinq.lightning.payment.PaymentRequest
 import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.utils.toMilliSatoshi
 import fr.acinq.phoenix.android.LocalBitcoinUnit
@@ -82,12 +81,10 @@ import fr.acinq.phoenix.android.components.TextInput
 import fr.acinq.phoenix.android.components.feedback.ErrorMessage
 import fr.acinq.phoenix.android.components.feedback.InfoMessage
 import fr.acinq.phoenix.android.components.feedback.WarningMessage
-import fr.acinq.phoenix.android.navController
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 import fr.acinq.phoenix.android.utils.borderColor
 import fr.acinq.phoenix.android.utils.copyToClipboard
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
-import fr.acinq.phoenix.android.utils.logger
 import fr.acinq.phoenix.android.utils.share
 import fr.acinq.phoenix.data.availableForReceive
 import fr.acinq.phoenix.data.canRequestLiquidity
@@ -318,9 +315,6 @@ private fun EvaluateLiquidityIssuesForPayment(
     onFeeManagementClick: () -> Unit,
     isEditing: Boolean, // do not show the dialog immediately when editing the invoice, it's annoying
 ) {
-    val log = logger("EvaluateLiquidity")
-    val context = LocalContext.current
-
     val channelsMap by business.peerManager.channelsFlow.collectAsState()
     val canRequestLiquidity = remember(channelsMap) { channelsMap.canRequestLiquidity() }
     val availableForReceive = remember(channelsMap) { channelsMap.availableForReceive() }
@@ -328,7 +322,7 @@ private fun EvaluateLiquidityIssuesForPayment(
     val mempoolFeerate by business.appConfigurationManager.mempoolFeerate.collectAsState()
     val swapFee = remember(mempoolFeerate) { mempoolFeerate?.swapEstimationFee(hasNoChannels = channelsMap?.values?.filterNot { it.isTerminated }.isNullOrEmpty()) }
 
-    val liquidityPolicyPrefs = UserPrefs.getLiquidityPolicy(context).collectAsState(null)
+    val liquidityPolicyPrefs = userPrefs.getLiquidityPolicy.collectAsState(null)
 
     when (val liquidityPolicy = liquidityPolicyPrefs.value) {
         null -> {}

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/receive/ReceiveViewModel.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/receive/ReceiveViewModel.kt
@@ -16,7 +16,6 @@
 
 package fr.acinq.phoenix.android.payments.receive
 
-import android.content.Context
 import androidx.annotation.UiThread
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -27,7 +26,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
-import fr.acinq.bitcoin.Bitcoin
 import fr.acinq.bitcoin.Chain
 import fr.acinq.bitcoin.utils.Either
 import fr.acinq.lightning.Lightning
@@ -37,7 +35,7 @@ import fr.acinq.phoenix.android.PhoenixApplication
 import fr.acinq.phoenix.android.utils.BitmapHelper
 import fr.acinq.phoenix.android.utils.datastore.InternalDataRepository
 import fr.acinq.phoenix.android.utils.datastore.SwapAddressFormat
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
+import fr.acinq.phoenix.android.utils.datastore.UserPrefsRepository
 import fr.acinq.phoenix.managers.PeerManager
 import fr.acinq.phoenix.managers.WalletManager
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -64,7 +62,7 @@ class ReceiveViewModel(
     private val peerManager: PeerManager,
     private val walletManager: WalletManager,
     private val internalDataRepository: InternalDataRepository,
-    private val context: Context,
+    private val userPrefs: UserPrefsRepository
 ): ViewModel() {
     private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -111,7 +109,7 @@ class ReceiveViewModel(
     @UiThread
     private fun monitorCurrentSwapAddress() {
         viewModelScope.launch {
-            val swapAddressFormat = UserPrefs.getSwapAddressFormat(context).first()
+            val swapAddressFormat = userPrefs.getSwapAddressFormat.first()
             if (swapAddressFormat == SwapAddressFormat.LEGACY) {
                 val legacySwapInAddress = peerManager.getPeer().swapInWallet.legacySwapInAddress
                 val image = BitmapHelper.generateBitmap(legacySwapInAddress).asImageBitmap()
@@ -145,7 +143,7 @@ class ReceiveViewModel(
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             val application = checkNotNull(extras[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as? PhoenixApplication)
             @Suppress("UNCHECKED_CAST")
-            return ReceiveViewModel(chain, peerManager, walletManager, application.internalDataRepository, application.applicationContext) as T
+            return ReceiveViewModel(chain, peerManager, walletManager, application.internalDataRepository, application.userPrefs) as T
         }
     }
 }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/spliceout/SpliceOutView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/spliceout/SpliceOutView.kt
@@ -74,7 +74,7 @@ fun SendSpliceOutView(
         header = { BackButtonWithBalance(onBackClick = onBackClick, balance = balance) },
         topContent = {
             AmountHeroInput(
-                initialAmount = amount?.toMilliSatoshi(),
+                amount = amount?.toMilliSatoshi(),
                 onAmountChange = {
                     amountErrorMessage = ""
                     val newAmount = it?.amount?.truncateToSatoshi()

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/InflightPaymentsWatcher.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/InflightPaymentsWatcher.kt
@@ -39,7 +39,7 @@ import fr.acinq.phoenix.android.PhoenixApplication
 import fr.acinq.phoenix.android.security.EncryptedSeed
 import fr.acinq.phoenix.android.security.SeedManager
 import fr.acinq.phoenix.android.utils.SystemNotificationHelper
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
+import fr.acinq.phoenix.android.utils.datastore.UserPrefsRepository
 import fr.acinq.phoenix.data.LocalChannelInfo
 import fr.acinq.phoenix.data.StartupParams
 import fr.acinq.phoenix.data.inFlightPaymentsCount
@@ -47,6 +47,7 @@ import fr.acinq.phoenix.legacy.utils.LegacyAppStatus
 import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
 import fr.acinq.phoenix.managers.AppConfigurationManager
 import fr.acinq.phoenix.managers.AppConnectionsDaemon
+import fr.acinq.phoenix.utils.MnemonicLanguage
 import fr.acinq.phoenix.utils.PlatformContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -87,7 +88,9 @@ class InflightPaymentsWatcher(context: Context, workerParams: WorkerParameters) 
 
         try {
 
-            val internalData = (applicationContext as PhoenixApplication).internalDataRepository
+            val application = (applicationContext as PhoenixApplication)
+            val internalData = application.internalDataRepository
+            val userPrefs = application.userPrefs
             val inFlightPaymentsCount = internalData.getInFlightPaymentsCount.first()
 
             if (inFlightPaymentsCount == 0) {
@@ -150,7 +153,7 @@ class InflightPaymentsWatcher(context: Context, workerParams: WorkerParameters) 
 
                                     jobChannelsWatcher = launch {
                                         val mnemonics = encryptedSeed.decrypt()
-                                        business = startBusiness(mnemonics)
+                                        business = startBusiness(mnemonics, userPrefs)
 
                                         business?.connectionsManager?.connections?.first { it.global is Connection.ESTABLISHED }
                                         log.info("connections established, watching channels for in-flight payments...")
@@ -216,17 +219,17 @@ class InflightPaymentsWatcher(context: Context, workerParams: WorkerParameters) 
         }
     }
 
-    private suspend fun startBusiness(mnemonics: ByteArray): PhoenixBusiness {
+    private suspend fun startBusiness(mnemonics: ByteArray, userPrefs: UserPrefsRepository): PhoenixBusiness {
         // retrieve preferences before starting business
         val business = PhoenixBusiness(PlatformContext(applicationContext))
-        val electrumServer = UserPrefs.getElectrumServer(applicationContext).first()
-        val isTorEnabled = UserPrefs.getIsTorEnabled(applicationContext).first()
-        val liquidityPolicy = UserPrefs.getLiquidityPolicy(applicationContext).first()
+        val electrumServer = userPrefs.getElectrumServer.first()
+        val isTorEnabled = userPrefs.getIsTorEnabled.first()
+        val liquidityPolicy = userPrefs.getLiquidityPolicy.first()
         val trustedSwapInTxs = LegacyPrefsDatastore.getMigrationTrustedSwapInTxs(applicationContext).first()
-        val preferredFiatCurrency = UserPrefs.getFiatCurrency(applicationContext).first()
+        val preferredFiatCurrency = userPrefs.getFiatCurrency.first()
 
         // preparing business
-        val seed = business.walletManager.mnemonicsToSeed(EncryptedSeed.toMnemonics(mnemonics))
+        val seed = business.walletManager.mnemonicsToSeed(EncryptedSeed.toMnemonics(mnemonics), wordList = MnemonicLanguage.English.wordlist())
         business.walletManager.loadWallet(seed)
         business.appConfigurationManager.updateElectrumConfig(electrumServer)
         business.appConfigurationManager.updatePreferredFiatCurrencies(

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/NodeService.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/NodeService.kt
@@ -32,7 +32,7 @@ import fr.acinq.phoenix.android.security.SeedManager
 import fr.acinq.phoenix.android.utils.LegacyMigrationHelper
 import fr.acinq.phoenix.android.utils.SystemNotificationHelper
 import fr.acinq.phoenix.android.utils.datastore.InternalDataRepository
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
+import fr.acinq.phoenix.android.utils.datastore.UserPrefsRepository
 import fr.acinq.phoenix.data.StartupParams
 import fr.acinq.phoenix.data.inFlightPaymentsCount
 import fr.acinq.phoenix.legacy.utils.LegacyPrefsDatastore
@@ -40,6 +40,7 @@ import fr.acinq.phoenix.managers.AppConfigurationManager
 import fr.acinq.phoenix.managers.CurrencyManager
 import fr.acinq.phoenix.managers.NodeParamsManager
 import fr.acinq.phoenix.managers.PeerManager
+import fr.acinq.phoenix.utils.MnemonicLanguage
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -246,20 +247,22 @@ class NodeService : Service() {
         }
 
         // retrieve preferences before starting business
-        val business = (applicationContext as? PhoenixApplication)?.business?.first() ?: throw RuntimeException("invalid context type, should be PhoenixApplication")
-        val electrumServer = UserPrefs.getElectrumServer(applicationContext).first()
-        val isTorEnabled = UserPrefs.getIsTorEnabled(applicationContext).first()
-        val liquidityPolicy = UserPrefs.getLiquidityPolicy(applicationContext).first()
+        val application = (applicationContext as? PhoenixApplication) ?: throw RuntimeException("invalid context type, should be PhoenixApplication")
+        val userPrefs = application.userPrefs
+        val business = application.business.filterNotNull().first()
+        val electrumServer = userPrefs.getElectrumServer.first()
+        val isTorEnabled = userPrefs.getIsTorEnabled.first()
+        val liquidityPolicy = userPrefs.getLiquidityPolicy.first()
         val trustedSwapInTxs = LegacyPrefsDatastore.getMigrationTrustedSwapInTxs(applicationContext).first()
-        val preferredFiatCurrency = UserPrefs.getFiatCurrency(applicationContext).first()
+        val preferredFiatCurrency = userPrefs.getFiatCurrency.first()
 
-        monitorPaymentsJob = serviceScope.launch { monitorPaymentsWhenHeadless(business.peerManager, business.currencyManager) }
+        monitorPaymentsJob = serviceScope.launch { monitorPaymentsWhenHeadless(business.peerManager, business.currencyManager, userPrefs) }
         monitorNodeEventsJob = serviceScope.launch { monitorNodeEvents(business.peerManager, business.nodeParamsManager) }
         monitorFcmTokenJob = serviceScope.launch { monitorFcmToken(business) }
         monitorInFlightPaymentsJob = serviceScope.launch { monitorInFlightPayments(business.peerManager) }
 
         // preparing business
-        val seed = business.walletManager.mnemonicsToSeed(EncryptedSeed.toMnemonics(decryptedMnemonics))
+        val seed = business.walletManager.mnemonicsToSeed(EncryptedSeed.toMnemonics(decryptedMnemonics), wordList = MnemonicLanguage.English.wordlist())
         business.walletManager.loadWallet(seed)
         business.appConfigurationManager.updateElectrumConfig(electrumServer)
         business.appConfigurationManager.updatePreferredFiatCurrencies(
@@ -333,7 +336,7 @@ class NodeService : Service() {
         }
     }
 
-    private suspend fun monitorPaymentsWhenHeadless(peerManager: PeerManager, currencyManager: CurrencyManager) {
+    private suspend fun monitorPaymentsWhenHeadless(peerManager: PeerManager, currencyManager: CurrencyManager, userPrefs: UserPrefsRepository) {
         peerManager.getPeer().eventsFlow.collect { event ->
             when (event) {
                 is PaymentReceived -> {
@@ -341,6 +344,7 @@ class NodeService : Service() {
                         receivedInBackground.add(event.received.amount)
                         SystemNotificationHelper.notifyPaymentsReceived(
                             context = applicationContext,
+                            userPrefs = userPrefs,
                             paymentHash = event.incomingPayment.paymentHash,
                             amount = event.received.amount,
                             rates = currencyManager.ratesFlow.value,

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/AppLockView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/AppLockView.kt
@@ -29,8 +29,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.components.*
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.android.utils.*
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import kotlinx.coroutines.launch
 
 
@@ -40,7 +40,7 @@ fun AppLockView(
 ) {
     val context = LocalContext.current
     val authStatus = BiometricsHelper.authStatus(context)
-    val isScreenLockActive by UserPrefs.getIsScreenLockActive(context).collectAsState(null)
+    val isScreenLockActive by userPrefs.getIsScreenLockActive.collectAsState(null)
 
     DefaultScreenLayout {
         DefaultScreenHeader(onBackClick = onBackClick, title = stringResource(id = R.string.accessctrl_title))
@@ -72,6 +72,7 @@ private fun AuthSwitch(
     isScreenLockActive: Boolean?,
 ) {
     val context = LocalContext.current
+    val userPrefs = userPrefs
     val activity = context.findActivity()
     val scope = rememberCoroutineScope()
     var errorMessage by remember { mutableStateOf("") }
@@ -91,7 +92,7 @@ private fun AuthSwitch(
                     if (it) {
                         BiometricsHelper
                         // if user wants to enable screen lock, we don't need to check authentication
-                        UserPrefs.saveIsScreenLockActive(context, true)
+                        userPrefs.saveIsScreenLockActive(true)
                     } else {
                         // if user wants to disable screen lock, we must first check his credentials
                         val promptInfo = BiometricPrompt.PromptInfo.Builder().apply {
@@ -101,7 +102,7 @@ private fun AuthSwitch(
                         BiometricsHelper.getPrompt(
                             activity = activity,
                             onSuccess = {
-                                scope.launch { UserPrefs.saveIsScreenLockActive(context, false) }
+                                scope.launch { userPrefs.saveIsScreenLockActive(false) }
                             },
                             onFailure = { errorCode ->
                                 errorMessage = errorCode?.let { BiometricsHelper.getAuthErrorMessage(context, code = it) } ?: ""

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/ElectrumView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/ElectrumView.kt
@@ -43,7 +43,6 @@ import fr.acinq.phoenix.android.components.*
 import fr.acinq.phoenix.android.components.feedback.ErrorMessage
 import fr.acinq.phoenix.android.components.mvi.MVIView
 import fr.acinq.phoenix.android.utils.*
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.controllers.config.ElectrumConfiguration
 import fr.acinq.phoenix.data.ElectrumConfig
 import fr.acinq.secp256k1.Hex
@@ -57,9 +56,9 @@ import java.text.NumberFormat
 @Composable
 fun ElectrumView() {
     val nc = navController
-    val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val electrumServerInPrefs by UserPrefs.getElectrumServer(context).collectAsState(initial = null)
+    val userPrefs = userPrefs
+    val electrumServerInPrefs by userPrefs.getElectrumServer.collectAsState(initial = null)
     var showCustomServerDialog by rememberSaveable { mutableStateOf(false) }
 
     DefaultScreenLayout {
@@ -78,7 +77,7 @@ fun ElectrumView() {
                         initialAddress = electrumServerInPrefs,
                         onConfirm = { address ->
                             scope.launch {
-                                UserPrefs.saveElectrumServer(context, address)
+                                userPrefs.saveElectrumServer(address)
                                 postIntent(ElectrumConfiguration.Intent.UpdateElectrumServer(address))
                                 showCustomServerDialog = false
                             }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/NotificationsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/NotificationsView.kt
@@ -49,7 +49,6 @@ import fr.acinq.phoenix.android.services.ChannelsWatcher
 import fr.acinq.phoenix.android.utils.Converter.toAbsoluteDateTimeString
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 import fr.acinq.phoenix.android.utils.Converter.toRelativeDateString
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.android.utils.safeLet
 import fr.acinq.phoenix.data.Notification
 import fr.acinq.phoenix.data.WatchTowerOutcome
@@ -119,6 +118,7 @@ private fun PermamentNotice(
 ) {
     val context = LocalContext.current
     val internalData = application.internalDataRepository
+    val userPrefs = application.userPrefs
     val nc = LocalNavController.current
     val scope = rememberCoroutineScope()
 
@@ -173,7 +173,7 @@ private fun PermamentNotice(
                         confirmStateChange = {
                             if (it == DismissValue.DismissedToEnd || it == DismissValue.DismissedToStart) {
                                 scope.launch {
-                                    UserPrefs.saveShowNotificationPermissionReminder(context, false)
+                                    userPrefs.saveShowNotificationPermissionReminder(false)
                                 }
                             }
                             true

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/PaymentSettingsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/PaymentSettingsView.kt
@@ -53,9 +53,7 @@ fun PaymentSettingsView(
 ) {
     val nc = navController
     val scope = rememberCoroutineScope()
-    val context = LocalContext.current
     val userPrefs = userPrefs
-    val btcUnit = LocalBitcoinUnit.current
 
     var showDescriptionDialog by rememberSaveable { mutableStateOf(false) }
     var showExpiryDialog by rememberSaveable { mutableStateOf(false) }
@@ -109,7 +107,6 @@ fun PaymentSettingsView(
                         when (swapAddressFormat) {
                             SwapAddressFormat.LEGACY -> Text(text = stringResource(id = R.string.paymentsettings_swap_format_legacy_title))
                             SwapAddressFormat.TAPROOT_ROTATE -> Text(text = stringResource(id = R.string.paymentsettings_swap_format_taproot_title))
-                            else -> Text(text = stringResource(id = R.string.utils_unknown))
                         }
                     },
                     enabled = true,
@@ -121,6 +118,20 @@ fun PaymentSettingsView(
                     initialShowDialog = false
                 )
             }
+        }
+
+        val isOverpaymentEnabled by userPrefs.getIsOverpaymentEnabled.collectAsState(initial = false)
+        CardHeader(text = stringResource(id = R.string.paymentsettings_category_outgoing))
+        Card {
+            SettingSwitch(
+                title = stringResource(id = R.string.paymentsettings_overpayment_title),
+                description = stringResource(id = if (isOverpaymentEnabled) R.string.paymentsettings_overpayment_enabled else R.string.paymentsettings_overpayment_disabled),
+                enabled = true,
+                isChecked = isOverpaymentEnabled,
+                onCheckChangeAttempt = {
+                    scope.launch { userPrefs.saveIsOverpaymentEnabled(it) }
+                }
+            )
         }
 
         val prefLnurlAuthSchemeState = userPrefs.getLnurlAuthScheme.collectAsState(initial = null)

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/PaymentSettingsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/PaymentSettingsView.kt
@@ -41,8 +41,8 @@ import fr.acinq.phoenix.android.LocalBitcoinUnit
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.components.*
 import fr.acinq.phoenix.android.navController
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.android.utils.datastore.SwapAddressFormat
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.data.lnurl.LnurlAuth
 import kotlinx.coroutines.launch
 import java.text.NumberFormat
@@ -54,14 +54,15 @@ fun PaymentSettingsView(
     val nc = navController
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
+    val userPrefs = userPrefs
     val btcUnit = LocalBitcoinUnit.current
 
     var showDescriptionDialog by rememberSaveable { mutableStateOf(false) }
     var showExpiryDialog by rememberSaveable { mutableStateOf(false) }
 
-    val invoiceDefaultDesc by UserPrefs.getInvoiceDefaultDesc(LocalContext.current).collectAsState(initial = "")
-    val invoiceDefaultExpiry by UserPrefs.getInvoiceDefaultExpiry(LocalContext.current).collectAsState(null)
-    val swapAddressFormatState = UserPrefs.getSwapAddressFormat(context).collectAsState(initial = null)
+    val invoiceDefaultDesc by userPrefs.getInvoiceDefaultDesc.collectAsState(initial = "")
+    val invoiceDefaultExpiry by userPrefs.getInvoiceDefaultExpiry.collectAsState(null)
+    val swapAddressFormatState = userPrefs.getSwapAddressFormat.collectAsState(initial = null)
 
     DefaultScreenLayout {
         DefaultScreenHeader(
@@ -115,14 +116,14 @@ fun PaymentSettingsView(
                     selectedItem = swapAddressFormat,
                     preferences = schemes,
                     onPreferenceSubmit = {
-                        scope.launch { UserPrefs.saveSwapAddressFormat(context, it.item) }
+                        scope.launch { userPrefs.saveSwapAddressFormat(it.item) }
                     },
                     initialShowDialog = false
                 )
             }
         }
 
-        val prefLnurlAuthSchemeState = UserPrefs.getLnurlAuthScheme(context).collectAsState(initial = null)
+        val prefLnurlAuthSchemeState = userPrefs.getLnurlAuthScheme.collectAsState(initial = null)
         val prefLnurlAuthScheme = prefLnurlAuthSchemeState.value
         if (prefLnurlAuthScheme != null) {
             CardHeader(text = stringResource(id = R.string.paymentsettings_category_lnurl))
@@ -152,7 +153,7 @@ fun PaymentSettingsView(
                     selectedItem = prefLnurlAuthScheme,
                     preferences = schemes,
                     onPreferenceSubmit = {
-                        scope.launch { UserPrefs.saveLnurlAuthScheme(context, it.item) }
+                        scope.launch { userPrefs.saveLnurlAuthScheme(it.item) }
                     },
                     initialShowDialog = initialShowLnurlAuthSchemeDialog
                 )
@@ -165,7 +166,7 @@ fun PaymentSettingsView(
             description = invoiceDefaultDesc,
             onDismiss = { showDescriptionDialog = false },
             onConfirm = {
-                scope.launch { UserPrefs.saveInvoiceDefaultDesc(context, it) }
+                scope.launch { userPrefs.saveInvoiceDefaultDesc(it) }
                 showDescriptionDialog = false
             }
         )
@@ -177,7 +178,7 @@ fun PaymentSettingsView(
                 expiry = it,
                 onDismiss = { showExpiryDialog = false },
                 onConfirm = {
-                    scope.launch { UserPrefs.saveInvoiceDefaultExpiry(context, it.toLong()) }
+                    scope.launch { userPrefs.saveInvoiceDefaultExpiry(it.toLong()) }
                     showExpiryDialog = false
                 }
             )

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/TorConfigView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/TorConfigView.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import fr.acinq.lightning.utils.Connection
@@ -33,7 +32,7 @@ import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.business
 import fr.acinq.phoenix.android.components.*
 import fr.acinq.phoenix.android.navController
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.android.utils.negativeColor
 import fr.acinq.phoenix.android.utils.orange
 import fr.acinq.phoenix.android.utils.positiveColor
@@ -41,11 +40,11 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun TorConfigView() {
-    val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val business = business
     val nc = navController
-    val torEnabledState = UserPrefs.getIsTorEnabled(context).collectAsState(initial = null)
+    val userPrefs = userPrefs
+    val torEnabledState = userPrefs.getIsTorEnabled.collectAsState(initial = null)
     val connState = business.connectionsManager.connections.collectAsState()
 
     DefaultScreenLayout {
@@ -69,7 +68,7 @@ fun TorConfigView() {
                     onCheckChangeAttempt = {
                         scope.launch {
                             business.appConfigurationManager.updateTorUsage(it)
-                            UserPrefs.saveIsTorEnabled(context, it)
+                            userPrefs.saveIsTorEnabled(it)
                         }
                     }
                 )

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/fees/AdvancedIncomingFeePolicy.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/fees/AdvancedIncomingFeePolicy.kt
@@ -34,10 +34,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import fr.acinq.bitcoin.Satoshi
 import fr.acinq.lightning.payment.LiquidityPolicy
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.business
@@ -51,9 +49,7 @@ import fr.acinq.phoenix.android.components.ProgressView
 import fr.acinq.phoenix.android.components.SettingSwitch
 import fr.acinq.phoenix.android.components.feedback.WarningMessage
 import fr.acinq.phoenix.android.components.enableOrFade
-import fr.acinq.phoenix.android.utils.Converter.toPrettyString
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
-import fr.acinq.phoenix.data.BitcoinUnit
+import fr.acinq.phoenix.android.userPrefs
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
@@ -61,14 +57,14 @@ import kotlin.math.roundToInt
 fun AdvancedIncomingFeePolicy(
     onBackClick: () -> Unit
 ) {
-    val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    val userPrefs = userPrefs
     val peerManager = business.peerManager
     val notificationsManager = business.notificationsManager
 
-    val maxSatFeePrefsFlow = UserPrefs.getIncomingMaxSatFeeInternal(context).collectAsState(null)
-    val maxPropFeePrefsFlow = UserPrefs.getIncomingMaxPropFeeInternal(context).collectAsState(null)
-    val liquidityPolicyInPrefsFlow = UserPrefs.getLiquidityPolicy(context).collectAsState(null)
+    val maxSatFeePrefsFlow = userPrefs.getIncomingMaxSatFeeInternal.collectAsState(null)
+    val maxPropFeePrefsFlow = userPrefs.getIncomingMaxPropFeeInternal.collectAsState(null)
+    val liquidityPolicyInPrefsFlow = userPrefs.getLiquidityPolicy.collectAsState(null)
 
     DefaultScreenLayout {
         DefaultScreenHeader(
@@ -128,7 +124,7 @@ fun AdvancedIncomingFeePolicy(
                         onClick = {
                             scope.launch {
                                 newPolicy?.let {
-                                    UserPrefs.saveLiquidityPolicy(context, newPolicy)
+                                    userPrefs.saveLiquidityPolicy(newPolicy)
                                     peerManager.updatePeerLiquidityPolicy(newPolicy)
                                     notificationsManager.dismissAllNotifications()
                                 }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/fees/LiquidityPolicyView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/fees/LiquidityPolicyView.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -43,16 +42,15 @@ import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.business
 import fr.acinq.phoenix.android.components.*
 import fr.acinq.phoenix.android.fiatRate
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 import fr.acinq.phoenix.android.utils.annotatedStringResource
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.android.utils.negativeColor
 import fr.acinq.phoenix.data.BitcoinUnit
 import fr.acinq.phoenix.data.MempoolFeerate
 import fr.acinq.phoenix.data.canRequestLiquidity
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun LiquidityPolicyView(
     onBackClick: () -> Unit,
@@ -61,10 +59,11 @@ fun LiquidityPolicyView(
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    val userPrefs = userPrefs
 
-    val maxSatFeePrefsFlow = UserPrefs.getIncomingMaxSatFeeInternal(context).collectAsState(null)
-    val maxPropFeePrefsFlow = UserPrefs.getIncomingMaxPropFeeInternal(context).collectAsState(null)
-    val liquidityPolicyPrefsFlow = UserPrefs.getLiquidityPolicy(context).collectAsState(null)
+    val maxSatFeePrefsFlow = userPrefs.getIncomingMaxSatFeeInternal.collectAsState(null)
+    val maxPropFeePrefsFlow = userPrefs.getIncomingMaxPropFeeInternal.collectAsState(null)
+    val liquidityPolicyPrefsFlow = userPrefs.getLiquidityPolicy.collectAsState(null)
 
     val peerManager = business.peerManager
     val notificationsManager = business.notificationsManager
@@ -147,7 +146,7 @@ fun LiquidityPolicyView(
                         keyboardManager?.hide()
                         scope.launch {
                             if (newPolicy != null) {
-                                UserPrefs.saveLiquidityPolicy(context, newPolicy)
+                                userPrefs.saveLiquidityPolicy(newPolicy)
                                 peerManager.updatePeerLiquidityPolicy(newPolicy)
                                 notificationsManager.dismissAllNotifications()
                             }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/SwapInWalletInfo.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/SwapInWalletInfo.kt
@@ -36,7 +36,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -58,10 +57,10 @@ import fr.acinq.phoenix.android.components.DefaultScreenLayout
 import fr.acinq.phoenix.android.components.HSeparator
 import fr.acinq.phoenix.android.components.IconPopup
 import fr.acinq.phoenix.android.components.TextWithIcon
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 import fr.acinq.phoenix.android.utils.Converter.toRelativeDateString
 import fr.acinq.phoenix.android.utils.annotatedStringResource
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.android.utils.negativeColor
 import fr.acinq.phoenix.data.Notification
 import fr.acinq.phoenix.utils.extensions.nextTimeout
@@ -76,10 +75,9 @@ fun SwapInWallet(
     onViewChannelPolicyClick: () -> Unit,
     onAdvancedClick: () -> Unit,
 ) {
-    val context = LocalContext.current
     val btcUnit = LocalBitcoinUnit.current
 
-    val liquidityPolicyInPrefs by UserPrefs.getLiquidityPolicy(context).collectAsState(null)
+    val liquidityPolicyInPrefs by userPrefs.getLiquidityPolicy.collectAsState(null)
     val swapInWallet by business.peerManager.swapInWallet.collectAsState()
     var showAdvancedMenuPopIn by remember { mutableStateOf(false) }
 

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/startup/StartupView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/startup/StartupView.kt
@@ -61,7 +61,6 @@ import fr.acinq.bitcoin.MnemonicCode
 import fr.acinq.phoenix.android.AppViewModel
 import fr.acinq.phoenix.android.BuildConfig
 import fr.acinq.phoenix.android.R
-import fr.acinq.phoenix.android.application
 import fr.acinq.phoenix.android.components.BorderButton
 import fr.acinq.phoenix.android.components.Button
 import fr.acinq.phoenix.android.components.Card
@@ -69,12 +68,13 @@ import fr.acinq.phoenix.android.components.FilledButton
 import fr.acinq.phoenix.android.components.HSeparator
 import fr.acinq.phoenix.android.components.TextWithIcon
 import fr.acinq.phoenix.android.components.feedback.ErrorMessage
+import fr.acinq.phoenix.android.internalData
 import fr.acinq.phoenix.android.security.SeedFileState
 import fr.acinq.phoenix.android.security.SeedManager
 import fr.acinq.phoenix.android.services.NodeServiceState
+import fr.acinq.phoenix.android.userPrefs
 import fr.acinq.phoenix.android.utils.BiometricsHelper
 import fr.acinq.phoenix.android.utils.Logging
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
 import fr.acinq.phoenix.android.utils.errorOutlinedTextFieldColors
 import fr.acinq.phoenix.android.utils.findActivity
 import fr.acinq.phoenix.android.utils.logger
@@ -94,8 +94,8 @@ fun StartupView(
 ) {
     val context = LocalContext.current
     val serviceState by appVM.serviceState.observeAsState()
-    val showIntro by application.internalDataRepository.getShowIntro.collectAsState(initial = null)
-    val isLockActiveState by UserPrefs.getIsScreenLockActive(context).collectAsState(initial = null)
+    val showIntro by internalData.getShowIntro.collectAsState(initial = null)
+    val isLockActiveState by userPrefs.getIsScreenLockActive.collectAsState(initial = null)
 
     Column(
         modifier = Modifier

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/SystemNotificationHelper.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/SystemNotificationHelper.kt
@@ -24,9 +24,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.os.Build
 import android.text.format.DateUtils
-import androidx.compose.ui.res.stringResource
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -42,7 +40,7 @@ import fr.acinq.phoenix.android.MainActivity
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.utils.Converter.toAbsoluteDateString
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
+import fr.acinq.phoenix.android.utils.datastore.UserPrefsRepository
 import fr.acinq.phoenix.data.BitcoinUnit
 import fr.acinq.phoenix.data.ExchangeRate
 import fr.acinq.phoenix.data.FiatCurrency
@@ -51,7 +49,6 @@ import kotlinx.coroutines.flow.first
 import org.slf4j.LoggerFactory
 import java.text.DecimalFormat
 import java.util.Random
-import kotlin.math.ceil
 
 object SystemNotificationHelper {
     private const val PAYMENT_FAILED_NOTIF_ID = 354319
@@ -247,16 +244,17 @@ object SystemNotificationHelper {
 
     suspend fun notifyPaymentsReceived(
         context: Context,
+        userPrefs: UserPrefsRepository,
         paymentHash: ByteVector32,
         amount: MilliSatoshi,
         rates: List<ExchangeRate>,
         isHeadless: Boolean,
     ): Notification {
-        val isFiat = UserPrefs.getIsAmountInFiat(context).first() && rates.isNotEmpty()
+        val isFiat = userPrefs.getIsAmountInFiat.first() && rates.isNotEmpty()
         val unit = if (isFiat) {
-            UserPrefs.getFiatCurrency(context).first()
+            userPrefs.getFiatCurrency.first()
         } else {
-            UserPrefs.getBitcoinUnit(context).first()
+            userPrefs.getBitcoinUnit.first()
         }
         val rate = if (isFiat) {
             when (val rate = rates.find { it.fiatCurrency == unit }) {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/Theme.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/Theme.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -41,7 +40,7 @@ import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import fr.acinq.phoenix.android.LocalTheme
 import fr.acinq.phoenix.android.Screen
 import fr.acinq.phoenix.android.isDarkTheme
-import fr.acinq.phoenix.android.utils.datastore.UserPrefs
+import fr.acinq.phoenix.android.userPrefs
 
 // primary for testnet
 val horizon = Color(0xff91b4d1)
@@ -211,8 +210,7 @@ fun PhoenixAndroidTheme(
     navController: NavController,
     content: @Composable () -> Unit
 ) {
-    val context = LocalContext.current
-    val userTheme by UserPrefs.getUserTheme(context).collectAsState(initial = UserTheme.SYSTEM)
+    val userTheme by userPrefs.getUserTheme.collectAsState(initial = UserTheme.SYSTEM)
     val systemUiController = rememberSystemUiController()
 
     CompositionLocalProvider(

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/datastore/UserPrefsRepository.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/datastore/UserPrefsRepository.kt
@@ -77,6 +77,7 @@ class UserPrefsRepository(private val data: DataStore<Preferences>) {
         private val TRAMPOLINE_MAX_PROPORTIONAL_FEE = longPreferencesKey("TRAMPOLINE_MAX_PROPORTIONAL_FEE")
         private val SWAP_ADDRESS_FORMAT = intPreferencesKey("SWAP_ADDRESS_FORMAT")
         private val LNURL_AUTH_SCHEME = intPreferencesKey("LNURL_AUTH_SCHEME")
+        private val IS_OVERPAYMENT_ENABLED = booleanPreferencesKey("IS_OVERPAYMENT_ENABLED")
         // liquidity policy & channels management
         private val LIQUIDITY_POLICY = stringPreferencesKey("LIQUIDITY_POLICY")
         private val INCOMING_MAX_SAT_FEE_INTERNAL_TRACKER = longPreferencesKey("INCOMING_MAX_SAT_FEE_INTERNAL_TRACKER")
@@ -236,6 +237,9 @@ class UserPrefsRepository(private val data: DataStore<Preferences>) {
             it[LNURL_AUTH_SCHEME] = scheme.id
         }
     }
+
+    val getIsOverpaymentEnabled: Flow<Boolean> = safeData.map { it[IS_OVERPAYMENT_ENABLED] ?: false }
+    suspend fun saveIsOverpaymentEnabled(enabled: Boolean) = data.edit { it[IS_OVERPAYMENT_ENABLED] = enabled }
 
     val getIsTorEnabled: Flow<Boolean> = safeData.map { it[IS_TOR_ENABLED] ?: false }
     suspend fun saveIsTorEnabled(isEnabled: Boolean) = data.edit { it[IS_TOR_ENABLED] = isEnabled }

--- a/phoenix-android/src/main/res/drawable/ic_minus_circle.xml
+++ b/phoenix-android/src/main/res/drawable/ic_minus_circle.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="@dimen/icon_size"
+    android:height="@dimen/icon_size"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M12,12m-10,0a10,10 0,1 1,20 0a10,10 0,1 1,-20 0"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M8,12L16,12"
+        android:strokeWidth="2"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/phoenix-android/src/main/res/drawable/ic_plus_circle.xml
+++ b/phoenix-android/src/main/res/drawable/ic_plus_circle.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="@dimen/icon_size"
+    android:height="@dimen/icon_size"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M12,12m-10,0a10,10 0,1 1,20 0a10,10 0,1 1,-20 0"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M12,8L12,16"
+        android:strokeWidth="2"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M8,12L16,12"
+        android:strokeWidth="2"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/phoenix-android/src/main/res/drawable/ic_revert.xml
+++ b/phoenix-android/src/main/res/drawable/ic_revert.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="@dimen/icon_size"
+    android:height="@dimen/icon_size"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M9,14 L4,9l5,-5"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M4,9h10.5a5.5,5.5 0,0 1,5.5 5.5v0a5.5,5.5 0,0 1,-5.5 5.5H11"
+        android:strokeWidth="1.5"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -613,6 +613,7 @@
     <string name="paymentsettings_title">Payment options</string>
 
     <string name="paymentsettings_category_incoming">Incoming payments</string>
+    <string name="paymentsettings_category_outgoing">Outgoing payments</string>
     <string name="paymentsettings_category_lnurl">LNURL</string>
 
     <string name="paymentsettings_defaultdesc_title">Invoice description</string>
@@ -636,6 +637,10 @@
     <string name="paymentsettings_swap_format_legacy_desc">A less efficient and less private format that does not rotate addresses. However, it is compatible with almost every services and wallets.</string>
     <string name="paymentsettings_swap_format_taproot_title">Taproot (recommended)</string>
     <string name="paymentsettings_swap_format_taproot_desc">Default format, with better privacy, cheaper fees and address rotation. Some services or wallets may however not understand the address.</string>
+
+    <string name="paymentsettings_overpayment_title">Enable overpayment</string>
+    <string name="paymentsettings_overpayment_enabled">You\'ll be able to overpay Lightning invoices up to 2 times the amount requested. Useful for manual tipping, or as a privacy measure.</string>
+    <string name="paymentsettings_overpayment_disabled">Disabled (default)</string>
 
     <!-- settings: currencies -->
 


### PR DESCRIPTION
This PR adds an option in the payments settings to allow the app to overpay (up to 2 times) Lightning invoices, when applicable. This option is disabled by default.

Note that disabling overpayments is needed because several services do not acknowledge overpayments (e.g. exchanges not crediting the additional funds to the user).

This is a follow-up of #538 made by @ndungudedan 

### Overpayment option

<img width="270" alt="image" src="https://github.com/ACINQ/phoenix/assets/5765435/e46f549d-549b-4e25-a0d9-6db6c9b733c4">

<img width="270" alt="image" src="https://github.com/ACINQ/phoenix/assets/5765435/c37aa1e4-9992-4e35-a35f-fd061c2483a3">

### Tipping buttons on Android

Unlike the iOS app, the Android app did not have the tipping buttons. It's now needed since with overpayment being disabled by default, tipping becomes harder to do. Tipping is done by increment of 5%.

Example with a 2000 sat payment, after a 10% tip:

<img width="270" alt="image" src="https://github.com/ACINQ/phoenix/assets/5765435/86d9e50f-fb82-46a1-831a-3d661d85ee98">

<img width="270" alt="image" src="https://github.com/ACINQ/phoenix/assets/5765435/b539cf12-7c38-4173-bdf7-021934c5d7b2">


