### PR TITLE
(android) Add fee warning message in lnurl-withdraw screen

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/AppView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/AppView.kt
@@ -273,7 +273,8 @@ fun AppView(
                         ScanDataView(
                             input = input,
                             onBackClick = { popToHome(navController) },
-                            onAuthSchemeInfoClick = { navController.navigate("${Screen.PaymentSettings.route}/true") }
+                            onAuthSchemeInfoClick = { navController.navigate("${Screen.PaymentSettings.route}/true") },
+                            onFeeManagementClick = { navController.navigate(Screen.LiquidityPolicy.route) },
                         )
                     }
                 }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/LnurlWithdrawView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/LnurlWithdrawView.kt
@@ -33,6 +33,7 @@ import fr.acinq.phoenix.android.business
 import fr.acinq.phoenix.android.components.*
 import fr.acinq.phoenix.android.components.feedback.ErrorMessage
 import fr.acinq.phoenix.android.fiatRate
+import fr.acinq.phoenix.android.payments.receive.EvaluateLiquidityIssuesForPayment
 import fr.acinq.phoenix.android.preferredAmountUnit
 import fr.acinq.phoenix.android.utils.Converter.toPrettyStringWithFallback
 import fr.acinq.phoenix.android.utils.annotatedStringResource
@@ -43,7 +44,8 @@ import fr.acinq.phoenix.data.lnurl.LnurlError
 fun LnurlWithdrawView(
     model: Scan.Model.LnurlWithdrawFlow,
     onBackClick: () -> Unit,
-    onWithdrawClick: (Scan.Intent.LnurlWithdrawFlow) -> Unit
+    onWithdrawClick: (Scan.Intent.LnurlWithdrawFlow) -> Unit,
+    onFeeManagementClick: () -> Unit,
 ) {
     val context = LocalContext.current
     val prefUnit = preferredAmountUnit
@@ -111,6 +113,13 @@ fun LnurlWithdrawView(
                         )
                     }
                 }
+
+                EvaluateLiquidityIssuesForPayment(
+                    amount = amount,
+                    onFeeManagementClick = onFeeManagementClick,
+                    showDialogImmediately = true,
+                    onDialogShown = {},
+                )
             }
             is Scan.Model.LnurlWithdrawFlow.LnurlWithdrawFetch -> {
                 ProgressView(text = stringResource(id = R.string.lnurl_withdraw_wait))

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/ScanDataView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/ScanDataView.kt
@@ -83,6 +83,7 @@ fun ScanDataView(
     input: String? = null,
     onBackClick: () -> Unit,
     onAuthSchemeInfoClick: () -> Unit,
+    onFeeManagementClick: () -> Unit,
 ) {
     var initialInput = remember { input }
     val peer by business.peerManager.peerState.collectAsState()
@@ -159,7 +160,7 @@ fun ScanDataView(
                 LnurlAuthView(model = model, onBackClick = onBackClick, onLoginClick = { postIntent(it) }, onAuthSchemeInfoClick = onAuthSchemeInfoClick)
             }
             is Scan.Model.LnurlWithdrawFlow -> {
-                LnurlWithdrawView(model = model, onBackClick = onBackClick, onWithdrawClick = { postIntent(it) })
+                LnurlWithdrawView(model = model, onBackClick = onBackClick, onWithdrawClick = { postIntent(it) }, onFeeManagementClick = onFeeManagementClick)
             }
         }
     }


### PR DESCRIPTION
Withdrawals over LNURL are subject to the same liquidity constraints as regular Lightning payments, so a warning should be displayed.

It's actually even more important to have a liquidity warning here, since many LNURL services (e.g. Telegram bots) do not handle failed payments well and declare the withdrawal has been consumed, even when the payment was not received.

This PR also improves the regular Receive screen on Android, where the fee warning message dialog was opened systematically, even when the user had just seen it.