### PR TITLE
(android) Split app into variants

### DIFF
--- a/phoenix-android/build.gradle.kts
+++ b/phoenix-android/build.gradle.kts
@@ -55,6 +55,16 @@ android {
         }
     }
 
+    flavorDimensions += "main"
+    productFlavors {
+        create("google") {
+            versionNameSuffix = "-google"
+        }
+        create("foss") {
+            versionNameSuffix = "-foss"
+        }
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
@@ -134,9 +144,9 @@ dependencies {
     implementation("org.slf4j:slf4j-api:${Versions.slf4j}")
     implementation("com.github.tony19:logback-android:${Versions.Android.logback}")
 
-    // firebase cloud messaging
-    implementation("com.google.firebase:firebase-messaging:${Versions.Android.fcm}")
-    implementation("com.google.android.gms:play-services-base:18.5.0")
+    // firebase cloud messaging -- only for the google flavor
+    "googleImplementation"("com.google.firebase:firebase-messaging:${Versions.Android.fcm}")
+    "googleImplementation"("com.google.android.gms:play-services-base:18.5.0")
 
     implementation("com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava")
 

--- a/phoenix-android/src/foss/AndroidManifest.xml
+++ b/phoenix-android/src/foss/AndroidManifest.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2024 ACINQ SAS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <application
+        android:name=".PhoenixApplicationFoss">
+
+        <activity
+            android:name=".MainActivityFoss"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.PhoenixAndroid.NoActionBar"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <!-- support for lightning/bitcoin/lnurl schemes -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <!-- bitcoin & lightning schemes -->
+                <data android:scheme="bitcoin" />
+                <data android:scheme="lightning" />
+                <!-- lnurl schemes -->
+                <data android:scheme="lnurl" />
+                <data android:scheme="lnurlw" />
+                <data android:scheme="lnurlp" />
+                <data android:scheme="keyauth" />
+                <!-- phoenix specific scheme, for apps who specifically want to open phoenix -->
+                <data android:scheme="phoenix" />
+            </intent-filter>
+        </activity>
+
+        <!-- node service -->
+        <service
+            android:name="fr.acinq.phoenix.android.services.NodeServiceFoss"
+            android:foregroundServiceType="shortService|remoteMessaging"
+            android:exported="false"
+            android:stopWithTask="false" />
+
+        <!-- broadcast receivers -->
+        <receiver
+            android:name="fr.acinq.phoenix.android.services.BootReceiverFoss"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
+    </application>
+</manifest>

--- a/phoenix-android/src/foss/kotlin/fr/acinq/phoenix/android/MainActivityFoss.kt
+++ b/phoenix-android/src/foss/kotlin/fr/acinq/phoenix/android/MainActivityFoss.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android
+
+import android.content.Context
+import android.content.Intent
+import fr.acinq.phoenix.android.services.HeadlessActions
+import fr.acinq.phoenix.android.services.NodeService
+import fr.acinq.phoenix.android.services.NodeServiceFoss
+
+class MainActivityFoss : MainActivity() {
+
+    override fun bindService() {
+        Intent(this, NodeServiceFoss::class.java).let { intent ->
+            applicationContext.bindService(intent, appViewModel.serviceConnection, Context.BIND_AUTO_CREATE or Context.BIND_ADJUST_WITH_ACTIVITY)
+        }
+    }
+
+    fun headlessServiceAction(action: HeadlessActions) {
+        val intent = Intent(applicationContext, NodeServiceFoss::class.java).apply {
+            this.action = action.name
+            putExtra(NodeService.EXTRA_ORIGIN, NodeService.ORIGIN_HEADLESS)
+        }
+        applicationContext.startForegroundService(intent)
+    }
+}

--- a/phoenix-android/src/foss/kotlin/fr/acinq/phoenix/android/PhoenixApplicationFoss.kt
+++ b/phoenix-android/src/foss/kotlin/fr/acinq/phoenix/android/PhoenixApplicationFoss.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android
+
+import android.content.Intent
+import fr.acinq.phoenix.android.services.NodeService
+import fr.acinq.phoenix.android.services.NodeServiceFoss
+
+
+class PhoenixApplicationFoss : PhoenixApplication() {
+
+    override val mainActivityClass: Class<out MainActivity> get() = MainActivityFoss::class.java
+    override val nodeServiceClass: Class<out NodeService> get() = NodeServiceFoss::class.java
+
+}

--- a/phoenix-android/src/foss/kotlin/fr/acinq/phoenix/android/home/BackgroundRestrictionBadgeFoss.kt
+++ b/phoenix-android/src/foss/kotlin/fr/acinq/phoenix/android/home/BackgroundRestrictionBadgeFoss.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android.home
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import fr.acinq.phoenix.android.AppViewModel
+import fr.acinq.phoenix.android.R
+import fr.acinq.phoenix.android.Screen
+import fr.acinq.phoenix.android.components.Clickable
+import fr.acinq.phoenix.android.components.Dialog
+import fr.acinq.phoenix.android.components.TextWithIcon
+import fr.acinq.phoenix.android.navController
+import fr.acinq.phoenix.android.utils.warningColor
+
+@Composable
+fun BackgroundRestrictionBadge(
+    appViewModel: AppViewModel,
+    isPowerSaverMode: Boolean,
+    isTorEnabled: Boolean,
+) {
+    val isHeadlessModeEnabled = appViewModel.service?.isHeadless == true
+
+    if (isTorEnabled || isPowerSaverMode || !isHeadlessModeEnabled) {
+        var showDialog by remember { mutableStateOf(false) }
+
+        TopBadgeButton(
+            text = null,
+            icon = R.drawable.ic_alert_triangle,
+            iconTint = warningColor,
+            onClick = { showDialog = true },
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+
+        if (showDialog) {
+            Dialog(
+                onDismiss = { showDialog = false },
+                title = stringResource(id = R.string.home_background_restriction_title)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.home_background_restriction_body_1),
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+
+                if (isTorEnabled) {
+                    TextWithIcon(
+                        text = stringResource(id = R.string.home_background_restriction_tor),
+                        textStyle = MaterialTheme.typography.body2,
+                        icon = R.drawable.ic_tor_shield_ok,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 6.dp),
+                    )
+                }
+
+                if (isPowerSaverMode) {
+                    TextWithIcon(
+                        text = stringResource(id = R.string.home_background_restriction_powersaver),
+                        textStyle = MaterialTheme.typography.body2,
+                        icon = R.drawable.ic_battery_charging,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 6.dp)
+                    )
+                }
+
+                if (!isHeadlessModeEnabled) {
+                    val nc = navController
+                    Clickable(onClick = { nc.navigate(Screen.Experimental.route) }) {
+                        Column(modifier = Modifier.padding(horizontal = 24.dp, vertical = 6.dp)) {
+                            TextWithIcon(
+                                text = stringResource(id = R.string.home_background_restriction_headless),
+                                textStyle = MaterialTheme.typography.body2,
+                                icon = R.drawable.ic_phone_tech,
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = stringResource(id = R.string.home_background_restriction_headless_desc),
+                                style = MaterialTheme.typography.subtitle2,
+                                modifier = Modifier.padding(start = 24.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/phoenix-android/src/foss/kotlin/fr/acinq/phoenix/android/services/BootReceiverFoss.kt
+++ b/phoenix-android/src/foss/kotlin/fr/acinq/phoenix/android/services/BootReceiverFoss.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android.services
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import fr.acinq.phoenix.android.PhoenixApplication
+import fr.acinq.phoenix.legacy.internalData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+
+/**
+ * This receiver is started when the device has booted, and schedules background jobs.
+ */
+class BootReceiverFoss : BroadcastReceiver() {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (Intent.ACTION_BOOT_COMPLETED == intent.action) {
+            ChannelsWatcher.schedule(context)
+            InflightPaymentsWatcher.scheduleOnce(context)
+
+            val internalPrefs = (context as? PhoenixApplication)?.internalDataRepository
+            val scope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
+            scope.launch {
+                internalPrefs?.getBackgroundServiceMode?.first()?.let { (isEnabled, isWakelock) ->
+                    if (isEnabled) {
+                        val action = if (isWakelock) HeadlessActions.Start.WithWakeLock else HeadlessActions.Start.NoWakeLock
+                        log.info("starting foreground service with action=$action")
+                        Intent(context, NodeServiceFoss::class.java).apply {
+                            this.action = action.name
+                            putExtra(NodeService.EXTRA_ORIGIN, NodeService.ORIGIN_HEADLESS)
+                        }
+                        context.startForegroundService(intent)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/phoenix-android/src/foss/kotlin/fr/acinq/phoenix/android/services/NodeServiceFoss.kt
+++ b/phoenix-android/src/foss/kotlin/fr/acinq/phoenix/android/services/NodeServiceFoss.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android.services
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.PowerManager
+import fr.acinq.phoenix.PhoenixBusiness
+import fr.acinq.phoenix.android.security.SeedManager
+import fr.acinq.phoenix.android.utils.SystemNotificationHelper
+
+
+sealed class HeadlessActions {
+    abstract val name: String
+    sealed class Start : HeadlessActions() {
+        data object WithWakeLock : Start() {
+            override val name: String = "START_WITH_WAKELOCK"
+        }
+        data object NoWakeLock : Start() {
+            override val name: String = "START_NO_WAKELOCK"
+        }
+    }
+    data object Stop : HeadlessActions() {
+        override val name: String = "STOP"
+    }
+
+    companion object {
+        fun read(name: String?) : HeadlessActions? {
+            return when (name) {
+                Start.NoWakeLock.name -> Start.NoWakeLock
+                Start.WithWakeLock.name -> Start.WithWakeLock
+                Stop.name -> Stop
+                else -> null
+            }
+        }
+    }
+}
+
+/**
+ * Implementation of [NodeService] without Google-based FCM support. Instead, to receive payments in the
+ * background, the user must first foreground this service manually and let the app run headless.
+ *
+ * Uses a [ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING] foreground type.
+ *
+ * See https://github.com/robertohuertasm/endless-service
+ */
+class NodeServiceFoss : NodeService() {
+
+    override suspend fun monitorFcmToken(business: PhoenixBusiness) {} // NOOP
+    override fun refreshFcmToken() {} // NOOP
+    override fun deleteFcmToken() {} // NOOP
+    override fun isFcmAvailable(context: Context): Boolean = false
+
+    var wakeLock: PowerManager.WakeLock? = null
+        private set
+
+    @SuppressLint("InlinedApi")
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+        val origin = intent?.getStringExtra(EXTRA_ORIGIN)
+        when (val action = HeadlessActions.read(intent?.action)) {
+            is HeadlessActions.Start -> {
+                log.info("--- start headless mode ---")
+                val (notif, serviceType) = when (state.value) {
+                    is NodeServiceState.Off -> {
+                        try {
+                            val encryptedSeed = SeedManager.loadSeedFromDisk(applicationContext)
+                            val seed = encryptedSeed!!.decrypt()
+                            log.debug("successfully decrypted seed in the background, starting wallet...")
+                            startBusiness(seed, requestCheckLegacyChannels = false)
+                            SystemNotificationHelper.getHeadlessNotification(applicationContext) to ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING
+                        } catch (e: Exception) {
+                            log.error("failed to decrypt seed: {}", e.localizedMessage)
+                            SystemNotificationHelper.getHeadlessFailureNotification(applicationContext) to ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
+                        }
+                    }
+                    else -> {
+                        SystemNotificationHelper.getHeadlessNotification(applicationContext) to ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING
+                    }
+                }
+                isHeadless = true
+                startForeground(notif, serviceType)
+                val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+                if (action is HeadlessActions.Start.WithWakeLock) {
+                    log.info("--- acquire wakelock ---")
+                    wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "PhoenixService::lock")
+                        .apply { acquire() }
+                }
+                return START_STICKY
+            }
+            is HeadlessActions.Stop -> {
+                log.info("--- stop headless mode ---")
+                isHeadless = false
+                if (wakeLock?.isHeld == true) {
+                    log.info("--- release wakelock ---")
+                    wakeLock?.release()
+                }
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                return START_NOT_STICKY
+            }
+            else -> {
+                log.info("--- unhandled start-command [ intent=${intent?.action} origin=$origin in state=${state.value} ] ---")
+                return START_NOT_STICKY
+            }
+        }
+    }
+
+}

--- a/phoenix-android/src/foss/kotlin/fr/acinq/phoenix/android/settings/ExperimentalViewFoss.kt
+++ b/phoenix-android/src/foss/kotlin/fr/acinq/phoenix/android/settings/ExperimentalViewFoss.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import fr.acinq.phoenix.android.AppViewModel
+import fr.acinq.phoenix.android.MainActivityFoss
+import fr.acinq.phoenix.android.R
+import fr.acinq.phoenix.android.components.Card
+import fr.acinq.phoenix.android.components.CardHeader
+import fr.acinq.phoenix.android.components.FilledButton
+import fr.acinq.phoenix.android.components.SwitchView
+import fr.acinq.phoenix.android.components.settings.SettingSwitch
+import fr.acinq.phoenix.android.internalData
+import fr.acinq.phoenix.android.services.HeadlessActions
+import fr.acinq.phoenix.android.services.NodeServiceFoss
+import fr.acinq.phoenix.android.utils.findActivity
+import kotlinx.coroutines.launch
+
+@Composable
+fun ManageHeadlessView(appViewModel: AppViewModel) {
+    CardHeader(text = stringResource(id = R.string.background_header))
+    Card(modifier = Modifier.fillMaxWidth()) {
+        val service = appViewModel.service as NodeServiceFoss?
+        val activity = LocalContext.current.findActivity() as MainActivityFoss
+        val scope = rememberCoroutineScope()
+        val internalPrefs = internalData
+
+        var showConfirmDialog by remember { mutableStateOf(false) }
+
+        SettingSwitch(
+            title = {
+                Text(
+                    text = stringResource(id = R.string.background_mode_title),
+                    style = MaterialTheme.typography.body2,
+                    modifier = Modifier.weight(1f)
+                )
+            },
+            subtitle = when (service?.isHeadless) {
+                null -> null
+                true -> if (service.wakeLock?.isHeld == true) {
+                    { Text(stringResource(id = R.string.background_mode_on_wakelock), style = MaterialTheme.typography.subtitle2) }
+                } else {
+                    { Text(stringResource(id = R.string.background_mode_on_no_wakelock), style = MaterialTheme.typography.subtitle2) }
+                }
+                false -> {
+                    { Text(text = stringResource(id = R.string.background_mode_off), style = MaterialTheme.typography.subtitle2) }
+                }
+            },
+            icon = R.drawable.ic_phone_tech,
+            enabled = service?.isHeadless != null,
+            isChecked = service?.isHeadless ?: false,
+            onCheckChangeAttempt = { runHeadless ->
+                scope.launch {
+                    if (runHeadless) {
+                        showConfirmDialog = true
+                    } else {
+                        scope.launch {
+                            activity.headlessServiceAction(HeadlessActions.Stop)
+                            internalPrefs.saveBackgroundServiceModeDisabled()
+                        }
+                    }
+                }
+            }
+        )
+
+        if (showConfirmDialog) {
+            ConfirmHeadlessDialog(
+                onDismiss = { showConfirmDialog = false },
+                onConfirm = { withWakeLock ->
+                    scope.launch {
+                        activity.headlessServiceAction(if (withWakeLock) HeadlessActions.Start.WithWakeLock else HeadlessActions.Start.NoWakeLock)
+                        internalPrefs.saveBackgroundServiceModeEnabled(withWakeLock)
+                        showConfirmDialog = false
+                    }
+                }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ConfirmHeadlessDialog(
+   onDismiss: () -> Unit,
+   onConfirm: (Boolean) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        sheetState = sheetState,
+        onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colors.surface,
+        contentColor = MaterialTheme.colors.onSurface,
+        scrimColor = MaterialTheme.colors.onBackground.copy(alpha = 0.2f),
+    ) {
+        var withWakeLock by remember { mutableStateOf(true) }
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .sizeIn(minHeight = 400.dp, maxHeight = 700.dp)
+                .padding(horizontal = 24.dp),
+        ) {
+            Text(text = stringResource(id = R.string.background_mode_dialog_title), style = MaterialTheme.typography.h4)
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = stringResource(id = R.string.background_mode_dialog_desc))
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = stringResource(id = R.string.background_mode_dialog_perfs_desc))
+            Spacer(modifier = Modifier.height(12.dp))
+            SwitchView(
+                text = stringResource(id = R.string.background_mode_dialog_wakelock_title),
+                textStyle = MaterialTheme.typography.body2,
+                description = stringResource(id = R.string.background_mode_dialog_wakelock_desc),
+                checked = withWakeLock,
+                onCheckedChange = { withWakeLock = it }
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(text = stringResource(id = R.string.background_mode_dialog_alternative_title), style = MaterialTheme.typography.h4)
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = stringResource(id = R.string.background_mode_dialog_alternative_desc))
+            Spacer(modifier = Modifier.height(32.dp))
+            FilledButton(
+                text = stringResource(id = R.string.btn_start),
+                icon = R.drawable.ic_start,
+                onClick = { onConfirm(withWakeLock) },
+                modifier = Modifier.align(Alignment.End)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            FilledButton(
+                text = stringResource(id = R.string.btn_cancel),
+                icon = R.drawable.ic_check,
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.End),
+                backgroundColor = Color.Transparent,
+                textStyle = MaterialTheme.typography.button
+            )
+            Spacer(modifier = Modifier.height(40.dp))
+        }
+    }
+}

--- a/phoenix-android/src/foss/res/drawable/ic_phone_tech.xml
+++ b/phoenix-android/src/foss/res/drawable/ic_phone_tech.xml
@@ -1,0 +1,99 @@
+<!--
+  ~ Copyright 2024 ACINQ SAS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="@dimen/icon_size"
+    android:height="@dimen/icon_size"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="m17.266,12.78v7.273c0,1.115 -0.773,2.013 -1.733,2.013H6.867c-0.96,0 -1.733,-0.898 -1.733,-2.013V3.947c0,-1.115 0.773,-2.013 1.733,-2.013v0h5.56"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.86793"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/colorPrimary"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m11.697,17.998h0.01"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.99314"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/colorPrimary"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M17.136,6.212m-3,0a3,3 0,1 1,6 0a3,3 0,1 1,-6 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.8"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/colorPrimary"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M20.836,7.612 L20.109,7.361"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/colorPrimary"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M14.162,5.137 L13.436,4.812"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/colorPrimary"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m15.736,9.912 l0.275,-0.603"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/colorPrimary"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m18.31,3.189 l0.226,-0.677"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/colorPrimary"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M18.736,9.912 L18.41,9.135"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/colorPrimary"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m15.936,3.289 l-0.4,-0.777"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/colorPrimary"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="m13.436,7.812 l0.703,-0.276"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/colorPrimary"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M20.084,4.913 L20.836,4.612"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/colorPrimary"
+      android:strokeLineCap="round"/>
+</vector>

--- a/phoenix-android/src/foss/res/drawable/ic_start.xml
+++ b/phoenix-android/src/foss/res/drawable/ic_start.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright 2024 ACINQ SAS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="@dimen/icon_size"
+    android:height="@dimen/icon_size"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M6,3l14,9l-14,9l0,-18z"
+        android:strokeWidth="2"
+        android:strokeColor="?attr/colorPrimary"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/phoenix-android/src/foss/res/values/strings.xml
+++ b/phoenix-android/src/foss/res/values/strings.xml
@@ -1,0 +1,36 @@
+<!--
+  ~ Copyright 2024 ACINQ SAS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="home_background_restriction_headless">Background service mode is disabled</string>
+    <string name="home_background_restriction_headless_desc">Tap for details.</string>
+
+    <string name="background_header">Background processing</string>
+    <string name="background_mode_title">Background service mode</string>
+    <string name="background_mode_off">Not running. Enable to improve payments reliability</string>
+    <string name="background_mode_on_wakelock">Service is running (wakelock enabled)</string>
+    <string name="background_mode_on_no_wakelock">Service is running</string>
+
+    <string name="background_mode_dialog_title">Always-on service</string>
+    <string name="background_mode_dialog_desc">When enabled, Phoenix will keep running as a background service even if the app is closed, allowing you to receive payments more reliably.</string>
+    <string name="background_mode_dialog_perfs_title">Performance cost</string>
+    <string name="background_mode_dialog_perfs_desc">Phoenix battery usage will increase significantly.</string>
+    <string name="background_mode_dialog_wakelock_title">Keep wake-lock</string>
+    <string name="background_mode_dialog_wakelock_desc">Makes the service more reliable, but uses much more battery.</string>
+    <string name="background_mode_dialog_alternative_title">Alternatives</string>
+    <string name="background_mode_dialog_alternative_desc">If you prefer optimised, just-in-time notifications for background processing, install the Google Play version of Phoenix instead.</string>
+
+</resources>

--- a/phoenix-android/src/google/AndroidManifest.xml
+++ b/phoenix-android/src/google/AndroidManifest.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2024 ACINQ SAS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:name=".PhoenixApplicationGoogle">
+
+        <activity
+            android:name=".MainActivityGoogle"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.PhoenixAndroid.NoActionBar"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <!-- support for lightning/bitcoin/lnurl schemes -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <!-- bitcoin & lightning schemes -->
+                <data android:scheme="bitcoin" />
+                <data android:scheme="lightning" />
+                <!-- lnurl schemes -->
+                <data android:scheme="lnurl" />
+                <data android:scheme="lnurlw" />
+                <data android:scheme="lnurlp" />
+                <data android:scheme="keyauth" />
+                <!-- phoenix specific scheme, for apps who specifically want to open phoenix -->
+                <data android:scheme="phoenix" />
+            </intent-filter>
+        </activity>
+
+        <!-- firebase cloud messaging -->
+        <service
+            android:name="fr.acinq.phoenix.android.services.FCMService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <!-- node service -->
+        <service
+            android:name="fr.acinq.phoenix.android.services.NodeServiceGoogle"
+            android:foregroundServiceType="shortService"
+            android:exported="false"
+            android:stopWithTask="false" />
+
+        <!-- broadcast receivers -->
+        <receiver
+            android:name="fr.acinq.phoenix.android.services.BootReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+    </application>
+</manifest>

--- a/phoenix-android/src/google/kotlin/fr/acinq/phoenix/android/MainActivityGoogle.kt
+++ b/phoenix-android/src/google/kotlin/fr/acinq/phoenix/android/MainActivityGoogle.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android
+
+import android.content.Context
+import android.content.Intent
+import fr.acinq.phoenix.android.services.NodeServiceGoogle
+
+class MainActivityGoogle : MainActivity() {
+
+    override fun bindService() {
+        Intent(this, NodeServiceGoogle::class.java).let { intent ->
+            applicationContext.bindService(intent, appViewModel.serviceConnection, Context.BIND_AUTO_CREATE or Context.BIND_ADJUST_WITH_ACTIVITY)
+        }
+    }
+}

--- a/phoenix-android/src/google/kotlin/fr/acinq/phoenix/android/PhoenixApplicationGoogle.kt
+++ b/phoenix-android/src/google/kotlin/fr/acinq/phoenix/android/PhoenixApplicationGoogle.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 ACINQ SAS
+ * Copyright 2020 ACINQ SAS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package fr.acinq.phoenix.android.utils
+package fr.acinq.phoenix.android
 
-import android.content.Context
-import com.google.android.gms.common.ConnectionResult
-import com.google.android.gms.common.GoogleApiAvailability
+import fr.acinq.phoenix.android.services.NodeService
+import fr.acinq.phoenix.android.services.NodeServiceGoogle
 
-object FCMHelper {
-    fun isFCMAvailable(context: Context): Boolean {
-        return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
-    }
+
+class PhoenixApplicationGoogle : PhoenixApplication() {
+
+    override val mainActivityClass: Class<out MainActivity> get() = MainActivityGoogle::class.java
+    override val nodeServiceClass: Class<out NodeService> get() = NodeServiceGoogle::class.java
 }

--- a/phoenix-android/src/google/kotlin/fr/acinq/phoenix/android/home/BackgroundRestrictionBadgeGoogle.kt
+++ b/phoenix-android/src/google/kotlin/fr/acinq/phoenix/android/home/BackgroundRestrictionBadgeGoogle.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android.home
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import fr.acinq.phoenix.android.AppViewModel
+import fr.acinq.phoenix.android.R
+import fr.acinq.phoenix.android.components.Dialog
+import fr.acinq.phoenix.android.components.TextWithIcon
+import fr.acinq.phoenix.android.utils.warningColor
+
+@Composable
+fun BackgroundRestrictionBadge(
+    appViewModel: AppViewModel,
+    isPowerSaverMode: Boolean,
+    isTorEnabled: Boolean,
+) {
+    val context = LocalContext.current
+    val isFcmAvailable = appViewModel.service?.isFcmAvailable(context) == true
+
+    if (isTorEnabled || isPowerSaverMode || !isFcmAvailable) {
+        var showDialog by remember { mutableStateOf(false) }
+
+        TopBadgeButton(
+            text = null,
+            icon = R.drawable.ic_alert_triangle,
+            iconTint = warningColor,
+            onClick = { showDialog = true },
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+
+        if (showDialog) {
+            Dialog(
+                onDismiss = { showDialog = false },
+                title = stringResource(id = R.string.home_background_restriction_title)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.home_background_restriction_body_1),
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+
+                if (isTorEnabled) {
+                    TextWithIcon(
+                        text = stringResource(id = R.string.home_background_restriction_tor),
+                        textStyle = MaterialTheme.typography.body2,
+                        icon = R.drawable.ic_tor_shield_ok,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 6.dp)
+                    )
+                }
+
+                if (isPowerSaverMode) {
+                    TextWithIcon(
+                        text = stringResource(id = R.string.home_background_restriction_powersaver),
+                        textStyle = MaterialTheme.typography.body2,
+                        icon = R.drawable.ic_battery_charging,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 6.dp)
+                    )
+                }
+
+                if (!isFcmAvailable) {
+                    Column(modifier = Modifier.padding(horizontal = 24.dp, vertical = 6.dp)) {
+                        TextWithIcon(
+                            text = stringResource(id = R.string.home_background_restriction_fcm),
+                            textStyle = MaterialTheme.typography.body2,
+                            icon = R.drawable.ic_battery_charging,
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = stringResource(id = R.string.home_background_restriction_fcm_details),
+                            style = MaterialTheme.typography.subtitle2,
+                            modifier = Modifier.padding(start = 24.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/phoenix-android/src/google/kotlin/fr/acinq/phoenix/android/services/FCMService.kt
+++ b/phoenix-android/src/google/kotlin/fr/acinq/phoenix/android/services/FCMService.kt
@@ -35,7 +35,7 @@ class FCMService : FirebaseMessagingService() {
 
         when {
             encryptedSeed !is EncryptedSeed.V2.NoAuth -> {
-                log.warn("ignored fcm message with unhandled seed=${encryptedSeed?.name()}")
+                log.warn("ignored fcm message with unhandled seed}")
             }
             remoteMessage.priority != RemoteMessage.PRIORITY_HIGH -> {
                 // cannot start foreground service from low/normal priority message
@@ -54,8 +54,11 @@ class FCMService : FirebaseMessagingService() {
     }
 
     private fun startPhoenixForegroundService(reason: String?) {
-        ContextCompat.startForegroundService(applicationContext, Intent(applicationContext, NodeService::class.java)
-            .apply { reason?.let { putExtra(NodeService.EXTRA_REASON, it) } })
+        ContextCompat.startForegroundService(applicationContext, Intent(applicationContext, NodeServiceGoogle::class.java)
+            .apply {
+                reason?.let { putExtra(NodeService.EXTRA_REASON, it) }
+                putExtra(NodeService.EXTRA_ORIGIN, NodeService.ORIGIN_FCM)
+            })
     }
 
     override fun onNewToken(token: String) {

--- a/phoenix-android/src/google/kotlin/fr/acinq/phoenix/android/services/NodeServiceGoogle.kt
+++ b/phoenix-android/src/google/kotlin/fr/acinq/phoenix/android/services/NodeServiceGoogle.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android.services
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.messaging.FirebaseMessaging
+import fr.acinq.lightning.utils.Connection
+import fr.acinq.phoenix.PhoenixBusiness
+import fr.acinq.phoenix.android.security.SeedManager
+import fr.acinq.phoenix.android.utils.SystemNotificationHelper
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+
+class NodeServiceGoogle : NodeService() {
+
+    override fun onBind(intent: Intent?): IBinder {
+        isHeadless = false
+        notificationManager.cancel(SystemNotificationHelper.HEADLESS_NOTIF_ID)
+        return super.onBind(intent)
+    }
+
+    override fun onUnbind(intent: Intent?): Boolean {
+        isHeadless = true
+        return super.onUnbind(intent)
+    }
+
+    override suspend fun monitorFcmToken(business: PhoenixBusiness) {
+        val token = internalData.getFcmToken.filterNotNull().first()
+        business.connectionsManager.connections.first { it.peer == Connection.ESTABLISHED }
+        business.registerFcmToken(token)
+    }
+
+    override fun refreshFcmToken() {
+        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                log.warn("fetching FCM registration token failed: ${task.exception?.localizedMessage}")
+                return@OnCompleteListener
+            }
+            task.result?.let { serviceScope.launch { internalData.saveFcmToken(it) } }
+        })
+    }
+
+    override fun deleteFcmToken() {
+        FirebaseMessaging.getInstance().deleteToken().addOnCompleteListener { task ->
+            if (task.isSuccessful) refreshFcmToken()
+        }
+    }
+
+    override fun isFcmAvailable(context: Context): Boolean {
+        return GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
+    }
+
+    // See [scheduleShutdown].
+    private val shutdownHandler = Handler(Looper.getMainLooper())
+
+    /**
+     * Schedules business shutdown and removal of service from the foreground if needed.
+     * After receiving a FCM wake-up message, the service is put in the foreground and then keeps running
+     * for a while (typically 2 minutes). Then it shuts down automatically.
+     *
+     * @param delayMillis default is 2 minutes. Should always be less than 3 minutes, to avoid [onTimeout] since
+     *      foreground mode is using the `SHORT_SERVICE` foreground type.
+     */
+    private fun scheduleShutdown(delayMillis: Long = 2 * 60 * 1000L) {
+        shutdownHandler.postDelayed(Runnable {
+            if (isHeadless) {
+                log.debug("reached scheduled shutdown...")
+                if (receivedInBackground.isEmpty()) {
+                    stopForeground(STOP_FOREGROUND_REMOVE)
+                } else {
+                    stopForeground(STOP_FOREGROUND_DETACH)
+                }
+                notificationManager.cancel(SystemNotificationHelper.HEADLESS_NOTIF_ID)
+                shutdown()
+            }
+        }, delayMillis)
+    }
+
+    @SuppressLint("InlinedApi")
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+        val origin = intent?.getStringExtra(EXTRA_ORIGIN)
+        val reason = intent?.getStringExtra(EXTRA_REASON)
+        log.info("--- start service from intent [ intent=$intent, flag=$flags, startId=$startId ] reason=$reason origin=$origin in state=${state.value} ---")
+
+        val encryptedSeed = SeedManager.loadSeedFromDisk(applicationContext)
+        val (notif, serviceType) = when (state.value) {
+            is NodeServiceState.Off -> {
+                try {
+                    val seed = encryptedSeed!!.decrypt()
+                    log.debug("successfully decrypted seed in the background, starting wallet...")
+                    startBusiness(seed, requestCheckLegacyChannels = false)
+                    SystemNotificationHelper.getHeadlessNotification(applicationContext) to ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
+                } catch (e: Exception) {
+                    log.error("failed to decrypt seed: {}", e.localizedMessage)
+                    SystemNotificationHelper.getHeadlessFailureNotification(applicationContext) to ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
+                }
+            }
+            else -> {
+                SystemNotificationHelper.getHeadlessNotification(applicationContext) to ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
+                // TODO force reconnect if disconnected!
+            }
+        }
+
+        startForeground(notif, serviceType)
+        shutdownHandler.removeCallbacksAndMessages(null)
+        scheduleShutdown()
+
+        if (origin == ORIGIN_FCM) {
+            isHeadless = true
+        } else {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+        }
+        return START_NOT_STICKY
+    }
+}

--- a/phoenix-android/src/google/kotlin/fr/acinq/phoenix/android/settings/ExperimentalViewGoogle.kt
+++ b/phoenix-android/src/google/kotlin/fr/acinq/phoenix/android/settings/ExperimentalViewGoogle.kt
@@ -1,0 +1,7 @@
+package fr.acinq.phoenix.android.settings
+
+import androidx.compose.runtime.Composable
+import fr.acinq.phoenix.android.AppViewModel
+
+@Composable
+fun ManageHeadlessView(appViewModel: AppViewModel) {}

--- a/phoenix-android/src/main/AndroidManifest.xml
+++ b/phoenix-android/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
-        android:name=".PhoenixApplication"
         android:allowBackup="false"
         android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"
@@ -34,35 +33,6 @@
             android:name="com.google.firebase.messaging.default_notification_color"
             android:value="#ff0000" />
 
-        <activity
-            android:name=".MainActivity"
-            android:exported="true"
-            android:launchMode="singleTask"
-            android:theme="@style/Theme.PhoenixAndroid.NoActionBar"
-            android:windowSoftInputMode="adjustResize">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-            <!-- support for lightning/bitcoin/lnurl schemes -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <category android:name="android.intent.category.DEFAULT" />
-
-                <!-- bitcoin & lightning schemes -->
-                <data android:scheme="bitcoin" />
-                <data android:scheme="lightning" />
-                <!-- lnurl schemes -->
-                <data android:scheme="lnurl" />
-                <data android:scheme="lnurlw" />
-                <data android:scheme="lnurlp" />
-                <data android:scheme="keyauth" />
-                <!-- phoenix specific scheme, for apps who specifically want to open phoenix -->
-                <data android:scheme="phoenix" />
-            </intent-filter>
-        </activity>
-
         <!-- providers -->
         <provider
             android:name="androidx.core.content.FileProvider"
@@ -74,31 +44,7 @@
                 android:resource="@xml/provider_paths" />
         </provider>
 
-        <!-- firebase cloud messaging -->
-        <service
-            android:name="fr.acinq.phoenix.android.services.FCMService"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="com.google.firebase.MESSAGING_EVENT" />
-            </intent-filter>
-        </service>
-
-        <!-- node service -->
-        <service
-            android:name="fr.acinq.phoenix.android.services.NodeService"
-            android:foregroundServiceType="shortService"
-            android:exported="false"
-            android:stopWithTask="false" />
-
-        <!-- broadcast receivers -->
-        <receiver
-            android:name="fr.acinq.phoenix.android.services.BootReceiver"
-            android:enabled="true"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
-            </intent-filter>
-        </receiver>
+        <!-- Services are defined in the variant folders (node service, fcm service, boot service) -->
 
     </application>
 </manifest>

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/MainActivity.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/MainActivity.kt
@@ -31,7 +31,6 @@ import androidx.navigation.*
 import androidx.navigation.compose.rememberNavController
 import fr.acinq.lightning.io.PhoenixAndroidLegacyInfoEvent
 import fr.acinq.lightning.utils.Connection
-import fr.acinq.phoenix.android.services.NodeService
 import fr.acinq.phoenix.android.utils.LegacyMigrationHelper
 import fr.acinq.phoenix.android.utils.PhoenixAndroidTheme
 import fr.acinq.phoenix.legacy.utils.*
@@ -47,10 +46,10 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 
-class MainActivity : AppCompatActivity() {
+abstract class MainActivity : AppCompatActivity() {
 
     val log: Logger = LoggerFactory.getLogger(MainActivity::class.java)
-    private val appViewModel: AppViewModel by viewModels { AppViewModel.Factory }
+    internal val appViewModel: AppViewModel by viewModels { AppViewModel.Factory }
 
     private var navController: NavHostController? = null
 
@@ -151,15 +150,15 @@ class MainActivity : AppCompatActivity() {
 
     override fun onStart() {
         super.onStart()
-        Intent(this, NodeService::class.java).let { intent ->
-            applicationContext.bindService(intent, appViewModel.serviceConnection, Context.BIND_AUTO_CREATE or Context.BIND_ADJUST_WITH_ACTIVITY)
-        }
+        bindService()
     }
 
     override fun onResume() {
         super.onResume()
         tryReconnect()
     }
+
+    abstract fun bindService()
 
     private fun tryReconnect() {
         lifecycleScope.launch {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/settings/SettingSwitch.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/settings/SettingSwitch.kt
@@ -19,6 +19,7 @@ package fr.acinq.phoenix.android.components.settings
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -47,6 +48,32 @@ fun SettingSwitch(
     isChecked: Boolean,
     onCheckChangeAttempt: ((Boolean) -> Unit)
 ) {
+    SettingSwitch(
+        modifier = modifier,
+        title = {
+            Text(text = title, style = if (enabled) MaterialTheme.typography.body2 else MaterialTheme.typography.caption, modifier = Modifier.weight(1f))
+        },
+        subtitle = description?.let {
+            { Text(text = description, style = MaterialTheme.typography.subtitle2, modifier = Modifier.weight(1f)) }
+        },
+        icon = icon,
+        enabled = enabled,
+        isChecked = isChecked,
+        onCheckChangeAttempt = onCheckChangeAttempt
+    )
+}
+
+
+@Composable
+fun SettingSwitch(
+    modifier: Modifier = Modifier,
+    title: @Composable RowScope.() -> Unit,
+    subtitle: (@Composable RowScope.() -> Unit)? = null,
+    icon: Int? = null,
+    enabled: Boolean,
+    isChecked: Boolean,
+    onCheckChangeAttempt: ((Boolean) -> Unit)
+) {
     Column(
         modifier
             .fillMaxWidth()
@@ -58,17 +85,17 @@ fun SettingSwitch(
                 PhoenixIcon(it, Modifier.size(ButtonDefaults.IconSize))
                 Spacer(Modifier.width(12.dp))
             }
-            Text(text = title, style = if (enabled) MaterialTheme.typography.body2 else MaterialTheme.typography.caption, modifier = Modifier.weight(1f))
+            title()
             Spacer(Modifier.width(16.dp))
             Switch(checked = isChecked, onCheckedChange = null, enabled = enabled, modifier = Modifier.enableOrFade(enabled))
         }
-        if (description != null) {
+        if (subtitle != null) {
             Spacer(modifier = Modifier.height(2.dp))
             Row(Modifier.fillMaxWidth()) {
                 icon?.let {
                     Spacer(modifier = Modifier.width(30.dp))
                 }
-                Text(text = description, style = MaterialTheme.typography.subtitle2, modifier = Modifier.weight(1f))
+                subtitle()
                 Spacer(Modifier.width(48.dp))
             }
         }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeTopAndBottom.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeTopAndBottom.kt
@@ -16,9 +16,22 @@
 
 package fr.acinq.phoenix.android.home
 
-import androidx.compose.animation.core.*
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
@@ -40,12 +53,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import fr.acinq.lightning.utils.Connection
+import fr.acinq.phoenix.android.AppViewModel
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.components.BorderButton
 import fr.acinq.phoenix.android.components.Button
 import fr.acinq.phoenix.android.components.Dialog
 import fr.acinq.phoenix.android.components.FilledButton
-import fr.acinq.phoenix.android.components.TextWithIcon
 import fr.acinq.phoenix.android.components.VSeparator
 import fr.acinq.phoenix.android.components.openLink
 import fr.acinq.phoenix.android.utils.isBadCertificate
@@ -57,12 +70,12 @@ import fr.acinq.phoenix.managers.Connections
 @Composable
 fun TopBar(
     modifier: Modifier = Modifier,
+    appViewModel: AppViewModel,
     onConnectionsStateButtonClick: () -> Unit,
     connections: Connections,
     electrumBlockheight: Int,
     onTorClick: () -> Unit,
     isTorEnabled: Boolean?,
-    isFCMUnavailable: Boolean,
     isPowerSaverMode: Boolean,
     inFlightPaymentsCount: Int,
     showRequestLiquidity: Boolean,
@@ -90,9 +103,9 @@ fun TopBar(
         }
 
         BackgroundRestrictionBadge(
-            isFCMUnavailable = isFCMUnavailable,
+            appViewModel = appViewModel,
+            isPowerSaverMode = isPowerSaverMode,
             isTorEnabled = isTorEnabled == true,
-            isPowerSaverMode = isPowerSaverMode
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -172,7 +185,7 @@ private fun ConnectionBadge(
 }
 
 @Composable
-private fun TopBadgeButton(
+fun TopBadgeButton(
     text: String?,
     icon: Int,
     onClick: () -> Unit,
@@ -191,58 +204,6 @@ private fun TopBadgeButton(
         modifier = modifier.widthIn(max = 120.dp),
         maxLines = 1
     )
-}
-
-@Composable
-private fun BackgroundRestrictionBadge(
-    isTorEnabled: Boolean,
-    isPowerSaverMode: Boolean,
-    isFCMUnavailable: Boolean,
-) {
-    if (isTorEnabled || isPowerSaverMode || isFCMUnavailable) {
-        var showDialog by remember { mutableStateOf(false) }
-
-        TopBadgeButton(
-            text = null,
-            icon = R.drawable.ic_alert_triangle,
-            iconTint = warningColor,
-            onClick = { showDialog = true },
-        )
-        Spacer(modifier = Modifier.width(4.dp))
-
-        if (showDialog) {
-            Dialog(
-                onDismiss = { showDialog = false },
-                title = stringResource(id = R.string.home_background_restriction_title)
-            ) {
-                Column(
-                    modifier = Modifier.padding(horizontal = 24.dp)
-                ) {
-                    Text(text = stringResource(id = R.string.home_background_restriction_body_1))
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(text = stringResource(id = R.string.home_background_restriction_body_2))
-                    Spacer(modifier = Modifier.height(8.dp))
-
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        if (isTorEnabled) {
-                            TextWithIcon(text = stringResource(id = R.string.home_background_restriction_tor), icon = R.drawable.ic_tor_shield_ok)
-                        }
-                        if (isPowerSaverMode) {
-                            TextWithIcon(text = stringResource(id = R.string.home_background_restriction_powersaver), icon = R.drawable.ic_battery_charging)
-                        }
-                        if (isFCMUnavailable) {
-                            TextWithIcon(text = stringResource(id = R.string.home_background_restriction_fcm), icon = R.drawable.ic_cloud_off)
-                            Text(
-                                text = stringResource(id = R.string.home_background_restriction_fcm_details),
-                                style = MaterialTheme.typography.caption.copy(fontSize = 14.sp),
-                                modifier = Modifier.padding(start = 26.dp)
-                            )
-                        }
-                    }
-                }
-            }
-        }
-    }
 }
 
 @Composable

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
@@ -44,6 +44,7 @@ import androidx.constraintlayout.compose.Dimension
 import androidx.constraintlayout.compose.MotionLayout
 import androidx.constraintlayout.compose.MotionScene
 import androidx.constraintlayout.compose.layoutId
+import fr.acinq.phoenix.android.AppViewModel
 import fr.acinq.phoenix.android.CF
 import fr.acinq.phoenix.android.NoticesViewModel
 import fr.acinq.phoenix.android.PaymentsViewModel
@@ -53,7 +54,6 @@ import fr.acinq.phoenix.android.business
 import fr.acinq.phoenix.android.components.Dialog
 import fr.acinq.phoenix.android.components.PrimarySeparator
 import fr.acinq.phoenix.android.components.mvi.MVIView
-import fr.acinq.phoenix.android.utils.FCMHelper
 import fr.acinq.phoenix.android.utils.annotatedStringResource
 import fr.acinq.phoenix.android.utils.datastore.HomeAmountDisplayMode
 import fr.acinq.phoenix.android.utils.findActivity
@@ -67,6 +67,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun HomeView(
+    appViewModel: AppViewModel,
     paymentsViewModel: PaymentsViewModel,
     noticesViewModel: NoticesViewModel,
     onPaymentClick: (WalletPaymentId) -> Unit,
@@ -85,8 +86,6 @@ fun HomeView(
     val internalData = application.internalDataRepository
     val userPrefs = application.userPrefs
     val isPowerSaverModeOn = noticesViewModel.isPowerSaverModeOn
-    val fcmToken by internalData.getFcmToken.collectAsState(initial = "")
-    val isFCMAvailable = remember { FCMHelper.isFCMAvailable(context) }
     val torEnabledState = userPrefs.getIsTorEnabled.collectAsState(initial = null)
     val balanceDisplayMode by userPrefs.getHomeAmountDisplayMode.collectAsState(initial = HomeAmountDisplayMode.REDACTED)
 
@@ -221,13 +220,13 @@ fun HomeView(
                 ) {}
                 TopBar(
                     modifier = Modifier.layoutId("topBar"),
+                    appViewModel = appViewModel,
                     onConnectionsStateButtonClick = { showConnectionsDialog = true },
                     connections = connections,
                     electrumBlockheight = electrumMessages?.blockHeight ?: 0,
                     inFlightPaymentsCount = inFlightPaymentsCount,
                     isTorEnabled = torEnabledState.value,
                     onTorClick = onTorClick,
-                    isFCMUnavailable = fcmToken == null || !isFCMAvailable,
                     isPowerSaverMode = isPowerSaverModeOn,
                     showRequestLiquidity = channels.canRequestLiquidity(),
                     onRequestLiquidityClick = onRequestLiquidityClick,

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/security/EncryptedSeed.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/security/EncryptedSeed.kt
@@ -73,7 +73,7 @@ sealed class EncryptedSeed {
       private const val NO_AUTH_KEY_VERSION = 1
       private const val REMOVED_DO_NOT_USE = 2
 
-      fun deserialize(stream: ByteArrayInputStream): V2 {
+      fun deserialize(stream: ByteArrayInputStream): V2.NoAuth {
         val keyVersion = stream.read()
         val iv = ByteArray(IV_LENGTH)
         stream.read(iv, 0, IV_LENGTH)
@@ -93,7 +93,7 @@ sealed class EncryptedSeed {
     const val SEED_FILE_VERSION_2: Byte = 2
 
     /** Reads an array of byte and de-serializes it as an [EncryptedSeed] object. */
-    fun deserialize(serialized: ByteArray): EncryptedSeed {
+    fun deserialize(serialized: ByteArray): EncryptedSeed.V2.NoAuth {
       val stream = ByteArrayInputStream(serialized)
       val version = stream.read()
       return when (version) {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/security/SeedManager.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/security/SeedManager.kt
@@ -42,7 +42,7 @@ object SeedManager {
     }
 
     /** Extract the encrypted seed from app private dir. */
-    fun loadSeedFromDisk(context: Context): EncryptedSeed? = loadSeedFromDir(getDatadir(context), SEED_FILE)
+    fun loadSeedFromDisk(context: Context): EncryptedSeed.V2.NoAuth? = loadSeedFromDir(getDatadir(context), SEED_FILE)
 
     fun getSeedState(context: Context): SeedFileState = try {
         when (val seed = loadSeedFromDisk(context)) {
@@ -56,7 +56,7 @@ object SeedManager {
     }
 
     /** Extract an encrypted seed contained in a given file/folder. */
-    private fun loadSeedFromDir(dir: File, seedFileName: String): EncryptedSeed? {
+    private fun loadSeedFromDir(dir: File, seedFileName: String): EncryptedSeed.V2.NoAuth? {
         val seedFile = File(dir, seedFileName)
         return if (!seedFile.exists()) {
             null

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/InflightPaymentsWatcher.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/InflightPaymentsWatcher.kt
@@ -128,7 +128,8 @@ class InflightPaymentsWatcher(context: Context, workerParams: WorkerParameters) 
                         service.value = null
                     }
                 }
-                Intent(applicationContext, NodeService::class.java).let { intent ->
+
+                Intent(applicationContext, application.nodeServiceClass).let { intent ->
                     applicationContext.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE)
                 }
 

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/NodeService.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/NodeService.kt
@@ -2,33 +2,30 @@ package fr.acinq.phoenix.android.services
 
 import android.app.Notification
 import android.app.Service
+import android.content.Context
 import android.content.Intent
-import android.content.pm.ServiceInfo
 import android.os.Binder
 import android.os.Build
-import android.os.Handler
 import android.os.IBinder
-import android.os.Looper
 import android.text.format.DateUtils
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.work.WorkManager
-import com.google.android.gms.tasks.OnCompleteListener
-import com.google.firebase.messaging.FirebaseMessaging
 import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.LiquidityEvents
 import fr.acinq.lightning.MilliSatoshi
-import fr.acinq.lightning.io.PaymentReceived
-import fr.acinq.lightning.utils.Connection
+import fr.acinq.lightning.PaymentEvents
 import fr.acinq.lightning.utils.currentTimestampMillis
 import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.android.BuildConfig
 import fr.acinq.phoenix.android.PhoenixApplication
 import fr.acinq.phoenix.android.security.EncryptedSeed
-import fr.acinq.phoenix.android.security.SeedManager
 import fr.acinq.phoenix.android.utils.LegacyMigrationHelper
 import fr.acinq.phoenix.android.utils.SystemNotificationHelper
 import fr.acinq.phoenix.android.utils.datastore.InternalDataRepository
@@ -44,30 +41,30 @@ import fr.acinq.phoenix.utils.MnemonicLanguage
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.time.Duration.Companion.hours
 
-class NodeService : Service() {
+abstract class NodeService : Service() {
 
-    private val log = LoggerFactory.getLogger(this::class.java)
-    private val serviceScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
+    internal val log = LoggerFactory.getLogger(this::class.java)
+
+    internal val serviceScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
     lateinit var internalData: InternalDataRepository
     private val binder = NodeBinder()
 
-    /** True if the service is running headless (that is without a GUI). In that case we should show a notification */
-    @Volatile
-    private var isHeadless = true
+    var isHeadless by mutableStateOf(false)
 
-    // Notifications
-    private lateinit var notificationManager: NotificationManagerCompat
+    lateinit var notificationManager: NotificationManagerCompat
 
     /** State of the wallet, provides access to the business when started. Private so that it's not mutated from the outside. */
     private val _state = MutableLiveData<NodeServiceState>(NodeServiceState.Off)
@@ -77,7 +74,7 @@ class NodeService : Service() {
     private val stateLock = ReentrantLock()
 
     /** List of payments received while the app is in the background */
-    private val receivedInBackground = mutableStateListOf<MilliSatoshi>()
+    val receivedInBackground = mutableStateListOf<MilliSatoshi>()
 
     // jobs monitoring events/payments after business start
     private var monitorPaymentsJob: Job? = null
@@ -87,112 +84,70 @@ class NodeService : Service() {
 
     override fun onCreate() {
         super.onCreate()
-        log.debug("creating node service...")
+        log.info("creating node service...")
         internalData = (applicationContext as PhoenixApplication).internalDataRepository
         notificationManager = NotificationManagerCompat.from(this)
         refreshFcmToken()
         log.debug("service created")
     }
 
-    internal fun refreshFcmToken() {
-        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
-            if (!task.isSuccessful) {
-                log.warn("fetching FCM registration token failed: ${task.exception?.localizedMessage}")
-                return@OnCompleteListener
-            }
-            task.result?.let { serviceScope.launch { internalData.saveFcmToken(it) } }
-        })
-    }
+    abstract fun refreshFcmToken()
+    abstract fun deleteFcmToken()
+
+    abstract fun isFcmAvailable(context: Context): Boolean
+
+    abstract suspend fun monitorFcmToken(business: PhoenixBusiness)
 
     // =========================================================== //
     //                      SERVICE LIFECYCLE                      //
     // =========================================================== //
 
     override fun onBind(intent: Intent?): IBinder {
-        log.debug("binding node service from intent=$intent")
-        // UI is binding to the service. The service is not headless anymore and we can remove the notification.
-        isHeadless = false
+        log.debug("binding node service from intent={}", intent)
         receivedInBackground.clear()
-        stopForeground(STOP_FOREGROUND_REMOVE)
-        notificationManager.cancel(SystemNotificationHelper.HEADLESS_NOTIF_ID)
         return binder
     }
 
     /** When unbound, the service is running headless. */
     override fun onUnbind(intent: Intent?): Boolean {
-        isHeadless = true
         return false
     }
 
-    private val shutdownHandler = Handler(Looper.getMainLooper())
-    private val shutdownRunnable: Runnable = Runnable {
-        if (isHeadless) {
-            log.debug("reached scheduled shutdown...")
-            if (receivedInBackground.isEmpty()) {
-                stopForeground(STOP_FOREGROUND_REMOVE)
-            } else {
-                stopForeground(STOP_FOREGROUND_DETACH)
-            }
-            shutdown()
-        }
+    override fun onTimeout(startId: Int) {
+        super.onTimeout(startId)
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        notificationManager.cancel(SystemNotificationHelper.HEADLESS_NOTIF_ID)
+        shutdown()
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        log.info("service destroyed")
+    }
+
+    // =========================================================== //
+    //                          UTILITY                            //
+    // =========================================================== //
 
     /** Shutdown the node, close connections and stop the service */
     fun shutdown() {
         log.info("shutting down service in state=${_state.value?.name}")
-        monitorNodeEventsJob?.cancel()
-        stopSelf()
-        _state.postValue(NodeServiceState.Off)
+        serviceScope.launch {
+            (application as? PhoenixApplication)?.business?.first()?.stop()
+            monitorNodeEventsJob?.cancel()
+            stopSelf()
+            _state.postValue(NodeServiceState.Off)
+            log.info("shutdown complete")
+        }
     }
 
-    // =========================================================== //
-    //                    START COMMAND HANDLER                    //
-    // =========================================================== //
-
-    /** Called when an intent is called for this service. */
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        super.onStartCommand(intent, flags, startId)
-        log.info("start service from intent [ intent=$intent, flag=$flags, startId=$startId ]")
-        val reason = intent?.getStringExtra(EXTRA_REASON)
-
-        fun startForeground(notif: Notification) {
-            if (Build.VERSION.SDK_INT >= 34) {
-                ServiceCompat.startForeground(this, SystemNotificationHelper.HEADLESS_NOTIF_ID, notif, ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE)
-            } else {
-                startForeground(SystemNotificationHelper.HEADLESS_NOTIF_ID, notif)
-            }
+    internal fun startForeground(notif: Notification, foregroundServiceType: Int) {
+        log.info("--- starting service in foreground with type=$foregroundServiceType ---")
+        if (Build.VERSION.SDK_INT >= 34) {
+            ServiceCompat.startForeground(this, SystemNotificationHelper.HEADLESS_NOTIF_ID, notif, foregroundServiceType)
+        } else {
+            startForeground(SystemNotificationHelper.HEADLESS_NOTIF_ID, notif)
         }
-
-        val encryptedSeed = SeedManager.loadSeedFromDisk(applicationContext)
-        when {
-            _state.value is NodeServiceState.Running -> {
-                // NOTE: the notification will NOT be shown if the app is already running
-                val notif = SystemNotificationHelper.notifyRunningHeadless(applicationContext)
-                startForeground(notif)
-            }
-            encryptedSeed is EncryptedSeed.V2.NoAuth -> {
-                val seed = encryptedSeed.decrypt()
-                log.debug("successfully decrypted seed in the background, starting wallet...")
-                val notif = SystemNotificationHelper.notifyRunningHeadless(applicationContext)
-                startBusiness(seed, requestCheckLegacyChannels = false)
-                startForeground(notif)
-            }
-            else -> {
-                log.warn("unhandled incoming payment with seed=${encryptedSeed?.name()} reason=$reason")
-                val notif = when (reason) {
-                    "IncomingPayment" -> SystemNotificationHelper.notifyPaymentMissedAppUnavailable(applicationContext)
-                    "PendingSettlement" -> SystemNotificationHelper.notifyPendingSettlement(applicationContext)
-                    else -> SystemNotificationHelper.notifyRunningHeadless(applicationContext)
-                }
-                startForeground(notif)
-            }
-        }
-        shutdownHandler.removeCallbacksAndMessages(null)
-        shutdownHandler.postDelayed(shutdownRunnable, 2 * 60 * 1000L) // service will shutdown in 2 minutes
-        if (!isHeadless) {
-            stopForeground(STOP_FOREGROUND_REMOVE)
-        }
-        return START_NOT_STICKY
     }
 
     // =========================================================== //
@@ -216,10 +171,6 @@ class NodeService : Service() {
         serviceScope.launch(Dispatchers.IO + CoroutineExceptionHandler { _, e ->
             log.error("error when starting node: ", e)
             _state.postValue(NodeServiceState.Error(e))
-            if (isHeadless) {
-                shutdown()
-                stopForeground(STOP_FOREGROUND_REMOVE)
-            }
         }) {
             log.info("cancel competing workers")
             val wm = WorkManager.getInstance(applicationContext)
@@ -256,7 +207,7 @@ class NodeService : Service() {
         val trustedSwapInTxs = LegacyPrefsDatastore.getMigrationTrustedSwapInTxs(applicationContext).first()
         val preferredFiatCurrency = userPrefs.getFiatCurrency.first()
 
-        monitorPaymentsJob = serviceScope.launch { monitorPaymentsWhenHeadless(business.peerManager, business.currencyManager, userPrefs) }
+        monitorPaymentsJob = serviceScope.launch { monitorPaymentsWhenHeadless(business.nodeParamsManager, business.currencyManager, userPrefs) }
         monitorNodeEventsJob = serviceScope.launch { monitorNodeEvents(business.peerManager, business.nodeParamsManager) }
         monitorFcmTokenJob = serviceScope.launch { monitorFcmToken(business) }
         monitorInFlightPaymentsJob = serviceScope.launch { monitorInFlightPayments(business.peerManager) }
@@ -285,21 +236,14 @@ class NodeService : Service() {
         }
     }
 
-    private suspend fun monitorFcmToken(business: PhoenixBusiness) {
-        val token = internalData.getFcmToken.filterNotNull().first()
-        business.connectionsManager.connections.first { it.peer == Connection.ESTABLISHED }
-        business.registerFcmToken(token)
-    }
-
     private suspend fun monitorNodeEvents(peerManager: PeerManager, nodeParamsManager: NodeParamsManager) {
         val monitoringStartedAt = currentTimestampMillis()
         combine(peerManager.swapInNextTimeout, nodeParamsManager.nodeParams.filterNotNull().first().nodeEvents) { nextTimeout, nodeEvent ->
             nextTimeout to nodeEvent
         }.collect { (nextTimeout, event) ->
-            // TODO: click on notif must deeplink to the notification screen
             when (event) {
                 is LiquidityEvents.Rejected -> {
-                    log.debug("processing liquidity_event=$event")
+                    log.debug("processing liquidity_event={}", event)
                     if (event.source == LiquidityEvents.Source.OnChainWallet) {
                         // Check the last time a rejected on-chain swap notification has been shown. If recent, we do not want to trigger a notification every time.
                         val lastRejectedSwap = internalData.getLastRejectedOnchainSwap.first().takeIf {
@@ -336,19 +280,20 @@ class NodeService : Service() {
         }
     }
 
-    private suspend fun monitorPaymentsWhenHeadless(peerManager: PeerManager, currencyManager: CurrencyManager, userPrefs: UserPrefsRepository) {
-        peerManager.getPeer().eventsFlow.collect { event ->
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private suspend fun monitorPaymentsWhenHeadless(nodeParamsManager: NodeParamsManager, currencyManager: CurrencyManager, userPrefs: UserPrefsRepository) {
+        nodeParamsManager.nodeParams.filterNotNull().flatMapLatest { it.nodeEvents }.collect { event ->
             when (event) {
-                is PaymentReceived -> {
+                is PaymentEvents.PaymentReceived -> {
                     if (isHeadless) {
-                        receivedInBackground.add(event.received.amount)
+                        receivedInBackground.add(event.amount)
                         SystemNotificationHelper.notifyPaymentsReceived(
                             context = applicationContext,
                             userPrefs = userPrefs,
-                            paymentHash = event.incomingPayment.paymentHash,
-                            amount = event.received.amount,
+                            paymentHash = event.paymentHash,
+                            amount = event.amount,
                             rates = currencyManager.ratesFlow.value,
-                            isHeadless = isHeadless && receivedInBackground.size == 1
+                            isFromBackground = isHeadless
                         )
                     }
                 }
@@ -375,5 +320,8 @@ class NodeService : Service() {
 
     companion object {
         const val EXTRA_REASON = "${BuildConfig.APPLICATION_ID}.SERVICE_SPAWN_REASON"
+        const val EXTRA_ORIGIN = "${BuildConfig.APPLICATION_ID}.SERVICE_SPAWN_ORIGIN"
+        const val ORIGIN_FCM = "fcm"
+        const val ORIGIN_HEADLESS = "fcm"
     }
 }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/NodeState.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/services/NodeState.kt
@@ -29,11 +29,11 @@ sealed class NodeServiceState {
     val name: String by lazy { this.javaClass.simpleName }
 
     /** Default state, the node is not started. */
-    object Off : NodeServiceState()
+    data object Off : NodeServiceState()
 
     /** This is an utility state that is used when the binding between the service holding the state and the consumers of that state is disconnected. */
-    object Disconnected : NodeServiceState()
-    object Init : NodeServiceState()
-    object Running : NodeServiceState()
+    data object Disconnected : NodeServiceState()
+    data object Init : NodeServiceState()
+    data object Running : NodeServiceState()
     data class Error(val cause: Throwable) : NodeServiceState()
 }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/ExperimentalView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/ExperimentalView.kt
@@ -35,6 +35,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.compose.viewModel
+import fr.acinq.phoenix.android.AppViewModel
 import fr.acinq.phoenix.android.PhoenixApplication
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.business
@@ -118,6 +119,7 @@ class ExperimentalViewModel(val peerManager: PeerManager, val internalDataReposi
 @Composable
 fun ExperimentalView(
     onBackClick: () -> Unit,
+    appViewModel: AppViewModel,
 ) {
     val vm = viewModel<ExperimentalViewModel>(factory = ExperimentalViewModel.Factory(business.peerManager))
 
@@ -131,6 +133,9 @@ fun ExperimentalView(
         Card(modifier = Modifier.fillMaxWidth()) {
             ClaimAddressButton(state = vm.claimAddressState, onClaim = { vm.claimAddress() })
         }
+
+        // flavored component
+        ManageHeadlessView(appViewModel = appViewModel)
     }
 }
 
@@ -156,7 +161,7 @@ private fun ClaimAddressButton(
                 leadingIcon = { PhoenixIcon(R.drawable.ic_arobase) },
                 subtitle = {
                     Text(text = stringResource(id = R.string.bip353_subtitle))
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(16.dp))
                     FilledButton(
                         text = stringResource(id = R.string.bip353_claim_button),
                         onClick = onClaim,

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/ResetWallet.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/ResetWallet.kt
@@ -49,6 +49,7 @@ import fr.acinq.phoenix.android.LocalBitcoinUnit
 import fr.acinq.phoenix.android.LocalFiatCurrency
 import fr.acinq.phoenix.android.MainActivity
 import fr.acinq.phoenix.android.R
+import fr.acinq.phoenix.android.application
 import fr.acinq.phoenix.android.business
 import fr.acinq.phoenix.android.components.BorderButton
 import fr.acinq.phoenix.android.components.Button
@@ -328,6 +329,7 @@ private fun WalletDeleted() {
         verticalArrangement = Arrangement.spacedBy(2.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        val application = application
         SuccessMessage(header = stringResource(id = R.string.reset_wallet_success))
         Spacer(modifier = Modifier.height(16.dp))
         BorderButton(
@@ -335,7 +337,7 @@ private fun WalletDeleted() {
             icon = R.drawable.ic_check,
             onClick = {
                 context.startActivity(
-                    Intent(context, MainActivity::class.java).apply {
+                    Intent(context, application.mainActivityClass).apply {
                         flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                     }
                 )

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/datastore/InternalDataRepository.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/datastore/InternalDataRepository.kt
@@ -57,6 +57,8 @@ class InternalDataRepository(private val internalData: DataStore<Preferences>) {
         private val SHOW_SPLICEOUT_CAPACITY_DISCLAIMER = booleanPreferencesKey("SHOW_SPLICEOUT_CAPACITY_DISCLAIMER")
         private val REMOTE_WALLET_NOTICE_READ_INDEX = intPreferencesKey("REMOTE_WALLET_NOTICE_READ_INDEX")
         private val BIP_353_ADDRESS = stringPreferencesKey("BIP_353_ADDRESS")
+        private val BACKGROUND_SERVICE_MODE = booleanPreferencesKey("BACKGROUND_SERVICE_MODE")
+        private val BACKGROUND_SERVICE_MODE_WITH_WAKELOCK = booleanPreferencesKey("BACKGROUND_SERVICE_MODE_WITH_WAKELOCK")
     }
 
     val log = LoggerFactory.getLogger(this::class.java)
@@ -147,4 +149,22 @@ class InternalDataRepository(private val internalData: DataStore<Preferences>) {
 
     val getBip353Address: Flow<String> = safeData.map { it[BIP_353_ADDRESS] ?: "" }
     suspend fun saveBip353Address(address: String) = internalData.edit { it[BIP_353_ADDRESS] = address }
+
+    val getBackgroundServiceMode: Flow<Pair<Boolean, Boolean>?> = safeData.map {
+        val isEnabled = it[BACKGROUND_SERVICE_MODE]
+        val withWakeLock = it[BACKGROUND_SERVICE_MODE_WITH_WAKELOCK] ?: false
+        isEnabled?.let { it to withWakeLock }
+    }
+    suspend fun saveBackgroundServiceModeEnabled(withWakeLock: Boolean) {
+        internalData.edit {
+            it[BACKGROUND_SERVICE_MODE] = true
+            it[BACKGROUND_SERVICE_MODE_WITH_WAKELOCK] = withWakeLock
+        }
+    }
+    suspend fun saveBackgroundServiceModeDisabled() {
+        internalData.edit {
+            it[BACKGROUND_SERVICE_MODE] = false
+            it[BACKGROUND_SERVICE_MODE_WITH_WAKELOCK] = false
+        }
+    }
 }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/extensions.kt
@@ -17,22 +17,18 @@
 package fr.acinq.phoenix.android.utils
 
 import android.content.*
-import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.core.content.FileProvider
 import fr.acinq.lightning.db.*
 import fr.acinq.lightning.utils.Connection
-import fr.acinq.lightning.utils.currentTimestampMillis
 import fr.acinq.phoenix.android.*
 import fr.acinq.phoenix.android.R
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 import fr.acinq.phoenix.data.BitcoinUnit
 import fr.acinq.phoenix.data.FiatCurrency
 import fr.acinq.phoenix.utils.extensions.desc
-import java.io.File
 import java.security.cert.CertificateException
 import java.util.*
 import kotlin.contracts.ExperimentalContracts

--- a/phoenix-android/src/main/res/values-b+es+419/important_strings.xml
+++ b/phoenix-android/src/main/res/values-b+es+419/important_strings.xml
@@ -80,8 +80,7 @@
     <string name="home_swapin_help_button">Ver detalles</string>
 
     <string name="home_background_restriction_title">Procesamiento en segundo plano restringido</string>.
-    <string name="home_background_restriction_body_1">Phoenix no podrá recibir pagos cuando esté en segundo plano, o cuando esté cerrado.</string>
-    <string name="home_background_restriction_body_2">Esto ocurre porque:</string>
+    <string name="home_background_restriction_body_1">Phoenix podría no recibir pagos cuando esté en segundo plano, o cuando esté cerrado.</string>
     <string name="home_background_restriction_tor">Tor está activado</string>
     <string name="home_background_restriction_powersaver">El dispositivo está en modo de ahorro de energía</string>
     <string name="home_background_restriction_fcm">FCM notificaciones no disponibles</string>

--- a/phoenix-android/src/main/res/values-cs/important_strings.xml
+++ b/phoenix-android/src/main/res/values-cs/important_strings.xml
@@ -83,8 +83,7 @@
     <string name="home_swapin_help_button">Klikněte pro podrobnosti</string>
 
     <string name="home_background_restriction_title">Omezeno zpracovávání na pozadí</string>
-    <string name="home_background_restriction_body_1">Phoenix nebude moci přijímat platby, pokud je na pozadí nebo pokud je zavřený.</string>.
-    <string name="home_background_restriction_body_2">Děje se tak, protože:</string>
+    <string name="home_background_restriction_body_1">Phoenix možná nebude moci přijímat platby, pokud je na pozadí nebo pokud je zavřený.</string>.
     <string name="home_background_restriction_tor">Tor je povolen</string>
     <string name="home_background_restriction_powersaver">Zařízení je v úsporném režimu</string>
     <string name="home_background_restriction_fcm">Oznámení FCM nejsou k dispozici</string>

--- a/phoenix-android/src/main/res/values-de/important_strings.xml
+++ b/phoenix-android/src/main/res/values-de/important_strings.xml
@@ -80,8 +80,7 @@
     <string name="home_swapin_help_button">Tippen Sie für Details</string>
 
     <string name="home_background_restriction_title">Hintergrundverarbeitung eingeschränkt</string>
-    <string name="home_background_restriction_body_1">Phoenix kann keine Zahlungen empfangen, wenn es im Hintergrund läuft oder geschlossen ist.</string>
-    <string name="home_background_restriction_body_2">Dies geschieht, weil:</string>
+    <string name="home_background_restriction_body_1">Phoenix wird möglicherweise keine Zahlungen erhalten können, wenn es im Hintergrund läuft oder geschlossen ist.</string>
     <string name="home_background_restriction_tor">Tor ist aktiviert</string>
     <string name="home_background_restriction_powersaver">Das Gerät ist im Energiesparmodus</string>
     <string name="home_background_restriction_fcm">FCM-Benachrichtigungen nicht verfügbar</string>

--- a/phoenix-android/src/main/res/values-es/important_strings.xml
+++ b/phoenix-android/src/main/res/values-es/important_strings.xml
@@ -75,8 +75,7 @@
     <string name="home_swapin_help_button">Ver detalles</string>
 
     <string name="home_background_restriction_title">Procesamiento en segundo plano restringido</string>.
-    <string name="home_background_restriction_body_1">Phoenix no podrá recibir pagos cuando esté en segundo plano, o cuando esté cerrado.</string>
-    <string name="home_background_restriction_body_2">Esto ocurre porque:</string>
+    <string name="home_background_restriction_body_1">Phoenix podría no recibir pagos cuando esté en segundo plano, o cuando esté cerrado.</string>
     <string name="home_background_restriction_tor">Tor está activado</string>
     <string name="home_background_restriction_powersaver">El dispositivo está en modo de ahorro de energía</string>
     <string name="home_background_restriction_fcm">FCM notificaciones no disponibles</string>

--- a/phoenix-android/src/main/res/values-fr/important_strings.xml
+++ b/phoenix-android/src/main/res/values-fr/important_strings.xml
@@ -83,8 +83,7 @@
     <string name="home_swapin_help_button">Voir les détails</string>
 
     <string name="home_background_restriction_title">Fonctionnement en arrière plan restreint</string>
-    <string name="home_background_restriction_body_1">Phoenix ne pourra pas recevoir de paiements quand l\'application est en arrière plan ou est fermée.</string>
-    <string name="home_background_restriction_body_2">Cela vient du fait que:</string>
+    <string name="home_background_restriction_body_1">Phoenix pourrait ne pas être en mesure de recevoir de paiements quand l\'application est en arrière plan ou est fermée.</string>
     <string name="home_background_restriction_tor">Tor est activé</string>
     <string name="home_background_restriction_powersaver">Le téléphone est en mode économie d\'énergie</string>
     <string name="home_background_restriction_fcm">Les notifications FCM sont indisponibles</string>

--- a/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
+++ b/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
@@ -83,8 +83,7 @@
     <string name="home_swapin_help_button">Toque para obter detalhes</string>
 
     <string name="home_background_restriction_title">Processamento em segundo plano restrito</string>
-    <string name="home_background_restriction_body_1">O Phoenix não poderá receber pagamentos quando estiver em segundo plano ou quando estiver fechado.</string>
-    <string name="home_background_restriction_body_2">Isso acontece porque:</string>
+    <string name="home_background_restriction_body_1">A Phoenix pode não conseguir receber pagamentos quando estiver em segundo plano ou quando estiver fechado.</string>
     <string name="home_background_restriction_tor">Tor está ativado</string>
     <string name="home_background_restriction_powersaver">O dispositivo está no modo de economia de energia</string>
     <string name="home_background_restriction_fcm">FCM notificações indisponíveis</string>

--- a/phoenix-android/src/main/res/values-sk/important_strings.xml
+++ b/phoenix-android/src/main/res/values-sk/important_strings.xml
@@ -83,8 +83,7 @@
     <string name="home_swapin_help_button">Kliknite pre podrobnosti</string>
 
     <string name="home_background_restriction_title">Omedzené spracovanie pozadia</string>
-    <string name="home_background_restriction_body_1">Fénix nebude môcť prijímať platby, keď je na pozadí alebo keď je zatvorený.</string>
-    <string name="home_background_restriction_body_2">Deje sa tak, pretože:</string>
+    <string name="home_background_restriction_body_1">Phoenix možno nebude môcť prijímať platby, keď je na pozadí alebo keď je zatvorený.</string>
     <string name="home_background_restriction_tor">Tor je povolený</string>
     <string name="home_background_restriction_powersaver">Zariadenie je v úspornom režime</string>
     <string name="home_background_restriction_fcm">Oznamy FCM nie sú k dispozícii</string>

--- a/phoenix-android/src/main/res/values-sw/important_strings.xml
+++ b/phoenix-android/src/main/res/values-sw/important_strings.xml
@@ -87,8 +87,7 @@
     <string name="home_swapin_help_button">Bonyeza kwa maelezo</string>
 
     <string name="home_background_restriction_title">Usindikaji wa nyuma umepunguzwa</string>
-    <string name="home_background_restriction_body_1">Phoenix haitaweza kupokea malipo wakati iko nyuma, au wakati imefungwa.</string>
-    <string name="home_background_restriction_body_2">Hii hutokea kwa sababu:</string>
+    <string name="home_background_restriction_body_1">Huenda Phoenix isiweze kupokea malipo ikiwa chinichini, au inapofungwa.</string>
     <string name="home_background_restriction_tor">Tor imewashwa</string>
     <string name="home_background_restriction_powersaver">Kifaa kipo kwenye hali ya kuokoa nguvu</string>
     <string name="home_background_restriction_fcm">Arifa za FCM hazipatikani</string>

--- a/phoenix-android/src/main/res/values-vi/important_strings.xml
+++ b/phoenix-android/src/main/res/values-vi/important_strings.xml
@@ -90,8 +90,7 @@
     <string name="home_swapin_help_button">Nhấn để biết thêm chi tiết</string>
 
     <string name="home_background_restriction_title">Hạn chế xử lý nền</string>
-    <string name="home_background_restriction_body_1">Phoenix sẽ không thể nhận thanh toán khi nó ở chế độ nền hoặc khi nó bị đóng.</string>
-    <string name="home_background_restriction_body_2">Điều này xảy ra vì:</string>
+    <string name="home_background_restriction_body_1">Phoenix có thể không nhận được thanh toán khi đang ở chế độ nền hoặc khi đóng cửa.</string>
     <string name="home_background_restriction_tor">Tor đã được bật</string>
     <string name="home_background_restriction_powersaver">Thiết bị đang ở chế độ tiết kiệm năng lượng</string>
     <string name="home_background_restriction_fcm">Thông báo FCM không khả dụng</string>

--- a/phoenix-android/src/main/res/values/important_strings.xml
+++ b/phoenix-android/src/main/res/values/important_strings.xml
@@ -29,6 +29,7 @@
     <!-- system notifications -->
 
     <string name="notif_headless_title_default">Phoenix is running in the background</string>
+    <string name="notif_headless_title_failure">Background start failed</string>
     <string name="notif_headless_received">Received +%1$s</string>
 
     <string name="notif_pending_settlement_title">Please start Phoenix</string>
@@ -87,8 +88,7 @@
     <string name="home_swapin_help_button">Tap for details</string>
 
     <string name="home_background_restriction_title">Background processing restricted</string>
-    <string name="home_background_restriction_body_1">Phoenix will not be able to receive payments when it is in the background, or when it is closed.</string>
-    <string name="home_background_restriction_body_2">This happens because:</string>
+    <string name="home_background_restriction_body_1">Phoenix may not be able to receive payments when it is in the background, or when it is closed.</string>
     <string name="home_background_restriction_tor">Tor is enabled</string>
     <string name="home_background_restriction_powersaver">The device is in power saving mode</string>
     <string name="home_background_restriction_fcm">FCM notifications unavailable</string>

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -235,6 +235,7 @@
     <string name="btn_share">Share</string>
     <string name="btn_ok">OK</string>
     <string name="btn_save">Save</string>
+    <string name="btn_start">Start</string>
     <string name="btn_confirm">Confirm</string>
     <string name="btn_cancel">Cancel</string>
     <string name="btn_close">Close</string>


### PR DESCRIPTION
This PR splits the Android application into two variants, using the flavour mechanism of Android: 
- a `google` variant, with support for FCM notifications for just-in-time payments and background processing. It embeds some Google Play Services libraries.
- a `foss` variant without any of the Google Play Services libraries, that is, without the FCM notifications.

The rest of the application is the same between the two variants.

### Why make a non-google variant

It allows us to:
- publish the app on non-Google app stores with strict requirements on the libraries used (e.g. with F-Droid, libraries must all be open source, which is not the case of the Play Service libraries)
- be less dependent on 3rd parties, whether it's FCM or Google Play
- give users more choice

### Background processing without FCM

To receive payments Phoenix must be online. To make it possible for payments to be received even if the app is not running (which is the case most of the time for an app on a mobile device), we have been using FCM notifications.

This will still be the case on the `google` variant.

However the `foss` variant cannot use FCM. The alternative is to let Phoenix run in the background all the time, using a "foreground" service (i.e., you'll get a permanent notification for Phoenix in the Foreground Tasks Manager). This is similar to what [Simplex is doing](https://simplex.chat/blog/20220404-simplex-chat-instant-notifications.html) for chat messages.

#### Experimental feature

A new button has been added in Settings > Experimental features. Starting the service must be initiated manually by the user. If the service is not started then the app will behave normally, except that it won't be able to receive payments when the app is closed or in the background (depending on the Android version).

<img width="250" alt="image" src="https://github.com/user-attachments/assets/73186edc-ff29-4137-a327-f9f2fe599475" /><img width="250" alt="image" src="https://github.com/user-attachments/assets/f6c08a3e-4502-416f-924c-f8be83c3a401" /><img width="250" alt="image" src="https://github.com/user-attachments/assets/a701034b-bb4d-4bae-8279-87b92ddc7d43" />

<img width="250" alt="image" src="https://github.com/user-attachments/assets/36d54150-e2c5-4054-a332-fcf489a83613">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/147e828a-d727-48f7-9673-6f2ec553b5af">
<img width="250" alt="image" src="https://github.com/user-attachments/assets/9e7656b7-ea39-413f-8cae-4ec9963f3827">

#### Impact on battery

Due to the [Doze/Stand-by mode](https://developer.android.com/training/monitoring-device-state/doze-standby) optimisations, this background mode needs to acquire a partial wake-lock when started, so that the service is not eagerly killed by Android. This has a significant impact on battery usage.

#### How reliable is it

Tests look good, and payments are faster than with FCM. However it remains to be seen whether it's reliable enough on a vast array of devices to be worth the battery cost. If not, we'll need to reassess.

It's also possible that, in the longer term, the permanent foreground service solution is restricted on Android altogether.