### PR TITLE
Handle new outgoing payment failures

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/details/PaymentDetailsSplashView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/details/PaymentDetailsSplashView.kt
@@ -779,7 +779,7 @@ private fun translatePaymentError(paymentFailure: OutgoingPaymentFailure): Strin
                 FinalFailure.FeaturesNotSupported -> stringResource(id = R.string.outgoing_failuremessage_unsupported_features)
                 FinalFailure.InsufficientBalance -> stringResource(id = R.string.outgoing_failuremessage_not_enough_balance)
                 FinalFailure.InvalidPaymentAmount -> stringResource(id = R.string.outgoing_failuremessage_invalid_amount)
-                FinalFailure.NoAvailableChannels -> stringResource(id = R.string.outgoing_failuremessage_not_enough_balance)
+                FinalFailure.NoAvailableChannels -> stringResource(id = R.string.outgoing_failuremessage_no_available_channels)
                 FinalFailure.RecipientUnreachable -> stringResource(id = R.string.outgoing_failuremessage_noroutefound)
                 FinalFailure.RetryExhausted -> stringResource(id = R.string.outgoing_failuremessage_noroutefound)
                 FinalFailure.UnknownError -> stringResource(id = R.string.outgoing_failuremessage_unknown)

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/details/PaymentDetailsSplashView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/details/PaymentDetailsSplashView.kt
@@ -780,7 +780,6 @@ private fun translatePaymentError(paymentFailure: OutgoingPaymentFailure): Strin
                 FinalFailure.InsufficientBalance -> stringResource(id = R.string.outgoing_failuremessage_not_enough_balance)
                 FinalFailure.InvalidPaymentAmount -> stringResource(id = R.string.outgoing_failuremessage_invalid_amount)
                 FinalFailure.NoAvailableChannels -> stringResource(id = R.string.outgoing_failuremessage_not_enough_balance)
-                FinalFailure.NoRouteToRecipient -> stringResource(id = R.string.outgoing_failuremessage_noroutefound)
                 FinalFailure.RecipientUnreachable -> stringResource(id = R.string.outgoing_failuremessage_noroutefound)
                 FinalFailure.RetryExhausted -> stringResource(id = R.string.outgoing_failuremessage_noroutefound)
                 FinalFailure.UnknownError -> stringResource(id = R.string.outgoing_failuremessage_unknown)

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/LegacyMigrationHelper.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/LegacyMigrationHelper.kt
@@ -464,11 +464,11 @@ object LegacyMigrationHelper {
                     val lastFailure = JavaConverters.asJavaCollectionConverter((it.last().status() as OutgoingPaymentStatus.Failed).failures()).asJavaCollection().toList().lastOrNull()
                     when {
                         lastFailure == null -> FinalFailure.UnknownError
-                        lastFailure.failureMessage().contains(TrampolineFeeInsufficient.message(), ignoreCase = true) -> FinalFailure.NoRouteToRecipient
+                        lastFailure.failureMessage().contains(TrampolineFeeInsufficient.message(), ignoreCase = true) -> FinalFailure.RecipientUnreachable
                         lastFailure.failureMessage().contains(TemporaryNodeFailure.message(), ignoreCase = true)
                                 || lastFailure.failureMessage().contains(UnknownNextPeer.message(), ignoreCase = true)
                                 || lastFailure.failureMessage().contains("is currently unavailable", ignoreCase = true) -> FinalFailure.RecipientUnreachable
-                        lastFailure.failureMessage().contains("incorrect payment details or unknown payment hash", ignoreCase = true) -> FinalFailure.NoRouteToRecipient
+                        lastFailure.failureMessage().contains("incorrect payment details or unknown payment hash", ignoreCase = true) -> FinalFailure.RecipientUnreachable
                         else -> FinalFailure.UnknownError
                     } to (it.last().status() as OutgoingPaymentStatus.Failed).completedAt()
                 }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/LegacyMigrationHelper.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/LegacyMigrationHelper.kt
