### PR TITLE
[IOS UI FIX]: check if send amount is within range

### DIFF
--- a/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
@@ -838,6 +838,11 @@ struct ValidateView: View {
 		guard let recipientAmountMsat = parsedAmountMsat() else {
 			return nil
 		}
+        
+        let range = priceRange()
+        if range != nil && recipientAmountMsat >= range!.max.msat {
+            return nil
+        }
 		
 		var preTipMsat: Int64? = nil
 		if let paymentRequest = paymentRequest() {


### PR DESCRIPTION
This PR resolves issue #547 

Checking if the amount being sent is within the allowed range before performing any calculations on the input amount resolves this arithmetic error.