### PR TITLE
Upgrade to Kotlin 2.0.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build
 build/
-.kotlin/
+.cxx
+.kotlin
 
 # Idea
 .idea
@@ -25,8 +26,6 @@ sdk-dependencies
 apk
 phoenix-legacy/release
 phoenix-legacy/debug
-.cxx
 
 # LangTool
 .langtool/deepl.authtoken
-

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -3,7 +3,7 @@ object Versions {
     const val secp256k1 = "0.14.0"
     const val torMobile = "0.2.0"
 
-    const val kotlin = "2.0.10"
+    const val kotlin = "2.0.21"
 
     const val ktor = "2.3.12"
     const val sqlDelight = "2.0.2"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -3,10 +3,10 @@ object Versions {
     const val secp256k1 = "0.14.0"
     const val torMobile = "0.2.0"
 
-    const val kotlin = "1.9.22"
+    const val kotlin = "2.0.10"
 
-    const val ktor = "2.3.7"
-    const val sqlDelight = "2.0.1"
+    const val ktor = "2.3.12"
+    const val sqlDelight = "2.0.2"
 
     const val slf4j = "1.7.30"
     const val junit = "4.13"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val lightningKmp = "1.8.4"
+    const val lightningKmp = "1.8.5-SNAPSHOT"
     const val secp256k1 = "0.14.0"
     const val torMobile = "0.2.0"
 
@@ -19,7 +19,6 @@ object Versions {
         const val prefs = "1.2.0"
         const val datastore = "1.0.0"
         const val compose = "1.6.8"
-        const val composeCompiler = "1.5.8"
         const val navCompose = "2.6.0"
         const val accompanist = "0.30.1"
         const val composeConstraintLayout = "1.1.0-alpha09"

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,7 @@ kotlin.mpp.stability.nowarn=true
 kotlin.incremental.multiplatform = true
 kotlin.parallel.tasks.in.project = true
 kotlin.mpp.enableCInteropCommonization = true
+kotlin.native.cacheKind=none
 
 # Android
 android.useAndroidX = true

--- a/phoenix-android/build.gradle.kts
+++ b/phoenix-android/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     kotlin("android")
     id("com.google.gms.google-services")
     id("kotlinx-serialization")
+    id("org.jetbrains.kotlin.plugin.compose") version Versions.kotlin
 }
 
 fun gitCommitHash(): String {
@@ -69,10 +70,6 @@ android {
         compose = true
         viewBinding = true
         dataBinding = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = Versions.Android.composeCompiler
     }
 
     packagingOptions {

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -1618,6 +1618,7 @@
 			buildConfigurationList = DCB0DB8C255AE42F005B29C8 /* Build configuration list for PBXNativeTarget "phoenix-ios-framework" */;
 			buildPhases = (
 				DCB0DB95255AE43E005B29C8 /* ShellScript */,
+				DCB0DB9F255AE6F1005B29C8 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1783,6 +1784,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "cd \"$SRCROOT/..\"\necho ./gradlew embedAndSignAppleFrameworkForXcode\n./gradlew embedAndSignAppleFrameworkForXcode\n";
+		};
+		DCB0DB9F255AE6F1005B29C8 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$SRCROOT/../phoenix-shared/build/xcode-frameworks/$CONFIGURATION/$SDK_NAME/PhoenixShared.framework",
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "FrmkDuplicate=\"$SRCROOT/../phoenix-shared/build/xcode-frameworks/$CONFIGURATION/$SDK_NAME/PhoenixShared.framework/Frameworks/PhoenixShared.framework\"\n\nif [ -e \"$FrmkDuplicate\" ]; then\n  echo \"Deleting duplicate framework: $FrmkDuplicate\"\n  rm -R \"$FrmkDuplicate\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -1618,7 +1618,6 @@
 			buildConfigurationList = DCB0DB8C255AE42F005B29C8 /* Build configuration list for PBXNativeTarget "phoenix-ios-framework" */;
 			buildPhases = (
 				DCB0DB95255AE43E005B29C8 /* ShellScript */,
-				DCB0DB9F255AE6F1005B29C8 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1784,27 +1783,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "cd \"$SRCROOT/..\"\necho ./gradlew embedAndSignAppleFrameworkForXcode\n./gradlew embedAndSignAppleFrameworkForXcode\n";
-		};
-		DCB0DB9F255AE6F1005B29C8 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$SRCROOT/../phoenix-shared/build/xcode-frameworks/$CONFIGURATION/$SDK_NAME/PhoenixShared.framework",
-				"$SRCROOT/../phoenix-shared/build/xcode-frameworks/$CONFIGURATION/$SDK_NAME/PhoenixShared.framework.dSYM",
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/PhoenixShared.framework,
-				$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/PhoenixShared.framework.dSYM,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "SrcFrmk=\"$SRCROOT/../phoenix-shared/build/xcode-frameworks/$CONFIGURATION/$SDK_NAME/PhoenixShared.framework\"\necho \"SrcFrmk = $SrcFrmk\"\n\nDstFrmk=\"$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME\"\necho \"DstFrmk = $DstFrmk\"\n\necho \"rm -R $DstFrmk/Frameworks\"\nrm -R \"$DstFrmk/Frameworks\"\n\necho \"cp -R $SrcFrmk/ $DstFrmk/\"\ncp -R \"$SrcFrmk/\" \"$DstFrmk/\"\n\necho \"cp -R $SrcFrmk.dSYM/ $DstFrmk.dSYM/\"\ncp -R \"$SrcFrmk.dSYM/\" \"$DstFrmk.dSYM/\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/phoenix-shared/build.gradle.kts
+++ b/phoenix-shared/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     if (System.getProperty("includeAndroid")?.toBoolean() == true) {
         id("com.android.library")
     }
-    id("co.touchlab.skie") version "0.8.4"
+    id("co.touchlab.skie") version "0.9.3"
 }
 
 val includeAndroid = System.getProperty("includeAndroid")?.toBoolean() ?: false
@@ -96,7 +96,7 @@ kotlin {
                 implementation("app.cash.sqldelight:runtime:${Versions.sqlDelight}")
                 implementation("app.cash.sqldelight:coroutines-extensions:${Versions.sqlDelight}")
                 // SKEI
-                implementation("co.touchlab.skie:configuration-annotations:0.8.4")
+                implementation("co.touchlab.skie:configuration-annotations:0.9.3")
             }
         }
 

--- a/phoenix-shared/build.gradle.kts
+++ b/phoenix-shared/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     if (System.getProperty("includeAndroid")?.toBoolean() == true) {
         id("com.android.library")
     }
-    id("co.touchlab.skie") version "0.8.1"
+    id("co.touchlab.skie") version "0.8.4"
 }
 
 val includeAndroid = System.getProperty("includeAndroid")?.toBoolean() ?: false
@@ -99,7 +99,7 @@ kotlin {
                 implementation("app.cash.sqldelight:runtime:${Versions.sqlDelight}")
                 implementation("app.cash.sqldelight:coroutines-extensions:${Versions.sqlDelight}")
                 // SKEI
-                implementation("co.touchlab.skie:configuration-annotations:0.8.1")
+                implementation("co.touchlab.skie:configuration-annotations:0.8.4")
             }
         }
 

