### PR TITLE
fix: "share" translation in german

### DIFF
--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -33432,7 +33432,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "aktie"
+            "value" : "teilen"
           }
         },
         "es" : {


### PR DESCRIPTION
"aktie" means "share" in a stock context, which is wrong.