### PR TITLE
iOS: Share invoices lowercased

### DIFF
--- a/phoenix-ios/phoenix-ios/views/receive/LightningDualView.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/LightningDualView.swift
@@ -894,7 +894,7 @@ struct LightningDualView: View {
 		log.trace("copyTextToPasteboard()")
 		
 		if let qrCodeValue = qrCode.value {
-			UIPasteboard.general.string = qrCodeValue
+            UIPasteboard.general.string = qrCodeValue.lowercased()
 			toast.pop(
 				NSLocalizedString("Copied to pasteboard!", comment: "Toast message"),
 				colorScheme: colorScheme.opposite,
@@ -921,7 +921,7 @@ struct LightningDualView: View {
 		
 		if let qrCodeValue = qrCode.value {
 			withAnimation {
-				let url = "lightning:\(qrCodeValue)"
+                let url = "lightning:\(qrCodeValue.lowercased())"
 				activeSheet = ReceiveViewSheet.sharingUrl(url: url)
 			}
 		}


### PR DESCRIPTION
According to BIP-0173, for presentation, lowercase invoices are preferable. The QRCodes are correctly encoded as uppercase here, but the text is also pasted as uppercase. Android copies the text as lowercase and since presentation is preferred to be lowercase I set the text to lowercase here.

Issue: https://github.com/ACINQ/phoenix/issues/601