--- a/phoenix-shared/build.gradle.kts
+++ b/phoenix-shared/build.gradle.kts
@@ -71,7 +71,7 @@ kotlin {
                     // The notification-service-extension is limited to 24 MB of memory.
                     // With mimalloc we can easily hit the 24 MB limit, and the OS kills the process.
                     // But with standard allocation, we're using less then half the limit.
-                    kotlinOptions.freeCompilerArgs += "-Xallocator=std"
+                    //kotlinOptions.freeCompilerArgs += "-Xallocator=std"
                     kotlinOptions.freeCompilerArgs += listOf("-linker-options", "-application_extension")
                     // workaround for xcode 15 and kotlin < 1.9.10: 
                     // https://youtrack.jetbrains.com/issue/KT-60230/Native-unknown-options-iossimulatorversionmin-sdkversion-with-Xcode-15-beta-3

--- a/phoenix-shared/build.gradle.kts
+++ b/phoenix-shared/build.gradle.kts
@@ -67,15 +67,12 @@ kotlin {
             }
             configureEach {
                 it.compilations.all {
-                    kotlinOptions.freeCompilerArgs += "-Xoverride-konan-properties=osVersionMin.ios_x64=15.0;osVersionMin.ios_arm64=15.0"
+                    kotlinOptions.freeCompilerArgs += "-Xoverride-konan-properties=osVersionMin.ios_x64=16.0;osVersionMin.ios_arm64=16.0"
                     // The notification-service-extension is limited to 24 MB of memory.
                     // With mimalloc we can easily hit the 24 MB limit, and the OS kills the process.
                     // But with standard allocation, we're using less then half the limit.
-                    //kotlinOptions.freeCompilerArgs += "-Xallocator=std"
+                    kotlinOptions.freeCompilerArgs += "-Xallocator=std"
                     kotlinOptions.freeCompilerArgs += listOf("-linker-options", "-application_extension")
-                    // workaround for xcode 15 and kotlin < 1.9.10: 
-                    // https://youtrack.jetbrains.com/issue/KT-60230/Native-unknown-options-iossimulatorversionmin-sdkversion-with-Xcode-15-beta-3
-                    linkerOpts += "-ld64"
                 }
             }
         }


