### PR TITLE
(android) Add UI to spend from final wallet

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/AppView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/AppView.kt
@@ -99,6 +99,7 @@ import fr.acinq.phoenix.android.settings.displayseed.DisplaySeedView
 import fr.acinq.phoenix.android.settings.fees.AdvancedIncomingFeePolicy
 import fr.acinq.phoenix.android.settings.fees.LiquidityPolicyView
 import fr.acinq.phoenix.android.settings.walletinfo.FinalWalletInfo
+import fr.acinq.phoenix.android.settings.walletinfo.FinalWalletRefundView
 import fr.acinq.phoenix.android.settings.walletinfo.SendSwapInRefundView
 import fr.acinq.phoenix.android.settings.walletinfo.SwapInAddresses
 import fr.acinq.phoenix.android.settings.walletinfo.SwapInSignerView
@@ -246,7 +247,8 @@ fun AppView(
                                 onPaymentsHistoryClick = { navController.navigate(Screen.PaymentsHistory.route) },
                                 onTorClick = { navController.navigate(Screen.TorConfig) },
                                 onElectrumClick = { navController.navigate(Screen.ElectrumServer) },
-                                onShowSwapInWallet = { navController.navigate(Screen.WalletInfo.SwapInWallet) },
+                                onNavigateToSwapInWallet = { navController.navigate(Screen.WalletInfo.SwapInWallet) },
+                                onNavigateToFinalWallet = { navController.navigate(Screen.WalletInfo.FinalWallet) },
                                 onShowNotifications = { navController.navigate(Screen.Notifications) },
                                 onRequestLiquidityClick = { navController.navigate(Screen.LiquidityRequest.route) },
                             )