@@ -417,8 +417,9 @@ object LegacyMigrationHelper {
                         amount = part.amount().toLong().msat + 0.msat, // must include the fee!!!
                         route = listOf(),
                         status = LightningOutgoingPayment.Part.Status.Failed(
-                            remoteFailureCode = null,
-                            details = JavaConverters.asJavaCollectionConverter(partStatus.failures()).asJavaCollection().toList().lastOrNull()?.failureMessage() ?: "error details unavailable",
+                            failure = LightningOutgoingPayment.Part.Status.Failure.Uninterpretable(
+                                message = JavaConverters.asJavaCollectionConverter(partStatus.failures()).asJavaCollection().toList().lastOrNull()?.failureMessage() ?: "error details unavailable",
+                            ),
                             completedAt = partStatus.completedAt()
                         ),
                         createdAt = part.createdAt()

--- a/phoenix-android/src/main/res/values-b+es+419/important_strings.xml
+++ b/phoenix-android/src/main/res/values-b+es+419/important_strings.xml
@@ -357,8 +357,30 @@
 
     <!-- Lightning payment errors -->
 
-    <string name="outgoing_finalfailure_alreadypaid">Esta factura ya ha sido pagada.</string>
-    <string name="outgoing_finalfailure_noroutefound">El destinatario no está localizable o no tiene suficiente liquidez entrante.</string>
+    <string name="outgoing_failuremessage_channel_closing">Los canales se están cerrando.</string>
+    <string name="outgoing_failuremessage_channel_splicing">Los canales ya están procesando un splice. Inténtelo de nuevo más tarde.</string>
+    <string name="outgoing_failuremessage_not_enough_fee">La tarifa es insuficiente.</string>
+    <string name="outgoing_failuremessage_not_enough_balance">Este pago supera su saldo.</string>
+    <string name="outgoing_failuremessage_too_big">El importe del pago es demasiado grande - intente dividirlo en varias partes.</string>
+    <string name="outgoing_failuremessage_too_small">El importe del pago es demasiado pequeño.</string>
+    <string name="outgoing_failuremessage_expiry_too_big">El vencimiento de este pago es demasiado lejano.</string>
+    <string name="outgoing_failuremessage_rejected_by_recipient">El pago ha sido rechazado por el destinatario. Es posible que esta factura en concreto ya se haya pagado.</string>
+    <string name="outgoing_failuremessage_recipient_offline">El destinatario no está conectado.</string>
+    <string name="outgoing_failuremessage_not_enough_liquidity">El pago no se ha podido retransmitir al destinatario (probablemente liquidez entrante insuficiente).</string>
+    <string name="outgoing_failuremessage_temporary_failure">Se ha producido un error en un nodo de la ruta de pago. El pago puede tener éxito si lo intentas de nuevo.</string>
+    <string name="outgoing_failuremessage_too_many_pending">Tienes demasiados pagos pendientes. Vuelva a intentarlo una vez que se hayan liquidado.</string>
+
+    <string name="outgoing_failuremessage_invalid_id">El ID del pago no es válido. Inténtelo de nuevo.</string>
+    <string name="outgoing_failuremessage_not_connected">Tu canal aún no está conectado. Espere a tener una conexión estable e inténtelo de nuevo.</string>
+    <string name="outgoing_failuremessage_channel_opening">Tu canal aún está en proceso de apertura. Espere e inténtelo de nuevo.</string>
+    <string name="outgoing_failuremessage_unsupported_features">Esta factura utiliza funciones no compatibles. Asegúrate de que estás en la última versión de Phoenix.</string>
+    <string name="outgoing_failuremessage_invalid_amount">El importe del pago no es válido.</string>
+    <string name="outgoing_failuremessage_no_available_channels">El pago no se ha podido enviar a través de sus canales existentes.</string>
+    <string name="outgoing_failuremessage_unknown">Se ha producido un error desconocido y el pago ha fallado.</string>
+    <string name="outgoing_failuremessage_restarted">La cartera se ha reiniciado mientras se procesaba el pago.</string>
+
+    <string name="outgoing_failuremessage_alreadypaid">Esta factura ya ha sido pagada.</string>
+    <string name="outgoing_failuremessage_noroutefound">El destinatario no está localizable o no tiene suficiente liquidez entrante.</string>
 
     <!-- low feerate disclaimer -->
 

--- a/phoenix-android/src/main/res/values-cs/important_strings.xml
+++ b/phoenix-android/src/main/res/values-cs/important_strings.xml
@@ -368,8 +368,30 @@
 
     <!-- Lightning payment errors -->
 
-    <string name="outgoing_finalfailure_alreadypaid">Tato platba již byla uhrazena.</string>
-    <string name="outgoing_finalfailure_noroutefound">Příjemce není dosažitelný nebo nemá dostatečnou příchozí likviditu.</string>
+    <string name="outgoing_failuremessage_channel_closing">Kanály se uzavírají.</string>
+    <string name="outgoing_failuremessage_channel_splicing">Kanály již zpracovávají splicing. Zkuste to později.</string>
+    <string name="outgoing_failuremessage_not_enough_fee">Poplatek je nedostatečný.</string>
+    <string name="outgoing_failuremessage_not_enough_balance">Tato platba přesahuje váš zůstatek.</string>
+    <string name="outgoing_failuremessage_too_big">Suma platby je příliš velká - zkuste ji rozdělit na více částí.</string>
+    <string name="outgoing_failuremessage_too_small">Suma platby je příliš malá.</string>
+    <string name="outgoing_failuremessage_expiry_too_big">Ukončení platnosti této platby je příliš daleko v budoucnosti.</string>
+    <string name="outgoing_failuremessage_rejected_by_recipient">Příjemce platbu odmítl. Tato konkrétní faktura již mohla být uhrazena.</string>
+    <string name="outgoing_failuremessage_recipient_offline">Příjemce je offline.</string>
+    <string name="outgoing_failuremessage_not_enough_liquidity">Platbu nebylo možné předat příjemci (pravděpodobně nedostatečná příchozí likvidita).</string>
+    <string name="outgoing_failuremessage_temporary_failure">Na uzlu v platební trase došlo k chybě. Platba může být úspěšná, pokud se o ni pokusíte znovu.</string>
+    <string name="outgoing_failuremessage_too_many_pending">Máte příliš mnoho čekajících plateb. Zkuste to znovu, jakmile budou vypořádány.</string>
+
+    <string name="outgoing_failuremessage_invalid_id">Identifikátor platby není platný. Zkuste to znovu.</string>
+    <string name="outgoing_failuremessage_not_connected">Váš kanál ještě není připojen. Počkejte na stabilní připojení a zkuste to znovu.</string>
+    <string name="outgoing_failuremessage_channel_opening">Váš kanál je stále v procesu otevírání. Počkejte a zkuste to znovu.</string>
+    <string name="outgoing_failuremessage_unsupported_features">Tato faktura používá nepodporované funkce. Ujistěte se, že používáte nejnovější verzi systému Phoenix.</string>
+    <string name="outgoing_failuremessage_invalid_amount">Částka platby je neplatná.</string>
+    <string name="outgoing_failuremessage_no_available_channels">Platba nemohla být odeslána prostřednictvím vašich stávajících kanálů.</string>
+    <string name="outgoing_failuremessage_unknown">Došlo k neznámé chybě a platba se nezdařila.</string>
+    <string name="outgoing_failuremessage_restarted">Peněženka byla restartována během zpracování platby.</string>
+
+    <string name="outgoing_failuremessage_alreadypaid">Tato platba již byla uhrazena.</string>
+    <string name="outgoing_failuremessage_noroutefound">Příjemce není dosažitelný nebo nemá dostatečnou příchozí likviditu.</string>
 
     <!-- low feerate disclaimer -->
 

--- a/phoenix-android/src/main/res/values-de/important_strings.xml
+++ b/phoenix-android/src/main/res/values-de/important_strings.xml
@@ -366,8 +366,30 @@
 
     <!-- Lightning payment errors -->
 
-    <string name="outgoing_finalfailure_alreadypaid">Diese Zahlung wurde bereits getätigt.</string>
-    <string name="outgoing_finalfailure_noroutefound">Der Empfänger ist nicht erreichbar oder hat nicht genügend Liquidität im Eingang.</string>
+    <string name="outgoing_failuremessage_channel_closing">Kanäle werden geschlossen.</string>
+    <string name="outgoing_failuremessage_channel_splicing">Kanäle verarbeiten bereits einen Splice. Versuchen Sie es später noch einmal.</string>
+    <string name="outgoing_failuremessage_not_enough_fee">Gebühr ist nicht ausreichend.</string>
+    <string name="outgoing_failuremessage_not_enough_balance">Diese Zahlung übersteigt Ihr Guthaben.</string>
+    <string name="outgoing_failuremessage_too_big">Der Zahlungsbetrag ist zu groß - versuchen Sie, ihn in mehrere Teile aufzuteilen.</string>
+    <string name="outgoing_failuremessage_too_small">Der Zahlungsbetrag ist zu klein.</string>
+    <string name="outgoing_failuremessage_expiry_too_big">Der Verfall dieser Zahlung liegt zu weit in der Zukunft.</string>
+    <string name="outgoing_failuremessage_rejected_by_recipient">Die Zahlung wurde vom Empfänger abgelehnt. Möglicherweise wurde diese Rechnung bereits bezahlt.</string>
+    <string name="outgoing_failuremessage_recipient_offline">Der Empfänger ist offline.</string>
+    <string name="outgoing_failuremessage_not_enough_liquidity">Die Zahlung konnte nicht an den Empfänger weitergeleitet werden (wahrscheinlich unzureichende eingehende Liquidität).</string>
+    <string name="outgoing_failuremessage_temporary_failure">Ein Fehler ist an einem Knoten in der Zahlungsroute aufgetreten. Die Zahlung kann erfolgreich sein, wenn Sie es erneut versuchen.</string>
+    <string name="outgoing_failuremessage_too_many_pending">Sie haben zu viele ausstehende Zahlungen. Versuchen Sie es erneut, sobald sie abgewickelt sind.</string>
+
+    <string name="outgoing_failuremessage_alreadypaid">Diese Zahlung wurde bereits getätigt.</string>
+    <string name="outgoing_failuremessage_noroutefound">Der Empfänger ist nicht erreichbar oder hat nicht genügend Liquidität im Eingang.</string>
+
+    <string name="outgoing_failuremessage_invalid_id">Die ID der Zahlung ist nicht gültig. Versuchen Sie es erneut.</string>
+    <string name="outgoing_failuremessage_not_connected">Ihr Kanal ist noch nicht verbunden. Warte auf eine stabile Verbindung und versuche es erneut.</string>
+    <string name="outgoing_failuremessage_channel_opening">Ihr Kanal wird noch geöffnet. Warten Sie und versuchen Sie es erneut.</string>
+    <string name="outgoing_failuremessage_unsupported_features">Diese Rechnung verwendet nicht unterstützte Funktionen. Stellen Sie sicher, dass Sie die neueste Phoenix-Version verwenden.</string>
+    <string name="outgoing_failuremessage_invalid_amount">Der Zahlungsbetrag ist ungültig.</string>
+    <string name="outgoing_failuremessage_no_available_channels">Die Zahlung konnte nicht über Ihre vorhandenen Kanäle gesendet werden.</string>
+    <string name="outgoing_failuremessage_unknown">Ein unbekannter Fehler ist aufgetreten und die Zahlung ist fehlgeschlagen.</string>
+    <string name="outgoing_failuremessage_restarted">Die Brieftasche wurde neu gestartet, während die Zahlung bearbeitet wurde.</string>
 
     <!-- low feerate disclaimer -->
 

--- a/phoenix-android/src/main/res/values-es/important_strings.xml
+++ b/phoenix-android/src/main/res/values-es/important_strings.xml
@@ -369,8 +369,30 @@
 
     <!-- Lightning payment errors -->
 
-    <string name="outgoing_finalfailure_alreadypaid">Esta factura ya ha sido pagada.</string>
-    <string name="outgoing_finalfailure_noroutefound">El destinatario no está localizable o no tiene suficiente liquidez entrante.</string>
+    <string name="outgoing_failuremessage_channel_closing">Los canales se están cerrando.</string>
+    <string name="outgoing_failuremessage_channel_splicing">Los canales ya están procesando un Splice. Inténtelo de nuevo más tarde.</string>
+    <string name="outgoing_failuremessage_not_enough_fee">La tarifa es insuficiente.</string>
+    <string name="outgoing_failuremessage_not_enough_balance">Este pago supera su saldo.</string>
+    <string name="outgoing_failuremessage_too_big">El importe del pago es demasiado grande - intente dividirlo en varias partes.</string>
+    <string name="outgoing_failuremessage_too_small">El importe del pago es demasiado pequeño.</string>
+    <string name="outgoing_failuremessage_expiry_too_big">El vencimiento de este pago es demasiado lejano.</string>
+    <string name="outgoing_failuremessage_rejected_by_recipient">El pago ha sido rechazado por el destinatario. Es posible que esta factura en concreto ya se haya pagado.</string>
+    <string name="outgoing_failuremessage_recipient_offline">El destinatario no está conectado.</string>
+    <string name="outgoing_failuremessage_not_enough_liquidity">El pago no se ha podido retransmitir al destinatario (probablemente liquidez entrante insuficiente).</string>
+    <string name="outgoing_failuremessage_temporary_failure">Se ha producido un error en un nodo de la ruta de pago. El pago puede tener éxito si lo intentas de nuevo.</string>
+    <string name="outgoing_failuremessage_too_many_pending">Tienes demasiados pagos pendientes. Vuelva a intentarlo una vez que se hayan liquidado.</string>
+
+    <string name="outgoing_failuremessage_invalid_id">El ID del pago no es válido. Inténtelo de nuevo.</string>
+    <string name="outgoing_failuremessage_not_connected">Tu canal aún no está conectado. Espere a tener una conexión estable e inténtelo de nuevo.</string>
+    <string name="outgoing_failuremessage_channel_opening">Tu canal aún está en proceso de apertura. Espere e inténtelo de nuevo.</string>
+    <string name="outgoing_failuremessage_unsupported_features">Esta factura utiliza funciones no compatibles. Asegúrate de que estás en la última versión de Phoenix.</string>
+    <string name="outgoing_failuremessage_invalid_amount">El importe del pago no es válido.</string>
+    <string name="outgoing_failuremessage_no_available_channels">El pago no se ha podido enviar a través de sus canales existentes.</string>
+    <string name="outgoing_failuremessage_unknown">Se ha producido un error desconocido y el pago ha fallado.</string>
+    <string name="outgoing_failuremessage_restarted">La cartera se ha reiniciado mientras se procesaba el pago.</string>
+
+    <string name="outgoing_failuremessage_alreadypaid">Esta factura ya ha sido pagada.</string>
+    <string name="outgoing_failuremessage_noroutefound">El destinatario no está localizable o no tiene suficiente liquidez entrante.</string>
 
     <!-- low feerate disclaimer -->
 

--- a/phoenix-android/src/main/res/values-fr/important_strings.xml
+++ b/phoenix-android/src/main/res/values-fr/important_strings.xml
@@ -369,8 +369,30 @@
 
     <!-- Lightning payment errors -->
 
-    <string name="outgoing_finalfailure_alreadypaid">Ce paiement a déjà été réglé.</string>
-    <string name="outgoing_finalfailure_noroutefound">Le destinataire de ce paiement n\'est pas joignable, ou bien ne dispose pas de suffisamment de liquidité entrante.</string>
+    <string name="outgoing_failuremessage_channel_closing">Les canaux de paiements sont en clôture.</string>
+    <string name="outgoing_failuremessage_channel_splicing">Un splice est déjà en cours de traitement. Réessayez plus tard.</string>
+    <string name="outgoing_failuremessage_not_enough_fee">Les frais sont insuffisants.</string>
+    <string name="outgoing_failuremessage_not_enough_balance">Ce paiement dépasse votre solde.</string>
+    <string name="outgoing_failuremessage_too_big">Le montant du paiement est trop élevé - essayez de le diviser en plusieurs parties.</string>
+    <string name="outgoing_failuremessage_too_small">Le montant du paiement est trop faible.</string>
+    <string name="outgoing_failuremessage_expiry_too_big">L\'échéance de ce paiement est trop lointaine.</string>
+    <string name="outgoing_failuremessage_rejected_by_recipient">Le paiement a été rejeté par le destinataire. Il se peut que ce paiement ait déjà été payée.</string>
+    <string name="outgoing_failuremessage_recipient_offline">Le destinataire est hors ligne.</string>
+    <string name="outgoing_failuremessage_not_enough_liquidity">Le paiement n\'a pas pu être transmis au destinataire. Il est probable qu\'il n\'ait pas suffisamment de liquidité entrante.</string>
+    <string name="outgoing_failuremessage_temporary_failure">Une erreur est survenue sur le trajet du paiement. Le paiement peut réussir si vous réessayez.</string>
+    <string name="outgoing_failuremessage_too_many_pending">Vous avez trop de paiements en attente. Réessayez une fois qu\'il sont terminés.</string>
+
+    <string name="outgoing_failuremessage_invalid_id">L\'identifiant du paiement n\'est pas valide. Réessayez.</string>
+    <string name="outgoing_failuremessage_not_connected">Votre canal de paiement n\'est pas encore connecté. Réessayez une fois que la connexion est stable.</string>
+    <string name="outgoing_failuremessage_channel_opening">Votre canal de paiement est toujours en cours d\'ouverture. Attendez et réessayez.</string>
+    <string name="outgoing_failuremessage_unsupported_features">Cette requête de paiement utilise des fonctionnalités non supportées. Assurez-vous que Phoenix soit à jour.</string>
+    <string name="outgoing_failuremessage_invalid_amount">Le montant du paiement n\'est pas valide.</string>
+    <string name="outgoing_failuremessage_no_available_channels">Le paiement n\'a pas pu être envoyé via les canaux disponibles.</string>
+    <string name="outgoing_failuremessage_unknown">Une erreur inconnue s\'est produite et le paiement a échoué.</string>
+    <string name="outgoing_failuremessage_restarted">Le portefeuille a été redémarré pendant le traitement du paiement.</string>
+
+    <string name="outgoing_failuremessage_alreadypaid">Ce paiement a déjà été réglé.</string>
+    <string name="outgoing_failuremessage_noroutefound">Le destinataire de ce paiement n\'est pas joignable, ou bien ne dispose pas de suffisamment de liquidité entrante.</string>
 
     <!-- low feerate disclaimer -->
 

--- a/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
+++ b/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
@@ -368,8 +368,30 @@
 
     <!-- Lightning payment errors -->
 
-    <string name="outgoing_finalfailure_alreadypaid">Este pagamento já foi pago.</string>
-    <string name="outgoing_finalfailure_noroutefound">O destinatário não está contactável ou não tem liquidez de entrada suficiente.</string>
+    <string name="outgoing_failuremessage_channel_closing">Os canais estão sendo fechados.</string>
+    <string name="outgoing_failuremessage_channel_splicing">Os canais já estão processando uma splice. Tente novamente mais tarde.</string>
+    <string name="outgoing_failuremessage_not_enough_fee">A taxa é insuficiente.</string>
+    <string name="outgoing_failuremessage_not_enough_balance">Este pagamento excede seu saldo.</string>
+    <string name="outgoing_failuremessage_too_big">O valor do pagamento é muito grande - tente dividi-lo em várias partes.</string>
+    <string name="outgoing_failuremessage_too_small">O valor do pagamento é muito pequeno.</string>
+    <string name="outgoing_failuremessage_expiry_too_big">O vencimento desse pagamento está muito distante no futuro.</string>
+    <string name="outgoing_failuremessage_rejected_by_recipient">O pagamento foi rejeitado pelo destinatário. Essa fatura específica pode já ter sido paga.</string>
+    <string name="outgoing_failuremessage_recipient_offline">O destinatário está off-line.</string>
+    <string name="outgoing_failuremessage_not_enough_liquidity">O pagamento não pôde ser retransmitido para o destinatário (provavelmente por falta de liquidez na entrada).</string>
+    <string name="outgoing_failuremessage_temporary_failure">Ocorreu um erro em um nó na rota de pagamento. O pagamento poderá ser bem-sucedido se você tentar novamente.</string>
+    <string name="outgoing_failuremessage_too_many_pending">Você tem muitos pagamentos pendentes. Tente novamente assim que eles forem liquidados.</string>
+
+    <string name="outgoing_failuremessage_invalid_id">O ID do pagamento não é válido. Tente novamente.</string>
+    <string name="outgoing_failuremessage_not_connected">Seu canal ainda não está conectado. Aguarde uma conexão estável e tente novamente.</string>
+    <string name="outgoing_failuremessage_channel_opening">Seu canal ainda está em processo de abertura. Aguarde e tente novamente.</string>
+    <string name="outgoing_failuremessage_unsupported_features">Esta fatura usa recursos não suportados. Verifique se você está usando a versão mais recente do Phoenix.</string>
+    <string name="outgoing_failuremessage_invalid_amount">O valor do pagamento é inválido.</string>
+    <string name="outgoing_failuremessage_no_available_channels">Não foi possível enviar o pagamento por meio de seus canais existentes.</string>
+    <string name="outgoing_failuremessage_unknown">Ocorreu um erro desconhecido e o pagamento falhou.</string>
+    <string name="outgoing_failuremessage_restarted">A carteira foi reiniciada enquanto o pagamento estava sendo processado.</string>
+
+    <string name="outgoing_failuremessage_alreadypaid">Este pagamento já foi pago.</string>
+    <string name="outgoing_failuremessage_noroutefound">O destinatário não está contactável ou não tem liquidez de entrada suficiente.</string>
 
     <!-- low feerate disclaimer -->
 

--- a/phoenix-android/src/main/res/values-sk/important_strings.xml
+++ b/phoenix-android/src/main/res/values-sk/important_strings.xml
@@ -369,8 +369,30 @@
 
     <!-- Lightning payment errors -->
 
-    <string name="outgoing_finalfailure_alreadypaid">Táto platba už bola uhradená.</string>
-    <string name="outgoing_finalfailure_noroutefound">Príjemca nie je dosiahnuteľný alebo nemá dostatočnú prichádzajúcu likviditu.</string>
+    <string name="outgoing_failuremessage_channel_closing">Kanály sa zatvárajú.</string>
+    <string name="outgoing_failuremessage_channel_splicing">Kanály už spracovávajú splicing. Skúste to neskôr.</string>
+    <string name="outgoing_failuremessage_not_enough_fee">Poplatok je nedostatočný.</string>
+    <string name="outgoing_failuremessage_not_enough_balance">Táto platba presahuje váš zostatok.</string>
+    <string name="outgoing_failuremessage_too_big">Suma platby je príliš veľká - skúste ju rozdeliť na viac častí.</string>
+    <string name="outgoing_failuremessage_too_small">Suma platby je príliš malá.</string>
+    <string name="outgoing_failuremessage_expiry_too_big">Uplynutie platnosti tejto platby je príliš ďaleko v budúcnosti.</string>
+    <string name="outgoing_failuremessage_rejected_by_recipient">Príjemca platbu odmietol. Táto konkrétna faktúra už mohla byť zaplatená.</string>
+    <string name="outgoing_failuremessage_recipient_offline">Príjemca je offline.</string>
+    <string name="outgoing_failuremessage_not_enough_liquidity">Platba nemohla byť postúpená príjemcovi (pravdepodobne nedostatočná likvidita na príchode).</string>
+    <string name="outgoing_failuremessage_temporary_failure">Na uzle v platobnej trase došlo k chybe. Platba môže byť úspešná, ak sa o to pokúsite znova.</string>
+    <string name="outgoing_failuremessage_too_many_pending">Máte príliš veľa čakajúcich platieb. Skúste to znova, keď budú vyrovnané.</string>
+
+    <string name="outgoing_failuremessage_invalid_id">Identifikátor platby nie je platný. Skúste to znova.</string>
+    <string name="outgoing_failuremessage_not_connected">Váš kanál ešte nie je pripojený. Počkajte na stabilné pripojenie a skúste to znova.</string>
+    <string name="outgoing_failuremessage_channel_opening">Váš kanál je stále v procese otvárania. Počkajte a skúste to znova.</string>
+    <string name="outgoing_failuremessage_unsupported_features">Táto faktúra používa nepodporované funkcie. Uistite sa, že používate najnovšiu verziu programu Phoenix.</string>
+    <string name="outgoing_failuremessage_invalid_amount">Suma platby je neplatná.</string>
+    <string name="outgoing_failuremessage_no_available_channels">Platbu nebolo možné odoslať prostredníctvom existujúcich kanálov.</string>
+    <string name="outgoing_failuremessage_unknown">Nastala neznáma chyba a platba zlyhala.</string>
+    <string name="outgoing_failuremessage_restarted">Peňaženka bola reštartovaná počas spracovania platby.</string>
+
+    <string name="outgoing_failuremessage_alreadypaid">Táto platba už bola uhradená.</string>
+    <string name="outgoing_failuremessage_noroutefound">Príjemca nie je dosiahnuteľný alebo nemá dostatočnú prichádzajúcu likviditu.</string>
 
     <!-- low feerate disclaimer -->
 

--- a/phoenix-android/src/main/res/values-vi/important_strings.xml
+++ b/phoenix-android/src/main/res/values-vi/important_strings.xml
@@ -376,8 +376,30 @@
 
     <!-- Lightning payment errors -->
 
-    <string name="outgoing_finalfailure_alreadypaid">Hóa đơn này đã được thanh toán.</string>
-    <string name="outgoing_finalfailure_noroutefound">Không thể liên lạc được với người nhận hoặc người nhận không có đủ thanh khoản đầu vào.</string>
+    <string name="outgoing_failuremessage_channel_closing">Các kênh đang đóng.</string>
+    <string name="outgoing_failuremessage_channel_splicing">Các kênh đang xử lý một mối nối. Hãy thử lại sau.</string>
+    <string name="outgoing_failuremessage_not_enough_fee">Phí không đủ.</string>
+    <string name="outgoing_failuremessage_not_enough_balance">Khoản thanh toán này vượt quá số dư của bạn.</string>
+    <string name="outgoing_failuremessage_too_big">Số tiền thanh toán quá lớn - hãy thử chia thành nhiều phần.</string>
+    <string name="outgoing_failuremessage_too_small">Số tiền thanh toán quá nhỏ.</string>
+    <string name="outgoing_failuremessage_expiry_too_big">Thời hạn thanh toán này còn quá xa trong tương lai.</string>
+    <string name="outgoing_failuremessage_rejected_by_recipient">Khoản thanh toán đã bị người nhận từ chối. Hóa đơn cụ thể này có thể đã được thanh toán.</string>
+    <string name="outgoing_failuremessage_recipient_offline">Người nhận đang ngoại tuyến.</string>
+    <string name="outgoing_failuremessage_not_enough_liquidity">Không thể chuyển khoản thanh toán đến người nhận (có thể thanh khoản gửi đến không đủ).</string>
+    <string name="outgoing_failuremessage_temporary_failure">Đã xảy ra lỗi trên một nút trong lộ trình thanh toán. Việc thanh toán có thể thành công nếu bạn thử lại.</string>
+    <string name="outgoing_failuremessage_too_many_pending">Bạn có quá nhiều khoản thanh toán đang chờ xử lý. Hãy thử lại sau khi chúng được giải quyết xong.</string>
+
+    <string name="outgoing_failuremessage_invalid_id">ID của khoản thanh toán không hợp lệ. Hãy thử lại.</string>
+    <string name="outgoing_failuremessage_not_connected">Kênh của bạn chưa được kết nối. Đợi kết nối ổn định và thử lại.</string>
+    <string name="outgoing_failuremessage_channel_opening">Kênh của bạn vẫn đang trong quá trình mở. Hãy đợi và thử lại.</string>
+    <string name="outgoing_failuremessage_unsupported_features">Hóa đơn này sử dụng các tính năng không được hỗ trợ. Đảm bảo bạn đang dùng phiên bản Phoenix mới nhất.</string>
+    <string name="outgoing_failuremessage_invalid_amount">Số tiền thanh toán không hợp lệ.</string>
+    <string name="outgoing_failuremessage_no_available_channels">Không thể gửi khoản thanh toán qua các kênh hiện có của bạn.</string>
+    <string name="outgoing_failuremessage_unknown">Đã xảy ra lỗi không xác định và thanh toán không thành công.</string>
+    <string name="outgoing_failuremessage_restarted">Ví đã được khởi động lại trong khi thanh toán đang được xử lý.</string>
+
+    <string name="outgoing_failuremessage_alreadypaid">Hóa đơn này đã được thanh toán.</string>
+    <string name="outgoing_failuremessage_noroutefound">Không thể liên lạc được với người nhận hoặc người nhận không có đủ thanh khoản đầu vào.</string>
 
     <!-- low feerate disclaimer -->
 

--- a/phoenix-android/src/main/res/values/important_strings.xml
+++ b/phoenix-android/src/main/res/values/important_strings.xml
@@ -372,8 +372,29 @@
 
     <!-- Lightning payment errors -->
 
-    <string name="outgoing_finalfailure_alreadypaid">This invoice has already been paid.</string>
-    <string name="outgoing_finalfailure_noroutefound">Recipient is not reachable, or does not have enough inbound liquidity.</string>
+    <string name="outgoing_failuremessage_channel_closing">Channels are closing.</string>
+    <string name="outgoing_failuremessage_channel_splicing">Channels are already processing a splice. Try again later.</string>
+    <string name="outgoing_failuremessage_not_enough_fee">Fee is insufficient.</string>
+    <string name="outgoing_failuremessage_not_enough_balance">This payment exceeds your balance.</string>
+    <string name="outgoing_failuremessage_too_big">The payment amount is too big - try splitting it in several parts.</string>
+    <string name="outgoing_failuremessage_too_small">The payment amount is too small.</string>
+    <string name="outgoing_failuremessage_expiry_too_big">The expiry of this payment is too far in the future.</string>
+    <string name="outgoing_failuremessage_rejected_by_recipient">The payment was rejected by the recipient. This particular invoice may have already been paid.</string>
+    <string name="outgoing_failuremessage_recipient_offline">The recipient is offline.</string>
+    <string name="outgoing_failuremessage_not_enough_liquidity">The payment could not be relayed to the recipient (probably insufficient inbound liquidity).</string>
+    <string name="outgoing_failuremessage_temporary_failure">An error occurred on a node in the payment route. The payment may succeed if you try again.</string>
+    <string name="outgoing_failuremessage_too_many_pending">You have too many pending payments. Try again once they are settled.</string>
+
+    <string name="outgoing_failuremessage_invalid_id">The ID of the payment is not valid. Try again.</string>
+    <string name="outgoing_failuremessage_alreadypaid">This invoice has already been paid.</string>
+    <string name="outgoing_failuremessage_not_connected">Your channel are not connected yet. Wait for a stable connection and try again.</string>
+    <string name="outgoing_failuremessage_channel_opening">Your channel is still in the process of being opened. Wait and try again.</string>
+    <string name="outgoing_failuremessage_unsupported_features">This invoice uses unsupported features. Make sure you\'re on the latest Phoenix version.</string>
+    <string name="outgoing_failuremessage_invalid_amount">The payment amount is invalid.</string>
+    <string name="outgoing_failuremessage_no_available_channels">The payment could not be sent through your existing channels.</string>
+    <string name="outgoing_failuremessage_noroutefound">Recipient is not reachable, or does not have enough inbound liquidity.</string>
+    <string name="outgoing_failuremessage_unknown">An unknown error occurred and payment has failed.</string>
+    <string name="outgoing_failuremessage_restarted">The wallet was restarted while the payment was processing.</string>
 
     <!-- spliceout: low feerate disclaimer -->
 

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		DC355E252A45FDD3008E8A8E /* NoticeMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC355E242A45FDD3008E8A8E /* NoticeMonitor.swift */; };
 		DC370A892B7FBD7C0093C56F /* BtcAddrOptionsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC370A882B7FBD7C0093C56F /* BtcAddrOptionsSheet.swift */; };
 		DC370A8B2B7FFFC70093C56F /* SwapInAddresses.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC370A8A2B7FFFC70093C56F /* SwapInAddresses.swift */; };
