### PR TITLE
(ios) Fix swap-in issues

### DIFF
--- a/phoenix-ios/phoenix-ios/officers/BusinessManager.swift
+++ b/phoenix-ios/phoenix-ios/officers/BusinessManager.swift
@@ -132,6 +132,7 @@ class BusinessManager {
 		business.start(startupParams: startupParams)
 		
 		setup()
+		startTasks()
 	}
 
 	public func stop() {

--- a/phoenix-ios/phoenix-ios/views/notifications/NotificationsView.swift
+++ b/phoenix-ios/phoenix-ios/views/notifications/NotificationsView.swift
@@ -272,9 +272,8 @@ struct NotificationsView : View {
 		log.trace("bizNotificationsChanges()")
 		
 		bizNotifications_payment = list.filter({ item in
-			if let paymentRejected = item.notification as? PhoenixShared.Notification.PaymentRejected {
-				// Remove items where source == onChain
-				return !(paymentRejected.source == Lightning_kmpLiquidityEventsSource.onchainwallet)
+			if let _ = item.notification as? PhoenixShared.Notification.PaymentRejected {
+				return true
 			} else {
 				return false
 			}


### PR DESCRIPTION
We were recently forced to [revert](https://github.com/ACINQ/phoenix/pull/551) a commit. And during the process, a call to `startTasks()` got dropped, which resulted in the swap-in wallet not functioning correctly.