@@ -455,7 +457,10 @@ fun AppView(
                         SendSwapInRefundView(onBackClick = { navController.popBackStack() })
                     }
                     composable(Screen.WalletInfo.FinalWallet.route) {
-                        FinalWalletInfo(onBackClick = { navController.popBackStack() })
+                        FinalWalletInfo(onBackClick = { navController.popBackStack() }, onSpendClick = { navController.navigate(Screen.WalletInfo.FinalWalletRefund.route) })
+                    }
+                    composable(Screen.WalletInfo.FinalWalletRefund.route) {
+                        FinalWalletRefundView(onBackClick = { navController.popBackStack() })
                     }
                     composable(Screen.LiquidityPolicy.route, deepLinks = listOf(navDeepLink { uriPattern ="phoenix:liquiditypolicy" })) {
                         LiquidityPolicyView(

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/Navigation.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/Navigation.kt
@@ -59,6 +59,7 @@ sealed class Screen(val route: String) {
         data object SwapInAddresses: Screen("settings/walletinfo/swapinaddresses")
         data object SwapInSigner: Screen("settings/walletinfo/swapinsigner")
         data object FinalWallet: Screen("settings/walletinfo/final")
+        data object FinalWalletRefund: Screen("settings/walletinfo/finalrefund")
         data object SwapInRefund: Screen("settings/walletinfo/swapinrefund")
     }
     data object LiquidityPolicy: Screen("settings/liquiditypolicy")

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeNotices.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeNotices.kt
@@ -192,7 +192,7 @@ private fun FirstNoticeView(
             }
 
             is Notice.FundsInFinalWallet -> {
-                NoticeTextView(text = "Funds available in the final wallet.", icon = R.drawable.ic_info)
+                NoticeTextView(text = stringResource(id = R.string.inappnotif_final_wallet_message), icon = R.drawable.ic_info)
             }
         }
 

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeNotices.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeNotices.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,14 +60,16 @@ fun HomeNotices(
     notices: List<Notice>,
     notifications: List<Pair<Set<UUID>, Notification>>,
     onNavigateToSwapInWallet: () -> Unit,
+    onNavigateToFinalWallet: () -> Unit,
     onNavigateToNotificationsList: () -> Unit,
 ) {
-    val filteredNotices = notices.filterIsInstance<Notice.ShowInHome>().sortedBy { it.priority }
-    val now = currentTimestampMillis()
-    val recentRejectedOffchainCount = notifications.map { it.second }
-        .filterIsInstance<Notification.PaymentRejected>()
-        .filter { it.source == LiquidityEvents.Source.OffChainPayment && (now - it.createdAt) < 15 * DateUtils.HOUR_IN_MILLIS }
-        .size
+    val filteredNotices = remember(notices) { notices.filterIsInstance<Notice.ShowInHome>().sortedBy { it.priority } }
+    val recentRejectedOffchainCount = remember (notifications) {
+        notifications.map { it.second }
+            .filterIsInstance<Notification.PaymentRejected>()
+            .filter { it.source == LiquidityEvents.Source.OffChainPayment && (currentTimestampMillis() - it.createdAt) < 15 * DateUtils.HOUR_IN_MILLIS }
+            .size
+    }
 
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
         if (recentRejectedOffchainCount > 0) {
@@ -77,6 +80,7 @@ fun HomeNotices(
                 notice = it,
                 messagesCount = notices.size + notifications.size,
                 onNavigateToSwapInWallet = onNavigateToSwapInWallet,
+                onNavigateToFinalWallet = onNavigateToFinalWallet,
                 onNavigateToNotificationsList = onNavigateToNotificationsList
             )
         }
@@ -90,6 +94,7 @@ private fun FirstNoticeView(
     notice: Notice.ShowInHome,
     messagesCount: Int,
     onNavigateToSwapInWallet: () -> Unit,
+    onNavigateToFinalWallet: () -> Unit,
     onNavigateToNotificationsList: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -130,6 +135,8 @@ private fun FirstNoticeView(
             is Notice.MempoolFull -> onNavigateToNotificationsList
 
             is Notice.RemoteMessage -> onNavigateToNotificationsList
+
+            is Notice.FundsInFinalWallet -> onNavigateToFinalWallet
         }
     } else {
         onNavigateToNotificationsList
@@ -184,6 +191,9 @@ private fun FirstNoticeView(
                 NoticeTextView(text = notice.notice.message, icon = R.drawable.ic_info)
             }
 
+            is Notice.FundsInFinalWallet -> {
+                NoticeTextView(text = "Funds available in the final wallet.", icon = R.drawable.ic_info)
+            }
         }
 
         if (messagesCount > 1) {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
@@ -76,7 +76,8 @@ fun HomeView(
     onPaymentsHistoryClick: () -> Unit,
     onTorClick: () -> Unit,
     onElectrumClick: () -> Unit,
-    onShowSwapInWallet: () -> Unit,
+    onNavigateToSwapInWallet: () -> Unit,
+    onNavigateToFinalWallet: () -> Unit,
     onShowNotifications: () -> Unit,
     onRequestLiquidityClick: () -> Unit,
 ) {
@@ -238,14 +239,15 @@ fun HomeView(
                     balanceDisplayMode = balanceDisplayMode,
                     swapInBalance = swapInBalance.value,
                     unconfirmedChannelsBalance = pendingChannelsBalance.value,
-                    onShowSwapInWallet = onShowSwapInWallet,
+                    onShowSwapInWallet = onNavigateToSwapInWallet,
                 )
                 PrimarySeparator(modifier = Modifier.layoutId("separator"))
                 HomeNotices(
                     modifier = Modifier.layoutId("notices"),
-                    notices = notices,
+                    notices = notices.toList(),
                     notifications = notifications,
-                    onNavigateToSwapInWallet = onShowSwapInWallet,
+                    onNavigateToSwapInWallet = onNavigateToSwapInWallet,
+                    onNavigateToFinalWallet = onNavigateToFinalWallet,
                     onNavigateToNotificationsList = onShowNotifications,
                 )
             }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/NotificationsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/NotificationsView.kt
@@ -248,8 +248,8 @@ private fun PermamentNotice(
         is Notice.FundsInFinalWallet -> {
             ImportantNotification(
                 icon = R.drawable.ic_chain,
-                message = "Funds available in the final wallet.",
-                actionText = "View funds",
+                message = stringResource(id = R.string.inappnotif_final_wallet_message),
+                actionText = stringResource(id = R.string.inappnotif_final_wallet_action),
                 onActionClick = { nc?.navigate(Screen.WalletInfo.FinalWallet.route) },
             )
         }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/NotificationsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/NotificationsView.kt
@@ -244,6 +244,15 @@ private fun PermamentNotice(
                 },
             )
         }
+
+        is Notice.FundsInFinalWallet -> {
+            ImportantNotification(
+                icon = R.drawable.ic_chain,
+                message = "Funds available in the final wallet.",
+                actionText = "View funds",
+                onActionClick = { nc?.navigate(Screen.WalletInfo.FinalWallet.route) },
+            )
+        }
     }
 }
 

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/FinalWalletRefundView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/FinalWalletRefundView.kt
@@ -211,44 +211,42 @@ private fun ColumnScope.AvailableForRefund(
     Card(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         when (state) {
             is FinalWalletRefundState.Init, is FinalWalletRefundState.Failed -> {
-                if (availableForRefund > 0.sat) {
-                    var showLowFeerateDialog by remember(feerate, mempoolFeerate) { mutableStateOf(false) }
+                var showLowFeerateDialog by remember(feerate, mempoolFeerate) { mutableStateOf(false) }
 
-                    if (showLowFeerateDialog) {
-                        ConfirmLowFeerate(
-                            onConfirm = {
-                                feerate?.let {
-                                    onEstimateRefundFee(address, FeeratePerByte(it))
-                                    showLowFeerateDialog = false
-                                }
-                            },
-                            onCancel = { showLowFeerateDialog = false }
-                        )
-                    }
-
-                    Button(
-                        text = stringResource(id = R.string.swapinrefund_estimate_button),
-                        icon = R.drawable.ic_inspect,
-                        enabled = feerate != null && address.isNotBlank(),
-                        onClick = {
-                            keyboardManager?.hide()
-                            val finalFeerate = feerate
-                            if (finalFeerate != null) {
-                                val recommendedFeerate = mempoolFeerate?.hour
-                                if (recommendedFeerate != null && finalFeerate < recommendedFeerate.feerate) {
-                                    showLowFeerateDialog = true
-                                } else {
-                                    onEstimateRefundFee(address, FeeratePerByte(finalFeerate))
-                                }
+                if (showLowFeerateDialog) {
+                    ConfirmLowFeerate(
+                        onConfirm = {
+                            feerate?.let {
+                                onEstimateRefundFee(address, FeeratePerByte(it))
+                                showLowFeerateDialog = false
                             }
                         },
-                        backgroundColor = MaterialTheme.colors.primary,
-                        textStyle = MaterialTheme.typography.button.copy(color = MaterialTheme.colors.onPrimary),
-                        iconTint = MaterialTheme.colors.onPrimary,
-                        padding = PaddingValues(16.dp),
-                        modifier = Modifier.fillMaxWidth(),
+                        onCancel = { showLowFeerateDialog = false }
                     )
                 }
+
+                Button(
+                    text = stringResource(id = R.string.swapinrefund_estimate_button),
+                    icon = R.drawable.ic_inspect,
+                    enabled = feerate != null && address.isNotBlank(),
+                    onClick = {
+                        keyboardManager?.hide()
+                        val finalFeerate = feerate
+                        if (finalFeerate != null) {
+                            val recommendedFeerate = mempoolFeerate?.hour
+                            if (recommendedFeerate != null && finalFeerate < recommendedFeerate.feerate) {
+                                showLowFeerateDialog = true
+                            } else {
+                                onEstimateRefundFee(address, FeeratePerByte(finalFeerate))
+                            }
+                        }
+                    },
+                    backgroundColor = MaterialTheme.colors.primary,
+                    textStyle = MaterialTheme.typography.button.copy(color = MaterialTheme.colors.onPrimary),
+                    iconTint = MaterialTheme.colors.onPrimary,
+                    padding = PaddingValues(16.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
 
             is FinalWalletRefundState.GettingFee -> {

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/FinalWalletRefundView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/FinalWalletRefundView.kt
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android.settings.walletinfo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.journeyapps.barcodescanner.DecoratedBarcodeView
+import fr.acinq.bitcoin.Satoshi
+import fr.acinq.bitcoin.Transaction
+import fr.acinq.lightning.blockchain.electrum.balance
+import fr.acinq.lightning.blockchain.fee.FeeratePerByte
+import fr.acinq.lightning.utils.sat
+import fr.acinq.lightning.utils.toMilliSatoshi
+import fr.acinq.phoenix.android.R
+import fr.acinq.phoenix.android.business
+import fr.acinq.phoenix.android.components.AmountWithFiatBelow
+import fr.acinq.phoenix.android.components.Button
+import fr.acinq.phoenix.android.components.Card
+import fr.acinq.phoenix.android.components.DefaultScreenHeader
+import fr.acinq.phoenix.android.components.DefaultScreenLayout
+import fr.acinq.phoenix.android.components.Dialog
+import fr.acinq.phoenix.android.components.FeerateSlider
+import fr.acinq.phoenix.android.components.InlineTransactionLink
+import fr.acinq.phoenix.android.components.ProgressView
+import fr.acinq.phoenix.android.components.SplashLabelRow
+import fr.acinq.phoenix.android.components.TextInput
+import fr.acinq.phoenix.android.components.feedback.ErrorMessage
+import fr.acinq.phoenix.android.components.feedback.SuccessMessage
+import fr.acinq.phoenix.android.payments.CameraPermissionsView
+import fr.acinq.phoenix.android.payments.ScannerView
+import fr.acinq.phoenix.android.utils.annotatedStringResource
+import fr.acinq.phoenix.data.MempoolFeerate
+import fr.acinq.phoenix.utils.Parser
+import fr.acinq.phoenix.utils.extensions.confirmed
+
+@Composable
+fun FinalWalletRefundView(
+    onBackClick: () -> Unit,
+) {
+    val vm = viewModel<FinalWalletRefundViewModel>(factory = FinalWalletRefundViewModel.Factory(business.peerManager, business.electrumClient))
+    val state = vm.state.value
+
+    val finalWallet by business.peerManager.finalWallet.collectAsState()
+    val available = finalWallet?.confirmed?.filter { it.blockHeight > 0 }?.balance
+
+    DefaultScreenLayout {
+        DefaultScreenHeader(onBackClick = onBackClick, title = stringResource(id = R.string.swapinrefund_title))
+        when (available) {
+            null -> {
+                ProgressView(text = stringResource(id = R.string.utils_loading_data))
+            }
+            else -> {
+                if (available == 0.sat) {
+                    Text(text = stringResource(id = R.string.finalwallet_refund_available_none), modifier = Modifier.fillMaxWidth(), textAlign = TextAlign.Center, style = MaterialTheme.typography.caption)
+                    Spacer(modifier = Modifier.height(16.dp))
+                } else {
+                    Card(internalPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp), modifier = Modifier.fillMaxWidth()) {
+                        Row {
+                            Text(text = stringResource(id = R.string.finalwallet_refund_available))
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Column { AmountWithFiatBelow(amount = available.toMilliSatoshi(), amountTextStyle = MaterialTheme.typography.body2) }
+                        }
+                    }
+                    AvailableForRefund(
+                        availableForRefund = available,
+                        state = state,
+                        onResetState = { vm.state.value = FinalWalletRefundState.Init },
+                        onEstimateRefundFee = vm::estimateRefundFee,
+                        onExecuteRefund = vm::executeRefund,
+                    )
+
+                }
+
+                if (state is FinalWalletRefundState.Success) {
+                    SuccessTx(state = state)
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(60.dp))
+    }
+}
+
+@Composable
+private fun AddressInputAndFeeSlider(
+    address: String,
+    onAddressChange: (String) -> Unit,
+    feerate: Satoshi?,
+    onFeerateChange: (Satoshi) -> Unit,
+    onShowScanner: () -> Unit,
+    mempoolFeerate: MempoolFeerate?,
+    isEnabled: Boolean
+) {
+    TextInput(
+        text = address,
+        onTextChange = onAddressChange,
+        staticLabel = stringResource(id = R.string.mutualclose_input_label),
+        trailingIcon = {
+            Button(
+                onClick = onShowScanner,
+                icon = R.drawable.ic_scan_qr,
+                iconTint = MaterialTheme.colors.primary
+            )
+        },
+        maxLines = 3,
+        modifier = Modifier.fillMaxWidth(),
+        enabled = isEnabled
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    SplashLabelRow(label = stringResource(id = R.string.send_spliceout_feerate_label)) {
+        feerate?.let { currentFeerate ->
+            FeerateSlider(
+                feerate = currentFeerate,
+                onFeerateChange = onFeerateChange,
+                mempoolFeerate = mempoolFeerate,
+                enabled = isEnabled
+            )
+        } ?: ProgressView(text = stringResource(id = R.string.send_spliceout_feerate_waiting_for_value), padding = PaddingValues(0.dp))
+    }
+}
+
+
+@Composable
+private fun ColumnScope.AvailableForRefund(
+    availableForRefund: Satoshi,
+    state: FinalWalletRefundState,
+    onResetState: () -> Unit,
+    onEstimateRefundFee: (String, FeeratePerByte) -> Unit,
+    onExecuteRefund: (Transaction) -> Unit,
+) {
+    val keyboardManager = LocalSoftwareKeyboardController.current
+    val mempoolFeerate by business.appConfigurationManager.mempoolFeerate.collectAsState()
+
+    var address by remember { mutableStateOf("") }
+    var feerate by remember { mutableStateOf(mempoolFeerate?.halfHour?.feerate) }
+
+    var showScannerView by remember { mutableStateOf(false) }
+
+    if (showScannerView) {
+        RefundScanner(
+            onScannerDismiss = { showScannerView = false },
+            onAddressChange = {
+                address = Parser.trimMatchingPrefix(Parser.removeExcessInput(it), Parser.bitcoinPrefixes)
+                showScannerView = false
+            }
+        )
+        return
+    }
+
+    Card(internalPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp), modifier = Modifier.fillMaxWidth()) {
+        Text(text = stringResource(id = R.string.finalwallet_refund_instructions))
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(text = stringResource(id = R.string.swapinrefund_instructions_2))
+        Spacer(modifier = Modifier.height(24.dp))
+        AddressInputAndFeeSlider(
+            address = address,
+            onAddressChange = { address = it ; onResetState() },
+            feerate = feerate,
+            onFeerateChange = { feerate = it ; onResetState() },
+            onShowScanner = { showScannerView = true },
+            mempoolFeerate = mempoolFeerate,
+            isEnabled = state !is FinalWalletRefundState.GettingFee && state !is FinalWalletRefundState.Publishing,
+        )
+    }
+
+    Card(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+        when (state) {
+            is FinalWalletRefundState.Init, is FinalWalletRefundState.Failed -> {
+                if (availableForRefund > 0.sat) {
+                    var showLowFeerateDialog by remember(feerate, mempoolFeerate) { mutableStateOf(false) }
+
+                    if (showLowFeerateDialog) {
+                        ConfirmLowFeerate(
+                            onConfirm = {
+                                feerate?.let {
+                                    onEstimateRefundFee(address, FeeratePerByte(it))
+                                    showLowFeerateDialog = false
+                                }
+                            },
+                            onCancel = { showLowFeerateDialog = false }
+                        )
+                    }
+
+                    Button(
+                        text = stringResource(id = R.string.swapinrefund_estimate_button),
+                        icon = R.drawable.ic_inspect,
+                        enabled = feerate != null && address.isNotBlank(),
+                        onClick = {
+                            keyboardManager?.hide()
+                            val finalFeerate = feerate
+                            if (finalFeerate != null) {
+                                val recommendedFeerate = mempoolFeerate?.hour
+                                if (recommendedFeerate != null && finalFeerate < recommendedFeerate.feerate) {
+                                    showLowFeerateDialog = true
+                                } else {
+                                    onEstimateRefundFee(address, FeeratePerByte(finalFeerate))
+                                }
+                            }
+                        },
+                        backgroundColor = MaterialTheme.colors.primary,
+                        textStyle = MaterialTheme.typography.button.copy(color = MaterialTheme.colors.onPrimary),
+                        iconTint = MaterialTheme.colors.onPrimary,
+                        padding = PaddingValues(16.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+
+            is FinalWalletRefundState.GettingFee -> {
+                ProgressView(text = stringResource(id = R.string.swapinrefund_estimating))
+            }
+
+            is FinalWalletRefundState.ReviewFee -> {
+                Spacer(modifier = Modifier.height(16.dp))
+                SplashLabelRow(
+                    label = stringResource(id = R.string.send_spliceout_complete_recap_fee),
+                    helpMessage = stringResource(id = R.string.paymentdetails_liquidity_miner_fee_help)
+                ) {
+                    AmountWithFiatBelow(amount = state.fees.toMilliSatoshi(), amountTextStyle = MaterialTheme.typography.body2)
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Button(
+                    text = stringResource(id = R.string.swapinrefund_send_button),
+                    icon = R.drawable.ic_send,
+                    onClick = { onExecuteRefund(state.transaction) },
+                    padding = PaddingValues(16.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                    backgroundColor = MaterialTheme.colors.primary,
+                    textStyle = MaterialTheme.typography.button.copy(color = MaterialTheme.colors.onPrimary),
+                    iconTint = MaterialTheme.colors.onPrimary,
+                )
+            }
+            is FinalWalletRefundState.Publishing -> {
+                ProgressView(text = stringResource(id = R.string.swapinrefund_sending))
+            }
+            is FinalWalletRefundState.Success ->  Unit
+        }
+    }
+
+    if (state is FinalWalletRefundState.Failed) {
+        ErrorMessage(
+            header = stringResource(id = R.string.swapinrefund_failed),
+            details = when (state) {
+                is FinalWalletRefundState.Failed.InvalidAddress -> stringResource(id = R.string.swapinrefund_failed_address)
+                is FinalWalletRefundState.Failed.Error -> state.e.message
+                is FinalWalletRefundState.Failed.CannotCreateTx -> stringResource(id = R.string.swapinrefund_failed_cannot_create)
+            },
+            modifier = Modifier.fillMaxWidth(),
+            alignment = Alignment.CenterHorizontally,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun SuccessTx(state: FinalWalletRefundState.Success) {
+    Card(modifier = Modifier.fillMaxWidth(), internalPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)) {
+        Text(text =  stringResource(id = R.string.swapinrefund_success), style = MaterialTheme.typography.body2)
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(text = stringResource(id = R.string.swapinrefund_success_details))
+        Spacer(modifier = Modifier.height(12.dp))
+        InlineTransactionLink(txId = state.tx.txid)
+    }
+}
+
+@Composable
+private fun ConfirmLowFeerate(
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Dialog(onDismiss = onCancel, title = stringResource(id = R.string.spliceout_low_feerate_dialog_title), buttons = null) {
+        Column(modifier = Modifier.padding(horizontal = 24.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(text = annotatedStringResource(id = R.string.spliceout_low_feerate_dialog_body1))
+            Text(text = annotatedStringResource(id = R.string.spliceout_low_feerate_dialog_body3))
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            Button(
+                text = stringResource(id = R.string.btn_cancel),
+                onClick = onCancel,
+            )
+            Button(
+                text = stringResource(id = R.string.btn_confirm),
+                onClick = onConfirm,
+                icon = R.drawable.ic_check_circle,
+                space = 8.dp,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.RefundScanner(
+    onScannerDismiss: () -> Unit,
+    onAddressChange: (String) -> Unit,
+) {
+    var scanView by remember { mutableStateOf<DecoratedBarcodeView?>(null) }
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .weight(1f)) {
+        ScannerView(
+            onScanViewBinding = { scanView = it },
+            onScannedText = { onAddressChange(it) }
+        )
+
+        CameraPermissionsView {
+            LaunchedEffect(Unit) { scanView?.resume() }
+        }
+
+        // buttons at the bottom of the screen
+        Column(
+            Modifier
+                .align(Alignment.BottomCenter)
+                .padding(24.dp)
+                .clip(RoundedCornerShape(24.dp))
+                .background(MaterialTheme.colors.surface)
+        ) {
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.btn_cancel),
+                icon = R.drawable.ic_arrow_back,
+                onClick = onScannerDismiss
+            )
+        }
+    }
+}

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/FinalWalletRefundViewModel.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/FinalWalletRefundViewModel.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.phoenix.android.settings.walletinfo
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import fr.acinq.bitcoin.BitcoinError
+import fr.acinq.bitcoin.Satoshi
+import fr.acinq.bitcoin.Transaction
+import fr.acinq.bitcoin.TxId
+import fr.acinq.bitcoin.utils.Either
+import fr.acinq.lightning.blockchain.electrum.ElectrumClient
+import fr.acinq.lightning.blockchain.fee.FeeratePerByte
+import fr.acinq.lightning.blockchain.fee.FeeratePerKw
+import fr.acinq.phoenix.data.BitcoinUriError
+import fr.acinq.phoenix.managers.NodeParamsManager
+import fr.acinq.phoenix.managers.PeerManager
+import fr.acinq.phoenix.utils.Parser
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+
+
+sealed class FinalWalletRefundState {
+    data object Init : FinalWalletRefundState()
+    data object GettingFee : FinalWalletRefundState()
+    data class ReviewFee(val fees: Satoshi, val transaction: Transaction) : FinalWalletRefundState()
+    data class Publishing(val transaction: Transaction) : FinalWalletRefundState()
+    data class Success(val tx: Transaction) : FinalWalletRefundState()
+    sealed class Failed : FinalWalletRefundState() {
+        data class Error(val e: Throwable) : Failed()
+        data object CannotCreateTx : Failed()
+        data class InvalidAddress(val address: String, val error: BitcoinUriError) : Failed()
+    }
+}
+
+class FinalWalletRefundViewModel(val peerManager: PeerManager, val electrumClient: ElectrumClient) : ViewModel() {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    val state = mutableStateOf<FinalWalletRefundState>(FinalWalletRefundState.Init)
+
+    fun estimateRefundFee(address: String, feerate: FeeratePerByte) {
+        if (state.value is FinalWalletRefundState.GettingFee) return
+        state.value = FinalWalletRefundState.GettingFee
+
+        viewModelScope.launch(Dispatchers.Default + CoroutineExceptionHandler { _, e ->
+            log.error("error when estimating fees for final wallet refund: ", e)
+            state.value = FinalWalletRefundState.Failed.Error(e)
+        }) {
+            when (val parseResult = Parser.parseBip21Uri(NodeParamsManager.chain, address)) {
+                is Either.Left -> {
+                    log.debug("invalid final-wallet refund address={} error={}", address, parseResult.value)
+                    state.value = FinalWalletRefundState.Failed.InvalidAddress(address, parseResult.value)
+                    return@launch
+                }
+                is Either.Right -> {
+                    if (parseResult.value.script == null) {
+                        state.value = FinalWalletRefundState.Failed.InvalidAddress(
+                            address = parseResult.value.address,
+                            error = BitcoinUriError.InvalidScript(BitcoinError.InvalidScript)
+                        )
+                    } else {
+                        val finalWallet = peerManager.getPeer().finalWallet!!
+                        log.debug("sending to address=${parseResult.value.address} feerate=$feerate")
+                        val res = finalWallet.buildSendAllTransaction(bitcoinAddress = parseResult.value.address, feerate = FeeratePerKw(feerate))
+                        delay(300)
+                        state.value = if (res == null) {
+                            log.error("failed to generate a refund transaction for the final wallet")
+                            FinalWalletRefundState.Failed.CannotCreateTx
+                        } else {
+                            val (tx, fee) = res
+                            log.debug("estimated fee=$fee for final-wallet refund")
+                            FinalWalletRefundState.ReviewFee(fees = fee, transaction = finalWallet.signTransaction(tx)!!)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fun executeRefund(tx: Transaction) {
+        if (state.value !is FinalWalletRefundState.ReviewFee) return
+        state.value = FinalWalletRefundState.Publishing(tx)
+
+        viewModelScope.launch(Dispatchers.Default + CoroutineExceptionHandler { _, e ->
+            log.error("error when broadcasting final-wallet refund tx=$tx: ", e)
+            state.value = FinalWalletRefundState.Failed.Error(e)
+        }) {
+            electrumClient.broadcastTransaction(tx)
+            log.info("final-wallet refund tx=$tx has been broadcast")
+            state.value = FinalWalletRefundState.Success(tx)
+        }
+    }
+
+    class Factory(
+        private val peerManager: PeerManager,
+        private val electrumClient: ElectrumClient,
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return FinalWalletRefundViewModel(peerManager, electrumClient) as T
+        }
+    }
+}

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/FinalWalletRefundViewModel.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/FinalWalletRefundViewModel.kt
@@ -81,7 +81,7 @@ class FinalWalletRefundViewModel(val peerManager: PeerManager, val electrumClien
                         )
                     } else {
                         val finalWallet = peerManager.getPeer().finalWallet!!
-                        log.debug("sending to address=${parseResult.value.address} feerate=$feerate")
+                        log.debug("sending to address={} feerate={}", parseResult.value.address, feerate)
                         val res = finalWallet.buildSendAllTransaction(bitcoinAddress = parseResult.value.address, feerate = FeeratePerKw(feerate))
                         delay(300)
                         state.value = if (res == null) {
@@ -89,8 +89,9 @@ class FinalWalletRefundViewModel(val peerManager: PeerManager, val electrumClien
                             FinalWalletRefundState.Failed.CannotCreateTx
                         } else {
                             val (tx, fee) = res
-                            log.debug("estimated fee=$fee for final-wallet refund")
-                            FinalWalletRefundState.ReviewFee(fees = fee, transaction = finalWallet.signTransaction(tx)!!)
+                            val signedTx = finalWallet.signTransaction(tx)!!
+                            log.debug("estimated fee={} for final-wallet refund", fee)
+                            FinalWalletRefundState.ReviewFee(fees = fee, transaction = signedTx)
                         }
                     }
                 }

--- a/phoenix-android/src/main/res/values-b+es+419/important_strings.xml
+++ b/phoenix-android/src/main/res/values-b+es+419/important_strings.xml
@@ -218,6 +218,9 @@
     <string name="inappnotif_mempool_full_message">Las comisiones en la cadena son elevadas.</string>
     <string name="inappnotif_mempool_full_action">Ver cómo afecta a Phoenix</string>
 
+    <string name="inappnotif_final_wallet_message">Fondos disponibles en la billetera final.</string>
+    <string name="inappnotif_final_wallet_action">Ver fondos</string>
+
     <string name="inappnotif_payment_onchain_pending_title">Fondos pendientes en la cadena (+%1$s)</string>
     <string name="inappnotif_payments_rejection_overview_one">Recientemente se rechazó un pago entrante</string>
     <string name="inappnotif_payments_rejection_overview_many">%1$d pagos entrantes rechazados recientemente</string>

--- a/phoenix-android/src/main/res/values-b+es+419/important_strings.xml
+++ b/phoenix-android/src/main/res/values-b+es+419/important_strings.xml
@@ -452,6 +452,13 @@
     <string name="swapinrefund_success">Transacción publicada.</string>
     <string name="swapinrefund_success_details">Puede encontrar la transacción a continuación. No aparecerá en su historial de pagos, así que haga una copia ahora si lo necesita.</string>
 
+    <!-- Final wallet refund -->
+
+    <string name="finalwallet_refund_title">Gastar fondos del billetero final</string>
+    <string name="finalwallet_refund_available_none">No hay fondos disponibles</string>
+    <string name="finalwallet_refund_available">Importe disponible</string>
+    <string name="finalwallet_refund_instructions">Utilice esta pantalla para gastar fondos de su billetera final. Estos fondos proceden de canales que se han cerrado en el pasado. Esto no afecta a sus canales Lightning existentes.</string>
+
     <!-- experimental features -->
 
     <string name="bip353_subtitle">Esta es una dirección humanamente legible para su solicitud de pago Bolt12.</string>

--- a/phoenix-android/src/main/res/values-cs/important_strings.xml
+++ b/phoenix-android/src/main/res/values-cs/important_strings.xml
@@ -463,6 +463,13 @@
     <string name="swapinrefund_success">Transakce odeslána.</string>
     <string name="swapinrefund_success_details">Transakci naleznete níže. Nebude se zobrazovat v historii plateb, proto si nyní v případě potřeby zkopírujte její ID.</string>
 
+    <!-- Final wallet refund -->
+
+    <string name="finalwallet_refund_title">Utratit prostředky z konečné peněženky</string>
+    <string name="finalwallet_refund_available_none">Nejsou k dispozici žádné prostředky</string>
+    <string name="finalwallet_refund_available">Dostupná částka</string>
+    <string name="finalwallet_refund_instructions">Na této obrazovce můžete utratit prostředky z konečné peněženky. Tyto prostředky pocházejí z kanálů, které byly v minulosti uzavřeny. To nemá vliv na váš stávající kanál Lightning.</string>
+
     <!-- experimental features -->
 
     <string name="bip353_subtitle">Toto je lidsky čitelná adresa pro vaši žádost o platbu Bolt12.</string>

--- a/phoenix-android/src/main/res/values-cs/important_strings.xml
+++ b/phoenix-android/src/main/res/values-cs/important_strings.xml
@@ -220,6 +220,9 @@
     <string name="inappnotif_mempool_full_message">Bitcoin mempool je plný a On-Chain poplatky jsou vysoké.</string>
     <string name="inappnotif_mempool_full_action">Podívejte se, jak je ovlivněn Phoenix</string>
 
+    <string name="inappnotif_final_wallet_message">Prostředky dostupné v konečné peněžence.</string>
+    <string name="inappnotif_final_wallet_action">Zobrazit prostředky</string>
+
     <string name="inappnotif_payment_onchain_pending_title">On-Chain finanční prostředky čekají na vyřízení (+%1$s)</string>
     <string name="inappnotif_payments_rejection_overview_one">Příchozí platba byla nedávno odmítnuta</string>
     <string name="inappnotif_payments_rejection_overview_many">%1$d nedávno odmítnutých příchozích plateb</string>

--- a/phoenix-android/src/main/res/values-de/important_strings.xml
+++ b/phoenix-android/src/main/res/values-de/important_strings.xml
@@ -461,6 +461,13 @@
     <string name="swapinrefund_success">Transaktion veröffentlicht.</string>
     <string name="swapinrefund_success_details">Sie können die Transaktion unten finden. Sie wird nicht in Ihrem Zahlungsverlauf erscheinen, also machen Sie bei Bedarf jetzt eine Kopie davon.</string>
 
+    <!-- Final wallet refund -->
+
+    <string name="finalwallet_refund_title">Guthaben aus der Final Wallet ausgeben</string>
+    <string name="finalwallet_refund_available_none">Kein Guthaben verfügbar</string>
+    <string name="finalwallet_refund_available">Verfügbarer Betrag</string>
+    <string name="finalwallet_refund_instructions">Verwenden Sie diesen Screen, um Guthaben aus Ihrer finalen Wallet auszugeben. Diese Gelder stammen aus Kanälen, die in der Vergangenheit geschlossen wurden. Dies hat keine Auswirkungen auf Ihre bestehenden Lightning-Kanäle.</string>
+
     <!-- experimental features -->
 
     <string name="bip353_subtitle">Dies ist eine von Menschen lesbare Adresse für Ihre Bolt12-Zahlungsanfrage.</string>

--- a/phoenix-android/src/main/res/values-de/important_strings.xml
+++ b/phoenix-android/src/main/res/values-de/important_strings.xml
@@ -217,6 +217,9 @@
     <string name="inappnotif_mempool_full_message">Der Bitcoin mempool ist voll und die on-chain Gebühren sind hoch.</string>
     <string name="inappnotif_mempool_full_action">Erfahren Sie inwiefern Phoenix davon betroffen ist</string>
 
+    <string name="inappnotif_final_wallet_message">Guthaben im Final Wallet verfügbar.</string>
+    <string name="inappnotif_final_wallet_action">Guthaben anzeigen</string>
+
     <string name="inappnotif_payment_onchain_pending_title">On-chain Guthaben ausstehend (+%1$s)</string>
     <string name="inappnotif_payments_rejection_overview_one">1 kürzlich abgelehnter Zahlungseingang</string>
     <string name="inappnotif_payments_rejection_overview_many">%1$d kürzlich abgelehnte Zahlungseingänge</string>

--- a/phoenix-android/src/main/res/values-es/important_strings.xml
+++ b/phoenix-android/src/main/res/values-es/important_strings.xml
@@ -464,6 +464,13 @@
     <string name="swapinrefund_success">Transacción publicada.</string>
     <string name="swapinrefund_success_details">Puede encontrar la transacción a continuación. No aparecerá en su historial de pagos, así que haga una copia ahora si lo necesita.</string>
 
+    <!-- Final wallet refund -->
+
+    <string name="finalwallet_refund_title">Gastar fondos del billetero final</string>
+    <string name="finalwallet_refund_available_none">No hay fondos disponibles</string>
+    <string name="finalwallet_refund_available">Importe disponible</string>
+    <string name="finalwallet_refund_instructions">Utilice esta pantalla para gastar fondos de su billetera final. Estos fondos proceden de canales que se han cerrado en el pasado. Esto no afecta a sus canales Lightning existentes.</string>
+
     <!-- experimental features -->
 
     <string name="bip353_subtitle">Esta es una dirección humanamente legible para su solicitud de pago Bolt12.</string>

--- a/phoenix-android/src/main/res/values-es/important_strings.xml
+++ b/phoenix-android/src/main/res/values-es/important_strings.xml
@@ -221,6 +221,9 @@
     <string name="inappnotif_mempool_full_message">El mempool de Bitcoin está lleno y las tasas en la cadena son altas.</string>
     <string name="inappnotif_mempool_full_action">Vea cómo afecta a Phoenix</string>
 
+    <string name="inappnotif_final_wallet_message">Fondos disponibles en la billetera final.</string>
+    <string name="inappnotif_final_wallet_action">Ver fondos</string>
+
     <string name="inappnotif_payment_onchain_pending_title">Fondos en cadena pendientes (+%1$s)</string>
     <string name="inappnotif_payments_rejection_overview_one">1 cobro rechazado recientemente</string>
     <string name="inappnotif_payments_rejection_overview_many">%1$d cobros rechazados recientemente</string>

--- a/phoenix-android/src/main/res/values-fr/important_strings.xml
+++ b/phoenix-android/src/main/res/values-fr/important_strings.xml
@@ -216,6 +216,9 @@
     <string name="inappnotif_mempool_full_message">Le mempool Bitcoin est plein, et les frais sur la chaîne sont élevés.</string>
     <string name="inappnotif_mempool_full_action">Voir en quoi Phoenix est affecté</string>
 
+    <string name="inappnotif_final_wallet_message">Des fonds sont disponibles dans le wallet final.</string>
+    <string name="inappnotif_final_wallet_action">Afficher les fonds</string>
+
     <string name="inappnotif_migration_from_legacy">Félicitations! Votre wallet a été mis à jour.</string>
     <string name="inappnotif_migration_from_legacy_action">Voir les nouveautés</string>
     <string name="inappnotif_migration_from_legacy_dialog_title">Votre adresse Bitcoin a changé</string>

--- a/phoenix-android/src/main/res/values-fr/important_strings.xml
+++ b/phoenix-android/src/main/res/values-fr/important_strings.xml
@@ -464,6 +464,13 @@
     <string name="swapinrefund_success">Transaction publiée.</string>
     <string name="swapinrefund_success_details">Vous pouvez trouver la transaction ci-dessous. Elle n\'apparaîtra pas dans votre historique de paiements, donc faites en copie maintenant si besoin.</string>
 
+    <!-- Final wallet refund -->
+
+    <string name="finalwallet_refund_title">Dépenser depuis le wallet final</string>
+    <string name="finalwallet_refund_available_none">Pas de fonds disponibles</string>
+    <string name="finalwallet_refund_available">Montant disponible</string>
+    <string name="finalwallet_refund_instructions">Utilisez cet écran pour dépenser les fonds de votre portefeuille final. Ces fonds proviennent de canaux qui ont été fermés par le passé. Cela n\'affecte pas les canaux Lightning existants.</string>
+
     <!-- experimental features -->
 
     <string name="bip353_subtitle">Il s\'agit d\'une adresse humainement compréhensible associée à votre code de paiement Bolt12.</string>

--- a/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
+++ b/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
@@ -219,6 +219,9 @@
     <string name="inappnotif_mempool_full_message">O mempool do Bitcoin está cheio e as taxas na cadeia estão altas.</string>
     <string name="inappnotif_mempool_full_action">Veja como a Phoenix é afetada</string>
 
+    <string name="inappnotif_final_wallet_message">Fundos disponíveis na carteira final.</string>
+    <string name="inappnotif_final_wallet_action">Ver fundos.</string>
+
     <string name="inappnotif_payment_onchain_pending_title">Fundos pendentes na cadeia (+%1$s)</string>
 
     <string name="inappnotif_payments_rejection_overview_one">1 pagamento recebido recentemente rejeitado</string>

--- a/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
+++ b/phoenix-android/src/main/res/values-pt-rBR/important_strings.xml
@@ -459,6 +459,13 @@
     <string name="swapinrefund_success">Transação publicada.</string>
     <string name="swapinrefund_success_details">Você pode encontrar a transação abaixo. Ela não aparecerá em seu histórico de pagamentos, portanto, faça uma cópia agora, se necessário.</string>
 
+    <!-- Final wallet refund -->
+
+    <string name="finalwallet_refund_title">Gastar fundos da carteira final</string>
+    <string name="finalwallet_refund_available_none">Não há fundos disponíveis</string>
+    <string name="finalwallet_refund_available">Valor disponível</string>
+    <string name="finalwallet_refund_instructions">Use esta tela para gastar fundos de sua carteira final. Esses fundos vêm de canais que foram fechados no passado. Isso não afeta seus canais Lightning existentes.</string>
+
     <!-- experimental features -->
 
     <string name="bip353_subtitle">Este é um endereço legível por humanos para sua solicitação de pagamento do Bolt12.</string>

--- a/phoenix-android/src/main/res/values-sk/important_strings.xml
+++ b/phoenix-android/src/main/res/values-sk/important_strings.xml
@@ -464,6 +464,13 @@
     <string name="swapinrefund_success">Zverejnená transakcia.</string>
     <string name="swapinrefund_success_details">Transakciu nájdete nižšie. Nebude sa zobrazovať v histórii platieb, preto si teraz vytvorte jej kópiu, ak ju potrebujete.</string>
 
+    <!-- Final wallet refund -->
+
+    <string name="finalwallet_refund_title">Míňať prostriedky z konečnej peňaženky</string>
+    <string name="finalwallet_refund_available_none">Nie sú k dispozícii žiadne prostriedky</string>
+    <string name="finalwallet_refund_available">Dostupná suma</string>
+    <string name="finalwallet_refund_instructions">Na tejto obrazovke môžete minúť prostriedky z konečnej peňaženky. Tieto prostriedky pochádzajú z kanálov, ktoré boli v minulosti uzavreté. Toto nemá vplyv na vaše existujúce kanály Lightning.</string>
+
     <!-- experimental features -->
 
     <string name="bip353_subtitle">Toto je ľudsky čitateľná adresa pre vašu žiadosť o platbu Bolt12.</string>

--- a/phoenix-android/src/main/res/values-sk/important_strings.xml
+++ b/phoenix-android/src/main/res/values-sk/important_strings.xml
@@ -220,6 +220,9 @@
     <string name="inappnotif_mempool_full_message">Bitcoin mempool je plný a on-chain poplatky sú vysoké.</string>
     <string name="inappnotif_mempool_full_action">Pozrite sa, ako je ovplyvnený Phoenix</string>
 
+    <string name="inappnotif_final_wallet_message">Prostriedky dostupné v konečnej peňaženke.</string>
+    <string name="inappnotif_final_wallet_action">Zobraziť prostriedky</string>
+
     <string name="inappnotif_payment_onchain_pending_title">On-chain finančné prostriedky čakajú na vybavenie (+%1$s)</string>
     <string name="inappnotif_payments_rejection_overview_one">Prichádzajúca platba bola nedávno zamietnutá</string>
     <string name="inappnotif_payments_rejection_overview_many">%1$d nedávno zamietnutých prichádzajúcich platieb</string>

--- a/phoenix-android/src/main/res/values-sw/important_strings.xml
+++ b/phoenix-android/src/main/res/values-sw/important_strings.xml
@@ -466,6 +466,13 @@
     <string name="swapinrefund_success">Muamala umetangazwa.</string>
     <string name="swapinrefund_success_details">Unaweza kupata muamala unaotumia fedha hapa chini. Haitaonekana kwenye historia ya malipo yako, hivyo fanya nakala ya kitambulisho chake sasa ikiwa inahitajika.</string>
 
+    <!-- Final wallet refund -->
+
+    <string name="finalwallet_refund_title">Tumia pesa kutoka kwa mkoba wa mwisho</string>
+    <string name="finalwallet_refund_available_none">Hakuna fedha zinazopatikana</string>
+    <string name="finalwallet_refund_available">Kiasi kinachopatikana</string>
+    <string name="finalwallet_refund_instructions">Tumia skrini hii kutumia pesa kutoka kwa pochi yako ya mwisho. Fedha hizi hutoka kwa chaneli ambazo zilifungwa hapo awali. Hii haiathiri chaneli zako zilizopo za Lightning.</string>
+
     <!-- experimental features -->
 
     <string name="bip353_subtitle">Hii ni anwani inayosomeka na binadamu kwa ombi lako la malipo la Bolt12.</string>

--- a/phoenix-android/src/main/res/values-sw/important_strings.xml
+++ b/phoenix-android/src/main/res/values-sw/important_strings.xml
@@ -223,6 +223,9 @@
     <string name="inappnotif_mempool_full_message">Ada za mtandaoni ziko juu.</string>
     <string name="inappnotif_mempool_full_action">Angalia jinsi Phoenix inavyoathirika</string>
 
+    <string name="inappnotif_final_wallet_message">Fedha zinapatikana katika pochi ya mwisho.</string>
+    <string name="inappnotif_final_wallet_action">Angalia fedha</string>
+
     <string name="inappnotif_payment_onchain_pending_title">Fedha za mtandaoni zinangosubiria (+%1$s)</string>
     <string name="inappnotif_payments_rejection_overview_one">Malipo moja ya kuingia yamekataliwa hivi karibuni</string>
     <string name="inappnotif_payments_rejection_overview_many">%1$d malipo ya kuingia yamekataliwa hivi karibuni</string>

--- a/phoenix-android/src/main/res/values-vi/important_strings.xml
+++ b/phoenix-android/src/main/res/values-vi/important_strings.xml
@@ -227,6 +227,9 @@
     <string name="inappnotif_mempool_full_message">Phí on-chain cao.</string>
     <string name="inappnotif_mempool_full_action">Xem những ảnh hưởng tới Phoenix.</string>
 
+    <string name="inappnotif_final_wallet_message">Tiền có sẵn trong ví cuối cùng.</string>
+    <string name="inappnotif_final_wallet_action">Xem tiền</string>
+
     <string name="inappnotif_payment_onchain_pending_title">Các khoản vốn on-chain đang chờ xử lý (+%1$s)</string>.
     <string name="inappnotif_payments_rejection_overview_one">Một khoản tiền đến đã bị từ chối gần đây.</string>
     <string name="inappnotif_payments_rejection_overview_many">Khoản thanh toán đến %1$d đã bị từ chối gần đây</string>

--- a/phoenix-android/src/main/res/values-vi/important_strings.xml
+++ b/phoenix-android/src/main/res/values-vi/important_strings.xml
@@ -471,6 +471,13 @@
     <string name="swapinrefund_success">Giao dịch đã được công bố.</string>
     <string name="swapinrefund_success_details">Bạn có thể tìm thấy giao dịch chi tiêu số tiền bên dưới. Nó sẽ không xuất hiện trong lịch sử thanh toán của bạn, vì vậy hãy tạo bản sao ID của nó ngay bây giờ nếu cần.</string>
 
+    <!-- Final wallet refund -->
+
+    <string name="finalwallet_refund_title">Chi tiêu tiền từ ví cuối cùng</string>
+    <string name="finalwallet_refund_available_none">Không có sẵn tiền</string>
+    <string name="finalwallet_refund_available">Số tiền có sẵn</string>
+    <string name="finalwallet_refund_instructions">Sử dụng màn hình này để tiêu tiền từ ví cuối cùng của bạn. Những khoản tiền này đến từ các kênh đã bị đóng trong quá khứ. Điều này không ảnh hưởng đến các kênh Lightning hiện tại của bạn.</string>
+
     <!-- experimental features -->
 
     <string name="bip353_subtitle">Đây là địa chỉ mà con người có thể đọc được cho yêu cầu thanh toán Bolt12 của bạn.</string>

--- a/phoenix-android/src/main/res/values/important_strings.xml
+++ b/phoenix-android/src/main/res/values/important_strings.xml
@@ -472,7 +472,7 @@
     <string name="finalwallet_refund_title">Spend funds from final wallet</string>
     <string name="finalwallet_refund_available_none">No funds available</string>
     <string name="finalwallet_refund_available">Amount available</string>
-    <string name="finalwallet_refund_instructions">Use this screen to spend funds from your final wallet. These funds typically come from channels that have been closed. This does not affect your Lightning channels.</string>
+    <string name="finalwallet_refund_instructions">Use this screen to spend funds from your final wallet. These funds come from channels that have been closed in the past. This does not affect your existing Lightning channels.</string>
 
     <!-- experimental features -->
 

--- a/phoenix-android/src/main/res/values/important_strings.xml
+++ b/phoenix-android/src/main/res/values/important_strings.xml
@@ -456,7 +456,7 @@
     <string name="swapinrefund_none_available_label">No cancelled swap-ins yet.</string>
     <string name="swapinrefund_available_label">Available: <b>%1$s</b> (%2$s)</string>
     <string name="swapinrefund_instructions_1">Use this screen to spend on-chain deposits that were not swapped in time. This does not affect your Lightning channels.</string>
-    <string name="swapinrefund_instructions_2">Make sure the destination address is valid and the feerate reasonable.</string>
+    <string name="swapinrefund_instructions_2">Make sure the destination address is valid, and use a reasonable feerate.</string>
     <string name="swapinrefund_estimate_button">Estimate fees</string>
     <string name="swapinrefund_estimating">Estimating fees…</string>
     <string name="swapinrefund_send_button">Broadcast</string>
@@ -465,7 +465,14 @@
     <string name="swapinrefund_failed_address">This address is not valid.</string>
     <string name="swapinrefund_failed_cannot_create">Cannot create the refund transaction.</string>
     <string name="swapinrefund_success">Transaction published.</string>
-    <string name="swapinrefund_success_details">You can find the transaction spending the funds below. It will not appear in your payments history, so make a copy of its ID now if needed.</string>
+    <string name="swapinrefund_success_details">You can find the transaction below. It will not appear in your payments history, so make a copy of its ID now if needed.</string>
+
+    <!-- Final wallet refund -->
+
+    <string name="finalwallet_refund_title">Spend funds from final wallet</string>
+    <string name="finalwallet_refund_available_none">No funds available</string>
+    <string name="finalwallet_refund_available">Amount available</string>
+    <string name="finalwallet_refund_instructions">Use this screen to spend funds from your final wallet. These funds typically come from channels that have been closed. This does not affect your Lightning channels.</string>
 
     <!-- experimental features -->
 

--- a/phoenix-android/src/main/res/values/important_strings.xml
+++ b/phoenix-android/src/main/res/values/important_strings.xml
@@ -223,6 +223,9 @@
     <string name="inappnotif_mempool_full_message">On-chain fees are high.</string>
     <string name="inappnotif_mempool_full_action">See how Phoenix is affected</string>
 
+    <string name="inappnotif_final_wallet_message">Funds available in the final wallet.</string>
+    <string name="inappnotif_final_wallet_action">View funds.</string>
+
     <string name="inappnotif_payment_onchain_pending_title">On-chain funds pending (+%1$s)</string>
     <string name="inappnotif_payments_rejection_overview_one">An incoming payment has been recently rejected</string>
     <string name="inappnotif_payments_rejection_overview_many">%1$d incoming payments recently rejected</string>

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/NodeParamsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/NodeParamsManager.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.hours
 
 
 class NodeParamsManager(
@@ -69,6 +70,7 @@ class NodeParamsManager(
                 ).copy(
                     zeroConfPeers = setOf(trampolineNodeId),
                     liquidityPolicy = MutableStateFlow(startupParams.liquidityPolicy),
+                    bolt12invoiceExpiry = 24.hours,
                 )
             }.collect {
                 log.info { "hello!" }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/extensions/WalletStateExtensions.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/extensions/WalletStateExtensions.kt
@@ -17,7 +17,9 @@
 package fr.acinq.phoenix.utils.extensions
 
 import fr.acinq.lightning.SwapInParams
+import fr.acinq.lightning.blockchain.electrum.FinalWallet
 import fr.acinq.lightning.blockchain.electrum.WalletState
+import fr.acinq.lightning.utils.getValue
 import kotlin.math.ceil
 
 /** Number of confirmation during which a utxo is locked between the swap window closing and the refund delay. */
@@ -42,3 +44,7 @@ val WalletState.WalletWithConfirmations.deeplyConfirmedToExpiry: List<Pair<Walle
 /** A map of deeply confirmed utxos to their expiry, according to the wallet's swap params. */
 val WalletState.WalletWithConfirmations.nextTimeout: Pair<WalletState.Utxo, Int>?
     get() = deeplyConfirmedToExpiry.minByOrNull { it.second }
+
+/** List of all confirmed utxos. */
+val WalletState.WalletWithConfirmations.confirmed
+    get() = this.all.filter { it.blockHeight > 0L }


### PR DESCRIPTION
Thanks to https://github.com/ACINQ/lightning-kmp/pull/700 (lightning-kmp v1.8.0), we can add the UI to spend confirmed funds in the final wallet from Phoenix (instead of having to use a 3rd party tool).

This PR adds a new UI similar to the one for spending cancelled swap-ins. The feerate can be customised (with a warning if it's too low). A notification has been added in the home screen to let the user know when there are funds in the final wallet (easy to miss otherwise).