+		DC3780392C04D60400937C8E /* KotlinEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3780382C04D60400937C8E /* KotlinEnums.swift */; };
 		DC384D81265C12B700131772 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC384D80265C12B700131772 /* Cache.swift */; };
 		DC384D83265C32F100131772 /* TextField+Verbatim.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC384D82265C32F100131772 /* TextField+Verbatim.swift */; };
 		DC39A2662A12C04D00F59E39 /* LiquidityPolicyHelp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC39A2652A12C04D00F59E39 /* LiquidityPolicyHelp.swift */; };
@@ -491,6 +492,7 @@
 		DC355E242A45FDD3008E8A8E /* NoticeMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeMonitor.swift; sourceTree = "<group>"; };
 		DC370A882B7FBD7C0093C56F /* BtcAddrOptionsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BtcAddrOptionsSheet.swift; sourceTree = "<group>"; };
 		DC370A8A2B7FFFC70093C56F /* SwapInAddresses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapInAddresses.swift; sourceTree = "<group>"; };
+		DC3780382C04D60400937C8E /* KotlinEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinEnums.swift; sourceTree = "<group>"; };
 		DC384D7C265BE41900131772 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = fr; path = fr.lproj/about.html; sourceTree = "<group>"; };
 		DC384D80265C12B700131772 /* Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
 		DC384D82265C32F100131772 /* TextField+Verbatim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextField+Verbatim.swift"; sourceTree = "<group>"; };
@@ -999,6 +1001,7 @@
 				DCB62F462A5DF19D00912A71 /* KotlinPublishers+Lightning.swift */,
 				DC74174A270F332700F7E3E3 /* KotlinTypes.swift */,
 				DCCFE6A32B63021E002FFF11 /* KotlinLogger.swift */,
