### PR TITLE
(ios) Don't show miner fee info for channel-closing transactions

### DIFF
--- a/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
@@ -290,7 +290,6 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 				onChain_broadcastAt(channelClosing)
 				onChain_confirmedAt(channelClosing)
 				common_amountSent(msat: outgoingPayment.amount)
-				onChain_minerFees(channelClosing)
 				common_amountReceived(sat: channelClosing.recipientAmount)
 				onChain_btcTxid(channelClosing)
 			}

--- a/phoenix-ios/phoenix-ios/views/inspect/WalletPaymentExtensions.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/WalletPaymentExtensions.swift
@@ -197,6 +197,16 @@ extension Lightning_kmpWalletPayment {
 				}
 			}
 			
+		} else if let _ = self as? Lightning_kmpChannelCloseOutgoingPayment {
+			
+			// Currently ACINQ pays the miner fees.
+			// But this will change soon, and the user will get to choose the feerate to pay.
+			// This will allow the user to control the speed of the closing transaction.
+			// And the UI will reflect this information.
+			// But for now we just don't want to show the miner fee for this TX type.
+			
+			return nil
+						
 		} else if let onChainOutgoingPayment = self as? Lightning_kmpOnChainOutgoingPayment {
 			
 			let sat = onChainOutgoingPayment.miningFees.sat


### PR DESCRIPTION
For now, this information isn't useful because ACINQ is paying the fee.

(But this will change soon, and the user will get to choose the feerate to pay. This will allow the user to control the speed of the closing transaction. And the future UI will reflect this information.)