### PR DESCRIPTION
This PR upgrades Kotlin as well as some other libraries to Kotlin 2.0.10. This upgrade is required due to side effects of iOS 18 and Xcode 16.

- ktor to 2.3.12
- kotlinx.serialisation to 1.7.1 (transitive, see https://github.com/ACINQ/lightning-kmp/pull/701)
- kotlinx.coroutine to 1.9.0 (transitive)
- kermit to 2.0.4 (transitive)
- skie to 0.8.4
- sqldelight to 2.0.2

# Issues found

### iOS: `SKIE` does not support kotlin 2.0.20 yet

We have to use Kotlin 2.0.10 instead, although `lightning-kmp` can keep using 2.0.20 without issues.

### `kotlinx.serialisation` v1.7.2 is not compatible 

This is a side effect of SKIE. `kotlinx.serialisation` v1.7.2 requires Kotlin 2.0.20 (because they use the new `kotlin.uuid.Uuid` object). In the meantime, we must use `kotlinx.serialisation` v1.7.1.

### iOS: Framework script removed 

In the build phases of `phoenix-ios-framework` we have a script that manually copied the `phoenix-shared` framework (and DSYM) generated by gradle in `phoenix-shared/build` into the Xcode `DerivedData` folder for the `phoenix-ios` application. 

This script now fails with Kotlin 2.0 because the files are already copied during the build process. @robbiehanson It should be investigated further but it seems this script is not needed anymore, and thus must be removed.

### iOS: Odd cache error

⚠️ **needs investigation**

An odd build error occurs in `:phoenix-shared:linkDebugFrameworkIosArm64`:

`
/Users/xxx/.gradle/caches/modules-2/files-2.1/app.cash.sqldelight/coroutines-extensions-iosarm64/2.0.2/51f8ddc76a4aa3d45402f46017e7b8405a5f6761/coroutines-extensions is cached (in /Users/xxx/.konan/kotlin-native-prebuilt-macos-x86_64-2.0.10/klib/cache/ios_arm64-gSTATIC-pl/app.cash.sqldelight:sqldelight-coroutines-extensions/unspecified/1v8rzgt0jt9l5.30bg0yuy4wun9/app.cash.sqldelight:sqldelight-coroutines-extensions-cache/bin/libapp.cash.sqldelight:sqldelight-coroutines-extensions-cache.a), but its dependency isn't: /Users/xxx/.konan/kotlin-native-prebuilt-macos-x86_64-2.0.10/klib/common/stdlib
`

Although it's mentioned in the log, it does not seem linked to the sqldelight coroutine extension. This error is "fixed" by removing the `kotlinOptions.freeCompilerArgs += "-Xallocator=std"` in `phoenix-shared/build.gradle.kts`. 

A similar report can be found [here](https://slack-chats.kotlinlang.org/t/18860817/trying-to-update-to-kotlin-2-0-0-and-when-i-build-my-ios-app).