+				DC3780382C04D60400937C8E /* KotlinEnums.swift */,
 			);
 			path = kotlin;
 			sourceTree = "<group>";
@@ -1935,6 +1938,7 @@
 				DCA3B41F2A5471C900E6B231 /* MinerFeeInfo.swift in Sources */,
 				DCACF6F02566D0A60009B01E /* Data+Hexadecimal.swift in Sources */,
 				DCE3C7AB2A6AD3CC00F4D385 /* MempoolMonitor.swift in Sources */,
+				DC3780392C04D60400937C8E /* KotlinEnums.swift in Sources */,
 				DCACF7092566D0F00009B01E /* AppAccessView.swift in Sources */,
 				DC27E4D1279753EC00C777CC /* TextFieldNumberStyler.swift in Sources */,
 				DC46CB1628D9F30500C4EAC7 /* LoadingView.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -6062,6 +6062,9 @@
         }
       }
     },
+    "An error occurred on a node in the payment route. The payment may succeed if you try again." : {
+
+    },
     "An on-chain operation will be likely required for you to receive this amount.\n\nThe fee is estimated to be around %@." : {
       "localizations" : {
         "ar" : {
@@ -6209,6 +6212,9 @@
           }
         }
       }
+    },
+    "An unknown error occurred and payment has failed." : {
+
     },
     "An unknown error occurred." : {
       "comment" : "error details",
@@ -9009,6 +9015,12 @@
       }
     },
     "Channel size impacted" : {
+
+    },
+    "Channels are already processing a splice. Try again later." : {
+
+    },
+    "Channels are closing." : {
 
     },
     "Channels are not available, try again later" : {
@@ -16284,6 +16296,9 @@
           }
         }
       }
+    },
+    "Fee is insufficient." : {
+
     },
     "Fee rate" : {
       "localizations" : {
@@ -26945,6 +26960,9 @@
         }
       }
     },
+    "Payment Failed" : {
+
+    },
     "payment hash" : {
       "comment" : "Label in DetailsView_IncomingPayment",
       "localizations" : {
@@ -27270,6 +27288,7 @@
     },
     "Payment Parts" : {
       "comment" : "Title in DetailsView_IncomingPayment",
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -29968,6 +29987,9 @@
         }
       }
     },
+    "Recipient is not reachable, or does not have enough inbound liquidity." : {
+
+    },
     "recipient pubkey" : {
       "comment" : "Label in DetailsView_IncomingPayment",
       "localizations" : {
@@ -31429,6 +31451,7 @@
     },
     "Send Failed" : {
       "comment" : "Title in DetailsView_IncomingPayment",
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -35586,6 +35609,9 @@
         }
       }
     },
+    "The expiry of this payment is too far in the future." : {
+
+    },
     "The fee is **%@%%** with a minimum fee of **%@**." : {
       "comment" : "IntroView",
       "extractionState" : "manual",
@@ -35892,6 +35918,9 @@
         }
       }
     },
+    "The ID of the payment is not valid. Try again." : {
+
+    },
     "The invoice doesn't include an amount. This can be dangerous: malicious nodes may be able to steal your payment. To be safe, **ask the payee to specify an amount** in the payment request." : {
       "comment" : "SendView",
       "extractionState" : "manual",
@@ -36143,6 +36172,27 @@
           }
         }
       }
+    },
+    "The payment amount is invalid." : {
+
+    },
+    "The payment amount is too big - try splitting it in several parts." : {
+
+    },
+    "The payment amount is too small." : {
+
+    },
+    "The payment could not be relayed to the recipient (probably insufficient inbound liquidity)." : {
+
+    },
+    "The payment could not be sent through your existing channels." : {
+
+    },
+    "The payment was rejected by the recipient. This particular invoice may have already been paid." : {
+
+    },
+    "The recipient is offline." : {
+
     },
     "The recovery phrase (sometimes called a seed), is a list of 12 words. It allows you to recover full access to your funds if needed." : {
       "localizations" : {
@@ -36543,6 +36593,9 @@
           }
         }
       }
+    },
+    "The wallet was restarted while the payment was processing." : {
+
     },
     "The wallet will be completely deleted from **this device**." : {
       "localizations" : {
@@ -37143,6 +37196,12 @@
         }
       }
     },
+    "This invoice has already been paid." : {
+
+    },
+    "This invoice uses unsupported features. Make sure you're on the latest Phoenix version." : {
+
+    },
     "This is a swap address. It is not controlled by your wallet. On-chain deposits sent to this address will be converted to Lightning channels." : {
       "extractionState" : "manual",
       "localizations" : {
@@ -37427,6 +37486,9 @@
           }
         }
       }
+    },
+    "This payment exceeds your balance." : {
+
     },
     "This screen is a debugging tool that can be used to manually import encrypted channels data.\n\nUse with caution." : {
       "localizations" : {
@@ -42982,6 +43044,9 @@
         }
       }
     },
+    "You have too many pending payments. Try again once they are settled." : {
+
+    },
     "You may be able to reduce your fees by increasing your bucket size ahead of a series of incoming payments." : {
       "localizations" : {
         "ar" : {
@@ -43338,6 +43403,12 @@
           }
         }
       }
+    },
+    "Your channel are not connected yet. Wait for a stable connection and try again." : {
+
+    },
+    "Your channel is still in the process of being opened. Wait and try again." : {
+
     },
     "Your comment will be sent when you pay." : {
       "localizations" : {

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -25061,6 +25061,7 @@
     },
     "non-invoice payment" : {
       "comment" : "Transaction Info: Explanation",
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinEnums.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinEnums.swift
@@ -1,0 +1,118 @@
+import PhoenixShared
+
+extension Lightning_kmpFinalFailure {
+	
+	func localizedDescription() -> String {
+		if let _ = self.asAlreadyPaid() {
+			return String(localized:
+				"This invoice has already been paid.")
+		}
+		if let _ = self.asChannelClosing() {
+			return String(localized:
+				"Channels are closing.")
+		}
+		if let _ = self.asChannelNotConnected() {
+			return String(localized:
+				"Your channel are not connected yet. Wait for a stable connection and try again.")
+		}
+		if let _ = self.asChannelOpening() {
+			return String(localized:
+				"Your channel is still in the process of being opened. Wait and try again.")
+		}
+		if let _ = self.asFeaturesNotSupported() {
+			return String(localized:
+				"This invoice uses unsupported features. Make sure you're on the latest Phoenix version.")
+		}
+		if let _ = self.asInsufficientBalance() {
+			return String(localized:
+				"This payment exceeds your balance.")
+		}
+		if let _ = self.asInvalidPaymentAmount() {
+			return String(localized:
+				"The payment amount is invalid.")
+		}
+		if let _ = self.asInvalidPaymentId() {
+			return String(localized:
+				"The ID of the payment is not valid. Try again.")
+		}
+		if let _ = self.asNoAvailableChannels() {
+			return String(localized:
+				"The payment could not be sent through your existing channels.")
+		}
+		if let _ = self.asRecipientUnreachable() {
+			return String(localized:
+				"Recipient is not reachable, or does not have enough inbound liquidity.")
+		}
+		if let _ = self.asRetryExhausted() {
+			return String(localized:
+				"Recipient is not reachable, or does not have enough inbound liquidity.")
+		}
+		if let _ = self.asWalletRestarted() {
+			return String(localized:
+				"The wallet was restarted while the payment was processing.")
+		}
+		
+		return String(localized:
+			"An unknown error occurred and payment has failed.")
+	}
+}
+
+extension Lightning_kmpLightningOutgoingPayment.PartStatusFailure {
+	
+	func localizedDescription() -> String {
+		if let _ =  self.asChannelIsClosing() {
+			return String(localized:
+				"Channels are closing.")
+		}
+		if let _ = self.asChannelIsSplicing() {
+			return String(localized:
+				"Channels are already processing a splice. Try again later.")
+		}
+		if let _ = self.asNotEnoughFees() {
+			return String(localized:
+				"Fee is insufficient.")
+		}
+		if let _ = self.asNotEnoughFunds() {
+			return String(localized:
+				"This payment exceeds your balance.")
+		}
+		if let _ = self.asPaymentAmountTooBig() {
+			return String(localized:
+				"The payment amount is too big - try splitting it in several parts.")
+		}
+		if let _ = self.asPaymentAmountTooSmall() {
+			return String(localized:
+				"The payment amount is too small.")
+		}
+		if let _ = self.asPaymentExpiryTooBig() {
+			return String(localized:
+				"The expiry of this payment is too far in the future.")
+		}
+		if let _ = self.asRecipientIsOffline() {
+			return String(localized:
+				"The recipient is offline.")
+		}
+		if let _ = self.asRecipientLiquidityIssue() {
+			return String(localized:
+				"The payment could not be relayed to the recipient (probably insufficient inbound liquidity).")
+		}
+		if let _ = self.asRecipientRejectedPayment() {
+			return String(localized:
+				"The payment was rejected by the recipient. This particular invoice may have already been paid.")
+		}
+		if let _ = self.asTemporaryRemoteFailure() {
+			return String(localized:
+				"An error occurred on a node in the payment route. The payment may succeed if you try again.")
+		}
+		if let _ = self.asTooManyPendingPayments() {
+			return String(localized:
+				"You have too many pending payments. Try again once they are settled.")
+		}
+		if let partFailure = self.asUninterpretable() {
+			return partFailure.message
+		}
+		
+		return String(localized:
+			"An unknown error occurred and payment has failed.")
+	}
+}

--- a/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
@@ -249,20 +249,13 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 			} else if let failed = lightningPayment.status.asFailed() {
 				
 				InlineSection {
-					header("Send Failed")
+					header("Payment Failed")
 				} content: {
 					failed_failedAt(failed)
-					failed_reason(failed)
-				}
-			}
-			
-			if lightningPayment.parts.count > 0 {
-				
-				InlineSection {
-					header("Payment Parts")
-				} content: {
-					ForEach(lightningPayment.parts.indices, id: \.self) { index in
-						lightningPart_row(lightningPayment.parts[index])
+					if let finalFailure = lightningPayment.explainAsFinalFailure() {
+						failed_explain_finalFailure(finalFailure)
+					} else if let partFailure = lightningPayment.explainAsPartFailure() {
+						failed_explain_partFailure(partFailure)
 					}
 				}
 			}
@@ -1043,7 +1036,9 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 	}
 	
 	@ViewBuilder
-	func failed_reason(_ failed: Lightning_kmpLightningOutgoingPayment.StatusCompletedFailed) -> some View {
+	func failed_explain_finalFailure(
+		_ finalFailure: Lightning_kmpFinalFailure
+	) -> some View {
 		let identifier: String = #function
 		
 		InfoGridRowWrapper(
@@ -1053,113 +1048,31 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 			keyColumn("reason")
 			
 		} valueColumn: {
-			Text(failed.reason.description)
+			
+			let localizedErrMsg = finalFailure.localizedDescription()
+			Text(verbatim: localizedErrMsg)
 			
 		} // </InfoGridRowWrapper>
 	}
 	
 	@ViewBuilder
-	func lightningPart_row(
-		_ part: Lightning_kmpLightningOutgoingPayment.Part
+	func failed_explain_partFailure(
+		_ partFailure: Lightning_kmpLightningOutgoingPayment.PartStatusFailure
 	) -> some View {
 		let identifier: String = #function
-		let imgSize: CGFloat = 20
 		
 		InfoGridRowWrapper(
 			identifier: identifier,
 			keyColumnWidth: keyColumnWidth(identifier: identifier)
 		) {
-			
-			if let part_succeeded = part.status as? Lightning_kmpLightningOutgoingPayment.PartStatusSucceeded {
-				keyColumn(verbatim: shortDisplayTime(date: part_succeeded.completedAtDate))
-				
-			} else if let part_failed = part.status as? Lightning_kmpLightningOutgoingPayment.PartStatusFailed {
-				keyColumn(verbatim: shortDisplayTime(date: part_failed.completedAtDate))
-				
-			} else {
-				keyColumn(verbatim: shortDisplayTime(date: part.createdAtDate))
-			}
+			keyColumn("reason")
 			
 		} valueColumn: {
-		
-			if let _ = part.status as? Lightning_kmpLightningOutgoingPayment.PartStatusSucceeded {
-				
-				VStack(alignment: HorizontalAlignment.leading, spacing: 4) {
-					HStack(alignment: VerticalAlignment.center, spacing: 4) {
-						Image("ic_payment_sent")
-							.renderingMode(.template)
-							.resizable()
-							.aspectRatio(contentMode: .fit)
-							.frame(width: imgSize, height: imgSize)
-							.foregroundColor(Color.appPositive)
-						
-						let formatted = Utils.formatBitcoin(
-							msat        : part.amount,
-							bitcoinUnit : currencyPrefs.bitcoinUnit,
-							policy      : .showMsatsIfNonZero
-						)
-						if formatted.hasSubFractionDigits { // e.g.: has visible millisatoshi's
-							Text(verbatim: formatted.integerDigits)
-							+	Text(verbatim: formatted.decimalSeparator)
-									.foregroundColor(formatted.hasStdFractionDigits ? .primary : .secondary)
-							+	Text(verbatim: formatted.stdFractionDigits)
-							+	Text(verbatim: formatted.subFractionDigits)
-									.foregroundColor(.secondary)
-							+	Text(verbatim: " \(formatted.type)")
-						} else {
-							Text(verbatim: formatted.string)
-						}
-					}
-				}
-				
-			} else if let part_failed = part.status as? Lightning_kmpLightningOutgoingPayment.PartStatusFailed {
-				
-				VStack(alignment: HorizontalAlignment.leading, spacing: 4) {
-					HStack(alignment: VerticalAlignment.center, spacing: 4) {
-						Image(systemName: "xmark.circle")
-							.renderingMode(.template)
-							.resizable()
-							.aspectRatio(contentMode: .fit)
-							.frame(width: imgSize, height: imgSize)
-							.foregroundColor(.appNegative)
-						
-						let formatted = Utils.formatBitcoin(
-							msat        : part.amount,
-							bitcoinUnit : currencyPrefs.bitcoinUnit,
-							policy      : .showMsatsIfNonZero
-						)
-						if formatted.hasSubFractionDigits { // e.g.: has visible millisatoshi's
-							Text(verbatim: formatted.integerDigits)
-							+	Text(verbatim: formatted.decimalSeparator)
-									.foregroundColor(formatted.hasStdFractionDigits ? .primary : .secondary)
-							+	Text(verbatim: formatted.stdFractionDigits)
-							+	Text(verbatim: formatted.subFractionDigits)
-									.foregroundColor(.secondary)
-							+	Text(verbatim: " \(formatted.type)")
-						} else {
-							Text(verbatim: formatted.string)
-						}
-					}
-					
-					Text(verbatim: "reason: \(part_failed.failure.description)")
-				}
-				
-			} else {
-				
-				VStack(alignment: HorizontalAlignment.leading, spacing: 4) {
-					HStack(alignment: VerticalAlignment.center, spacing: 4) {
-						Image("ic_payment_sending")
-							.renderingMode(.template)
-							.resizable()
-							.aspectRatio(contentMode: .fit)
-							.frame(width: imgSize, height: imgSize)
-							.foregroundColor(Color.borderColor)
-						
-						Text("pending")
-					}
-				}
-			}
-		}
+			
+			let localizedErrMsg = partFailure.localizedDescription()
+			Text(verbatim: localizedErrMsg)
+			
+		} // </InfoGridRowWrapper>
 	}
 	
 	@ViewBuilder

--- a/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
@@ -1141,8 +1141,7 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 						}
 					}
 					
-					let code = part_failed.remoteFailureCode?.description ?? "local"
-					Text(verbatim: "\(code): \(part_failed.details)")
+					Text(verbatim: "reason: \(part_failed.failure.description)")
 				}
 				
 			} else {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
@@ -183,7 +183,7 @@ class SqlitePaymentsDb(
 
     override suspend fun completeOutgoingLightningPart(
         partId: UUID,
-        failure: Either<ChannelException, FailureMessage>,
+        failure: LightningOutgoingPayment.Part.Status.Failure,
         completedAt: Long
     ) {
         withContext(Dispatchers.Default) {
@@ -202,7 +202,7 @@ class SqlitePaymentsDb(
         completedAt: Long
     ) {
         withContext(Dispatchers.Default) {
-            val (statusType, statusData) = failedStatus.mapToDb()
+            val (statusType, statusData) = failedStatus.failure.mapToDb()
             outQueries.database.outgoingPaymentsQueries.updateLightningPart(
                 part_id = partId.toString(),
                 part_status_type = statusType,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/LightningOutgoingPartType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/cloud/LightningOutgoingPartType.kt
@@ -69,7 +69,7 @@ data class LightningOutgoingPartWrapper(
                 return when (status) {
                     is LightningOutgoingPayment.Part.Status.Pending -> null
                     is LightningOutgoingPayment.Part.Status.Failed -> {
-                        val (type, blob) = status.mapToDb()
+                        val (type, blob) = status.failure.mapToDb()
                         StatusWrapper(
                             ts = status.completedAt,
                             type = type.name,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingPartStatusType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingPartStatusType.kt
@@ -100,6 +100,8 @@ sealed class OutgoingPartStatusData {
 fun LightningOutgoingPayment.Part.Status.Succeeded.mapToDb() = OutgoingPartStatusTypeVersion.SUCCEEDED_V0 to
         Json.encodeToString(OutgoingPartStatusData.Succeeded.V0(preimage)).toByteArray(Charsets.UTF_8)
 
+fun LightningOutgoingPayment.Part.Status.Failed.mapToDb() = this.failure.mapToDb()
+
 fun LightningOutgoingPayment.Part.Status.Failure.mapToDb(): Pair<OutgoingPartStatusTypeVersion, ByteArray> {
     val (code, details) = when (this) {
         is LightningOutgoingPayment.Part.Status.Failure.Uninterpretable -> 0 to message

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingPartStatusType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingPartStatusType.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.json.Json
 
 enum class OutgoingPartStatusTypeVersion {
     SUCCEEDED_V0,
-    /* Obsolete, do not use anymore. Failed parts are now typed, with a code and an option string message. */
+    @Deprecated("Obsolete, do not use anymore. Failed parts are now typed, with a code and an option string message.")
     FAILED_V0,
     FAILED_V1,
 }
@@ -47,6 +47,7 @@ sealed class OutgoingPartStatusData {
     }
 
     sealed class Failed : OutgoingPartStatusData() {
+        @Deprecated("Use V1 instead")
         @Serializable
         data class V0(val remoteFailureCode: Int?, val details: String) : Failed()
 
@@ -100,21 +101,21 @@ fun LightningOutgoingPayment.Part.Status.Succeeded.mapToDb() = OutgoingPartStatu
         Json.encodeToString(OutgoingPartStatusData.Succeeded.V0(preimage)).toByteArray(Charsets.UTF_8)
 
 fun LightningOutgoingPayment.Part.Status.Failure.mapToDb(): Pair<OutgoingPartStatusTypeVersion, ByteArray> {
-    val code = when (this) {
-        is LightningOutgoingPayment.Part.Status.Failure.Uninterpretable -> 0
-        is LightningOutgoingPayment.Part.Status.Failure.PaymentAmountTooSmall -> 1
-        is LightningOutgoingPayment.Part.Status.Failure.PaymentAmountTooBig -> 2
-        is LightningOutgoingPayment.Part.Status.Failure.NotEnoughFunds -> 3
-        is LightningOutgoingPayment.Part.Status.Failure.NotEnoughFees -> 4
-        is LightningOutgoingPayment.Part.Status.Failure.PaymentExpiryTooBig -> 5
-        is LightningOutgoingPayment.Part.Status.Failure.TooManyPendingPayments -> 6
-        is LightningOutgoingPayment.Part.Status.Failure.ChannelIsSplicing -> 7
-        is LightningOutgoingPayment.Part.Status.Failure.ChannelIsClosing -> 8
-        is LightningOutgoingPayment.Part.Status.Failure.TemporaryRemoteFailure -> 9
-        is LightningOutgoingPayment.Part.Status.Failure.RecipientLiquidityIssue -> 10
-        is LightningOutgoingPayment.Part.Status.Failure.RecipientIsOffline -> 11
-        is LightningOutgoingPayment.Part.Status.Failure.RecipientRejectedPayment -> 12
+    val (code, details) = when (this) {
+        is LightningOutgoingPayment.Part.Status.Failure.Uninterpretable -> 0 to message
+        is LightningOutgoingPayment.Part.Status.Failure.PaymentAmountTooSmall -> 1 to null
+        is LightningOutgoingPayment.Part.Status.Failure.PaymentAmountTooBig -> 2 to null
+        is LightningOutgoingPayment.Part.Status.Failure.NotEnoughFunds -> 3 to null
+        is LightningOutgoingPayment.Part.Status.Failure.NotEnoughFees -> 4 to null
+        is LightningOutgoingPayment.Part.Status.Failure.PaymentExpiryTooBig -> 5 to null
+        is LightningOutgoingPayment.Part.Status.Failure.TooManyPendingPayments -> 6 to null
+        is LightningOutgoingPayment.Part.Status.Failure.ChannelIsSplicing -> 7 to null
+        is LightningOutgoingPayment.Part.Status.Failure.ChannelIsClosing -> 8 to null
+        is LightningOutgoingPayment.Part.Status.Failure.TemporaryRemoteFailure -> 9 to null
+        is LightningOutgoingPayment.Part.Status.Failure.RecipientLiquidityIssue -> 10 to null
+        is LightningOutgoingPayment.Part.Status.Failure.RecipientIsOffline -> 11 to null
+        is LightningOutgoingPayment.Part.Status.Failure.RecipientRejectedPayment -> 12 to null
     }
-    return OutgoingPartStatusTypeVersion.FAILED_V0 to
-            Json.encodeToString(OutgoingPartStatusData.Failed.V0(code, "")).toByteArray(Charsets.UTF_8)
+    return OutgoingPartStatusTypeVersion.FAILED_V1 to
+            Json.encodeToString(OutgoingPartStatusData.Failed.V1(code, details)).toByteArray(Charsets.UTF_8)
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingPartStatusType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingPartStatusType.kt
@@ -34,7 +34,9 @@ import kotlinx.serialization.json.Json
 
 enum class OutgoingPartStatusTypeVersion {
     SUCCEEDED_V0,
+    /* Obsolete, do not use anymore. Failed parts are now typed, with a code and an option string message. */
     FAILED_V0,
+    FAILED_V1,
 }
 
 sealed class OutgoingPartStatusData {
@@ -47,19 +49,47 @@ sealed class OutgoingPartStatusData {
     sealed class Failed : OutgoingPartStatusData() {
         @Serializable
         data class V0(val remoteFailureCode: Int?, val details: String) : Failed()
+
+        @Serializable
+        data class V1(val code: Int, val details: String?) : Failed()
     }
 
     companion object {
         fun deserialize(
             typeVersion: OutgoingPartStatusTypeVersion,
-            blob: ByteArray, completedAt: Long
+            blob: ByteArray,
+            completedAt: Long
         ): LightningOutgoingPayment.Part.Status = DbTypesHelper.decodeBlob(blob) { json, format ->
             when (typeVersion) {
                 OutgoingPartStatusTypeVersion.SUCCEEDED_V0 -> format.decodeFromString<Succeeded.V0>(json).let {
                     LightningOutgoingPayment.Part.Status.Succeeded(it.preimage, completedAt)
                 }
                 OutgoingPartStatusTypeVersion.FAILED_V0 -> format.decodeFromString<Failed.V0>(json).let {
-                    LightningOutgoingPayment.Part.Status.Failed(it.remoteFailureCode, it.details, completedAt)
+                    LightningOutgoingPayment.Part.Status.Failed(
+                        failure = LightningOutgoingPayment.Part.Status.Failure.Uninterpretable(message = it.details),
+                        completedAt = completedAt,
+                    )
+                }
+                OutgoingPartStatusTypeVersion.FAILED_V1 -> format.decodeFromString<Failed.V1>(json).let {
+                    LightningOutgoingPayment.Part.Status.Failed(
+                        failure = when (it.code) {
+                            0 -> LightningOutgoingPayment.Part.Status.Failure.Uninterpretable(it.details ?: "n/a")
+                            1 -> LightningOutgoingPayment.Part.Status.Failure.PaymentAmountTooSmall
+                            2 -> LightningOutgoingPayment.Part.Status.Failure.PaymentAmountTooBig
+                            3 -> LightningOutgoingPayment.Part.Status.Failure.NotEnoughFunds
+                            4 -> LightningOutgoingPayment.Part.Status.Failure.NotEnoughFees
+                            5 -> LightningOutgoingPayment.Part.Status.Failure.PaymentExpiryTooBig
+                            6 -> LightningOutgoingPayment.Part.Status.Failure.TooManyPendingPayments
+                            7 -> LightningOutgoingPayment.Part.Status.Failure.ChannelIsSplicing
+                            8 -> LightningOutgoingPayment.Part.Status.Failure.ChannelIsClosing
+                            9 -> LightningOutgoingPayment.Part.Status.Failure.TemporaryRemoteFailure
+                            10 -> LightningOutgoingPayment.Part.Status.Failure.RecipientLiquidityIssue
+                            11 -> LightningOutgoingPayment.Part.Status.Failure.RecipientIsOffline
+                            12 -> LightningOutgoingPayment.Part.Status.Failure.RecipientRejectedPayment
+                            else -> LightningOutgoingPayment.Part.Status.Failure.Uninterpretable(it.details ?: "n/a")
+                        },
+                        completedAt = completedAt,
+                    )
                 }
             }
         }
@@ -69,5 +99,22 @@ sealed class OutgoingPartStatusData {
 fun LightningOutgoingPayment.Part.Status.Succeeded.mapToDb() = OutgoingPartStatusTypeVersion.SUCCEEDED_V0 to
         Json.encodeToString(OutgoingPartStatusData.Succeeded.V0(preimage)).toByteArray(Charsets.UTF_8)
 
-fun LightningOutgoingPayment.Part.Status.Failed.mapToDb() = OutgoingPartStatusTypeVersion.FAILED_V0 to
-        Json.encodeToString(OutgoingPartStatusData.Failed.V0(remoteFailureCode, details)).toByteArray(Charsets.UTF_8)
+fun LightningOutgoingPayment.Part.Status.Failure.mapToDb(): Pair<OutgoingPartStatusTypeVersion, ByteArray> {
+    val code = when (this) {
+        is LightningOutgoingPayment.Part.Status.Failure.Uninterpretable -> 0
+        is LightningOutgoingPayment.Part.Status.Failure.PaymentAmountTooSmall -> 1
+        is LightningOutgoingPayment.Part.Status.Failure.PaymentAmountTooBig -> 2
+        is LightningOutgoingPayment.Part.Status.Failure.NotEnoughFunds -> 3
+        is LightningOutgoingPayment.Part.Status.Failure.NotEnoughFees -> 4
+        is LightningOutgoingPayment.Part.Status.Failure.PaymentExpiryTooBig -> 5
+        is LightningOutgoingPayment.Part.Status.Failure.TooManyPendingPayments -> 6
+        is LightningOutgoingPayment.Part.Status.Failure.ChannelIsSplicing -> 7
+        is LightningOutgoingPayment.Part.Status.Failure.ChannelIsClosing -> 8
+        is LightningOutgoingPayment.Part.Status.Failure.TemporaryRemoteFailure -> 9
+        is LightningOutgoingPayment.Part.Status.Failure.RecipientLiquidityIssue -> 10
+        is LightningOutgoingPayment.Part.Status.Failure.RecipientIsOffline -> 11
+        is LightningOutgoingPayment.Part.Status.Failure.RecipientRejectedPayment -> 12
+    }
+    return OutgoingPartStatusTypeVersion.FAILED_V0 to
+            Json.encodeToString(OutgoingPartStatusData.Failed.V0(code, "")).toByteArray(Charsets.UTF_8)
+}

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingQueries.kt
@@ -126,11 +126,11 @@ class OutgoingQueries(val database: PaymentsDatabase) {
 
     fun updateLightningPart(
         partId: UUID,
-        failure: Either<ChannelException, FailureMessage>,
+        failure: LightningOutgoingPayment.Part.Status.Failure,
         completedAt: Long
     ): Boolean {
         var result = true
-        val (statusTypeVersion, statusData) = OutgoingPaymentFailure.convertFailure(failure).mapToDb()
+        val (statusTypeVersion, statusData) = failure.mapToDb()
         database.transaction {
             queries.updateLightningPart(
                 part_id = partId.toString(),

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingStatusType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingStatusType.kt
@@ -104,10 +104,14 @@ sealed class OutgoingStatusData {
             FinalFailure.InvalidPaymentId::class.simpleName -> FinalFailure.InvalidPaymentId
             FinalFailure.NoAvailableChannels::class.simpleName -> FinalFailure.NoAvailableChannels
             FinalFailure.InsufficientBalance::class.simpleName -> FinalFailure.InsufficientBalance
-            FinalFailure.NoRouteToRecipient::class.simpleName -> FinalFailure.NoRouteToRecipient
             FinalFailure.RecipientUnreachable::class.simpleName -> FinalFailure.RecipientUnreachable
             FinalFailure.RetryExhausted::class.simpleName -> FinalFailure.RetryExhausted
             FinalFailure.WalletRestarted::class.simpleName -> FinalFailure.WalletRestarted
+            FinalFailure.AlreadyPaid::class.simpleName -> FinalFailure.AlreadyPaid
+            FinalFailure.ChannelClosing::class.simpleName -> FinalFailure.ChannelClosing
+            FinalFailure.ChannelOpening::class.simpleName -> FinalFailure.ChannelOpening
+            FinalFailure.ChannelNotConnected::class.simpleName -> FinalFailure.ChannelNotConnected
+            FinalFailure.FeaturesNotSupported::class.simpleName -> FinalFailure.FeaturesNotSupported
             else -> FinalFailure.UnknownError
         }
     }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingStatusType.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/OutgoingStatusType.kt
@@ -27,6 +27,7 @@ import fr.acinq.lightning.db.ChannelCloseOutgoingPayment
 import fr.acinq.lightning.db.LightningOutgoingPayment
 import fr.acinq.lightning.payment.FinalFailure
 import fr.acinq.lightning.utils.UUID
+import fr.acinq.lightning.utils.msat
 import fr.acinq.lightning.utils.sat
 import fr.acinq.phoenix.data.FiatCurrency.Companion.valueOfOrNull
 import fr.acinq.phoenix.db.payments.DbTypesHelper.decodeBlob

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/OutgoingPaymentDbTypeVersionTest.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/OutgoingPaymentDbTypeVersionTest.kt
@@ -24,6 +24,8 @@ import fr.acinq.lightning.payment.FinalFailure
 import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.wire.PermanentNodeFailure
 import fr.acinq.phoenix.db.payments.*
+import io.ktor.utils.io.charsets.Charsets
+import io.ktor.utils.io.core.toByteArray
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -64,17 +66,26 @@ class OutgoingPaymentDbTypeVersionTest {
     }
 
     @Test
-    fun outgoing_part_status_failed_channelexception() {
-        val status = LightningOutgoingPayment.Part.Status.Failed(null, InvalidFinalScript(channelId1).details(), completedAt = 123)
-        val deserialized = OutgoingPartStatusData.deserialize(OutgoingPartStatusTypeVersion.FAILED_V0, status.mapToDb().second, completedAt = 123)
+    fun outgoing_part_status_failed_part() {
+        val status = LightningOutgoingPayment.Part.Status.Failed(LightningOutgoingPayment.Part.Status.Failure.ChannelIsClosing, completedAt = 123)
+        val deserialized = OutgoingPartStatusData.deserialize(OutgoingPartStatusTypeVersion.FAILED_V1, status.failure.mapToDb().second, completedAt = 123)
         assertEquals(status, deserialized)
+
+        val status2 = LightningOutgoingPayment.Part.Status.Failed(LightningOutgoingPayment.Part.Status.Failure.Uninterpretable("lorem ipsum"), completedAt = 123)
+        val deserialized2 = OutgoingPartStatusData.deserialize(OutgoingPartStatusTypeVersion.FAILED_V1, status2.failure.mapToDb().second, completedAt = 123)
+        assertEquals(status2, deserialized2)
     }
 
     @Test
-    fun outgoing_part_status_failed_remotefailure() {
-        val status = LightningOutgoingPayment.Part.Status.Failed(PermanentNodeFailure.code, PermanentNodeFailure.message, completedAt = 345)
-        val deserialized = OutgoingPartStatusData.deserialize(OutgoingPartStatusTypeVersion.FAILED_V0, status.mapToDb().second, completedAt = 345)
-        assertEquals(status, deserialized)
+    fun outgoing_part_status_failed_channelexception_legacy() {
+        val serialized = """
+            {"remoteFailureCode":8243,"details":"payment fee was below the minimum required by the trampoline node"}
+        """.trimIndent()
+        val deserialized = OutgoingPartStatusData.deserialize(OutgoingPartStatusTypeVersion.FAILED_V0, serialized.toByteArray(Charsets.UTF_8), completedAt = 123)
+        val expected = LightningOutgoingPayment.Part.Status.Failed(
+            LightningOutgoingPayment.Part.Status.Failure.Uninterpretable("payment fee was below the minimum required by the trampoline node"), completedAt = 123
+        )
+        assertEquals(expected, deserialized)
     }
 
     @Test

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/SqlitePaymentsDatabaseTest.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/SqlitePaymentsDatabaseTest.kt
@@ -255,17 +255,17 @@ class SqlitePaymentsDatabaseTest {
         val onePartFailed = p.copy(
             parts = listOf(
                 p.parts[0].copy(
-                    status = LightningOutgoingPayment.Part.Status.Failed(TemporaryNodeFailure.code, TemporaryNodeFailure.message, 110)
+                    status = LightningOutgoingPayment.Part.Status.Failed(LightningOutgoingPayment.Part.Status.Failure.TemporaryRemoteFailure, 110)
                 ),
                 p.parts[1]
             )
         )
-        db.completeOutgoingLightningPart(p.parts[0].id, Either.Right(TemporaryNodeFailure), 110)
+        db.completeOutgoingLightningPart(p.parts[0].id, LightningOutgoingPayment.Part.Status.Failure.TemporaryRemoteFailure, 110)
         assertEquals(onePartFailed, db.getLightningOutgoingPayment(p.id))
         p.parts.forEach { assertEquals(onePartFailed, db.getLightningOutgoingPaymentFromPartId(it.id)) }
 
         // Updating non-existing parts should fail.
-        assertFalse { db.outQueries.updateLightningPart(UUID.randomUUID(), Either.Right(TemporaryNodeFailure), 110) }
+        assertFalse { db.outQueries.updateLightningPart(UUID.randomUUID(), LightningOutgoingPayment.Part.Status.Failure.TemporaryRemoteFailure, 110) }
         assertFalse { db.outQueries.updateLightningPart(UUID.randomUUID(), randomBytes32(), 110) }
 
         // Additional parts must have a unique id.
@@ -373,17 +373,17 @@ class SqlitePaymentsDatabaseTest {
         val channelId = randomBytes32()
         val partsFailed = p.copy(
             parts = listOf(
-                p.parts[0].copy(status = OutgoingPaymentFailure.convertFailure(Either.Right(TemporaryNodeFailure), 110)),
-                p.parts[1].copy(status = OutgoingPaymentFailure.convertFailure(Either.Left(TooManyAcceptedHtlcs(channelId, 10)), 111)),
+                p.parts[0].copy(status = LightningOutgoingPayment.Part.Status.Failed(LightningOutgoingPayment.Part.Status.Failure.TemporaryRemoteFailure, 110)),
+                p.parts[1].copy(status = LightningOutgoingPayment.Part.Status.Failed(LightningOutgoingPayment.Part.Status.Failure.TooManyPendingPayments, 111)),
             )
         )
-        db.completeOutgoingLightningPart(p.parts[0].id, Either.Right(TemporaryNodeFailure), 110)
-        db.completeOutgoingLightningPart(p.parts[1].id, Either.Left(TooManyAcceptedHtlcs(channelId, 10)), 111)
+        db.completeOutgoingLightningPart(p.parts[0].id, LightningOutgoingPayment.Part.Status.Failure.TemporaryRemoteFailure, 110)
+        db.completeOutgoingLightningPart(p.parts[1].id, LightningOutgoingPayment.Part.Status.Failure.TooManyPendingPayments, 111)
         assertEquals(partsFailed, db.getLightningOutgoingPayment(p.id))
         p.parts.forEach { assertEquals(partsFailed, db.getLightningOutgoingPaymentFromPartId(it.id)) }
 
         val paymentStatus = LightningOutgoingPayment.Status.Completed.Failed(
-            reason = FinalFailure.NoRouteToRecipient,
+            reason = FinalFailure.RecipientUnreachable,
             completedAt = 120
         )
         val paymentFailed = partsFailed.copy(status = paymentStatus)

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/cloud/CloudDataTest.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/cloud/CloudDataTest.kt
@@ -213,8 +213,7 @@ class CloudDataTest {
             amount = 500_005.msat,
             route = listOf(HopDesc(a, b)),
             status = LightningOutgoingPayment.Part.Status.Failed(
-                remoteFailureCode = 418,
-                details = "I'm a teapot"
+                LightningOutgoingPayment.Part.Status.Failure.Uninterpretable("I'm a teapot")
             )
         )
         val outgoingPayment = LightningOutgoingPayment(


### PR DESCRIPTION
This PR supports the new outgoing payment failures types added in https://github.com/ACINQ/lightning-kmp/pull/634.

There is a small impact on the payments database, as the status of failed parts are stored using a `code: Int` json (with an optional String message).

@robbiehanson we should remove the details for failed parts on iOS. Instead, show a single error message using the `OutgoingPaymentFailure.explain()` method that will pick the most pertinent error for a given payment (will return either a `FinalFailure` error, or a `Part.Status.Failure`)