### PR TITLE
(ios) Various UI fixes

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		DC74174B270F332700F7E3E3 /* KotlinTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC74174A270F332700F7E3E3 /* KotlinTypes.swift */; };
 		DC74174D270F455D00F7E3E3 /* AES256.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC74174C270F455D00F7E3E3 /* AES256.swift */; };
 		DC784A112B31EA180018DC4A /* LiquidityAdsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC784A102B31EA180018DC4A /* LiquidityAdsView.swift */; };
+		DC7BAA002CADAAE70074B568 /* WalletIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7BA9FF2CADAAE70074B568 /* WalletIdentifier.swift */; };
 		DC7DA9F62AD84DF200F86B99 /* String+Substring.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7DA9F52AD84DF200F86B99 /* String+Substring.swift */; };
 		DC81B79F25BF2AA200F5A52C /* MVI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC81B79E25BF2AA200F5A52C /* MVI.swift */; };
 		DC82EED629789853007A5853 /* TxHistoryExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC82EED529789853007A5853 /* TxHistoryExporter.swift */; };
@@ -613,6 +614,7 @@
 		DC74174A270F332700F7E3E3 /* KotlinTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinTypes.swift; sourceTree = "<group>"; };
 		DC74174C270F455D00F7E3E3 /* AES256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AES256.swift; sourceTree = "<group>"; };
 		DC784A102B31EA180018DC4A /* LiquidityAdsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidityAdsView.swift; sourceTree = "<group>"; };
+		DC7BA9FF2CADAAE70074B568 /* WalletIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletIdentifier.swift; sourceTree = "<group>"; };
 		DC7DA9F52AD84DF200F86B99 /* String+Substring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Substring.swift"; sourceTree = "<group>"; };
 		DC81B79E25BF2AA200F5A52C /* MVI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MVI.swift; sourceTree = "<group>"; };
 		DC82EED529789853007A5853 /* TxHistoryExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxHistoryExporter.swift; sourceTree = "<group>"; };
@@ -833,6 +835,7 @@
 				DCDD9ECD28637474001800A3 /* Orientation.swift */,
 				DC355E222A45FAF2008E8A8E /* NestedObservableObject.swift */,
 				DCCFE6A52B63028A002FFF11 /* UnfairLock.swift */,
+				DC7BA9FF2CADAAE70074B568 /* WalletIdentifier.swift */,
 			);
 			path = utils;
 			sourceTree = "<group>";
@@ -1925,6 +1928,7 @@
 				DCA02BA02BD1A5FC0080520F /* ChannelSizeImpactWarning.swift in Sources */,
 				DC355E232A45FAF2008E8A8E /* NestedObservableObject.swift in Sources */,
 				DC5F1C4A28DDAA49007A55ED /* ResetWalletView_Confirm.swift in Sources */,
+				DC7BAA002CADAAE70074B568 /* WalletIdentifier.swift in Sources */,
 				DC39D4E7286BB2130030F18D /* PaymentLayerChoice.swift in Sources */,
 				DC46BAF626CACCF700E760A6 /* KotlinFutures.swift in Sources */,
 				DC641C7E2821744000862DCD /* Currency+CurrencyPrefs.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -324,6 +324,9 @@
         }
       }
     },
+    "? confirmations" : {
+
+    },
     "..." : {
       "localizations" : {
         "ar" : {

--- a/phoenix-ios/phoenix-ios/officers/BusinessManager.swift
+++ b/phoenix-ios/phoenix-ios/officers/BusinessManager.swift
@@ -448,7 +448,7 @@ class BusinessManager {
 		self.walletInfo = _walletInfo
 		maybeRegisterFcmToken()
 		
-		let encryptedNodeId = _walletInfo.cloudKeyHash as String
+		let walletId = WalletIdentifier(chain: business.chain, walletInfo: _walletInfo)
 		
 		if let walletRestoreType = walletRestoreType {
 			switch walletRestoreType {
@@ -457,13 +457,13 @@ class BusinessManager {
 				// User is restoring wallet after manually typing in the recovery phrase.
 				// So we can mark the manual_backup task as completed.
 				//
-				Prefs.shared.backupSeed.manualBackup_setTaskDone(true, encryptedNodeId: encryptedNodeId)
+				Prefs.shared.backupSeed.manualBackup_setTaskDone(true, walletId)
 				//
 				// And ensure cloud backup is disabled for the wallet.
 				//
 				Prefs.shared.backupSeed.isEnabled = false
-				Prefs.shared.backupSeed.setName(nil, encryptedNodeId: encryptedNodeId)
-				Prefs.shared.backupSeed.setHasUploadedSeed(false, encryptedNodeId: encryptedNodeId)
+				Prefs.shared.backupSeed.setName(nil, walletId)
+				Prefs.shared.backupSeed.setHasUploadedSeed(false, walletId)
 				
 			case .fromCloudBackup(let name):
 				//
@@ -471,12 +471,12 @@ class BusinessManager {
 				// So we can mark the iCloud backpu as completed.
 				//
 				Prefs.shared.backupSeed.isEnabled = true
-				Prefs.shared.backupSeed.setName(name, encryptedNodeId: encryptedNodeId)
-				Prefs.shared.backupSeed.setHasUploadedSeed(true, encryptedNodeId: encryptedNodeId)
+				Prefs.shared.backupSeed.setName(name, walletId)
+				Prefs.shared.backupSeed.setHasUploadedSeed(true, walletId)
 				//
 				// And ensure manual backup is diabled for the wallet.
 				//
-				Prefs.shared.backupSeed.manualBackup_setTaskDone(false, encryptedNodeId: encryptedNodeId)
+				Prefs.shared.backupSeed.manualBackup_setTaskDone(false, walletId)
 			}
 		}
 
@@ -492,15 +492,17 @@ class BusinessManager {
 		return true
 	}
 	
-	/// The current encryptedNodeId (from the current unlocked wallet).
+	/// The current walletIdentifier (from the current unlocked wallet).
 	///
 	/// Always fetch this on demand - don't cache it.
 	/// Because it might change if the user closes his/her wallet.
 	///
-	public var encryptedNodeId: String? {
-
-		// For historical reasons, this is the cloudKeyHash, and NOT the nodeIdHash.
-		return walletInfo?.cloudKeyHash
+	public var walletId: WalletIdentifier? {
+		if let walletInfo {
+			return WalletIdentifier(chain: business.chain, walletInfo: walletInfo)
+		} else {
+			return nil
+		}
 	}
 
 	/// The current nodeIdHash (from the current unlocked wallet).

--- a/phoenix-ios/phoenix-ios/officers/WalletReset.swift
+++ b/phoenix-ios/phoenix-ios/officers/WalletReset.swift
@@ -171,7 +171,7 @@ class WalletReset {
 		let dbDir = groupDir.appendingPathComponent("databases", isDirectory: true)
 		
 		let chainName: String = Biz.business.chain.phoenixName
-		let nodeIdHash: String = Biz.nodeIdHash ?? "nil"
+		let nodeIdHash: String = Biz.nodeIdHash!
 		
 		log.debug("dbDir: \(dbDir.path)")
 		log.debug("chainName: \(chainName)")
@@ -214,9 +214,9 @@ class WalletReset {
 		log.trace("step4()")
 		progress.send(.resetingUserDefaults)
 		
-		let encrypedNodeId = Biz.encryptedNodeId ?? "nil"
+		let walletId = Biz.walletId!
 		
-		Prefs.shared.resetWallet(encryptedNodeId: encrypedNodeId)
+		Prefs.shared.resetWallet(walletId)
 		GroupPrefs.shared.resetWallet()
 		
 		DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {

--- a/phoenix-ios/phoenix-ios/prefs/Prefs+BackupSeed.swift
+++ b/phoenix-ios/phoenix-ios/prefs/Prefs+BackupSeed.swift
@@ -53,18 +53,18 @@ class Prefs_BackupSeed {
 		return PassthroughSubject<Void, Never>()
 	}()
 	
-	private func hasUploadedSeed_key(_ encryptedNodeId: String) -> String {
-		return "\(Key.backupSeed_hasUploadedSeed.rawValue)-\(encryptedNodeId)"
+	private func hasUploadedSeed_key(_ walletId: WalletIdentifier) -> String {
+		return "\(Key.backupSeed_hasUploadedSeed.rawValue)-\(walletId.prefsKeySuffix)"
 	}
 	
-	func hasUploadedSeed(encryptedNodeId: String) -> Bool {
+	func hasUploadedSeed(_ walletId: WalletIdentifier) -> Bool {
 		
-		return defaults.bool(forKey: hasUploadedSeed_key(encryptedNodeId))
+		return defaults.bool(forKey: hasUploadedSeed_key(walletId))
 	}
 	
-	func setHasUploadedSeed(_ value: Bool, encryptedNodeId: String) {
+	func setHasUploadedSeed(_ value: Bool, _ walletId: WalletIdentifier) {
 		
-		let key = hasUploadedSeed_key(encryptedNodeId)
+		let key = hasUploadedSeed_key(walletId)
 		if value == true {
 			defaults.setValue(value, forKey: key)
 		} else {
@@ -79,19 +79,19 @@ class Prefs_BackupSeed {
 		return PassthroughSubject<Void, Never>()
 	}()
 	
-	private func name_key(_ encryptedNodeId: String) -> String {
-		return "\(Key.backupSeed_name)-\(encryptedNodeId)"
+	private func name_key(_ walletId: WalletIdentifier) -> String {
+		return "\(Key.backupSeed_name)-\(walletId.prefsKeySuffix)"
 	}
 	
-	func name(encryptedNodeId: String) -> String? {
+	func name(_ walletId: WalletIdentifier) -> String? {
 		
-		return defaults.string(forKey: name_key(encryptedNodeId))
+		return defaults.string(forKey: name_key(walletId))
 	}
 	
-	func setName(_ value: String?, encryptedNodeId: String) {
+	func setName(_ value: String?, _ walletId: WalletIdentifier) {
 		
-		let key = name_key(encryptedNodeId)
-		let oldValue = name(encryptedNodeId: encryptedNodeId) ?? ""
+		let key = name_key(walletId)
+		let oldValue = name(walletId) ?? ""
 		let newValue = value ?? ""
 		
 		if oldValue != newValue {
@@ -100,7 +100,7 @@ class Prefs_BackupSeed {
 			} else {
 				defaults.setValue(newValue, forKey: key)
 			}
-			setHasUploadedSeed(false, encryptedNodeId: encryptedNodeId)
+			setHasUploadedSeed(false, walletId)
 			runOnMainThread {
 				self.name_publisher.send()
 			}
@@ -112,18 +112,18 @@ class Prefs_BackupSeed {
 		return PassthroughSubject<Void, Never>()
 	}()
 	
-	private func manualBackup_taskDone_key(_ encryptedNodeId: String) -> String {
-		return "\(Key.manualBackup_taskDone)-\(encryptedNodeId)"
+	private func manualBackup_taskDone_key(_ walletId: WalletIdentifier) -> String {
+		return "\(Key.manualBackup_taskDone)-\(walletId.prefsKeySuffix)"
 	}
 	
-	func manualBackup_taskDone(encryptedNodeId: String) -> Bool {
+	func manualBackup_taskDone(_ walletId: WalletIdentifier) -> Bool {
 		
-		return defaults.bool(forKey: manualBackup_taskDone_key(encryptedNodeId))
+		return defaults.bool(forKey: manualBackup_taskDone_key(walletId))
 	}
 	
-	func manualBackup_setTaskDone(_ newValue: Bool, encryptedNodeId: String) {
+	func manualBackup_setTaskDone(_ newValue: Bool, _ walletId: WalletIdentifier) {
 		
-		let key = manualBackup_taskDone_key(encryptedNodeId)
+		let key = manualBackup_taskDone_key(walletId)
 		if newValue {
 			defaults.setValue(newValue, forKey: key)
 		} else {
@@ -134,12 +134,12 @@ class Prefs_BackupSeed {
 		}
 	}
 	
-	func resetWallet(encryptedNodeId: String) {
+	func resetWallet(_ walletId: WalletIdentifier) {
 		
 		defaults.removeObject(forKey: Key.backupSeed_enabled.rawValue)
-		defaults.removeObject(forKey: hasUploadedSeed_key(encryptedNodeId))
-		defaults.removeObject(forKey: name_key(encryptedNodeId))
-		defaults.removeObject(forKey: manualBackup_taskDone_key(encryptedNodeId))
+		defaults.removeObject(forKey: hasUploadedSeed_key(walletId))
+		defaults.removeObject(forKey: name_key(walletId))
+		defaults.removeObject(forKey: manualBackup_taskDone_key(walletId))
 		
 		// Reset any publishers with stored state
 		runOnMainThread {
@@ -150,7 +150,7 @@ class Prefs_BackupSeed {
 
 extension Prefs {
 	
-	func backupSeedStatePublisher(_ encryptedNodeId: String) -> AnyPublisher<BackupSeedState, Never> {
+	func backupSeedStatePublisher(_ walletId: WalletIdentifier) -> AnyPublisher<BackupSeedState, Never> {
 		
 		let publisher = Publishers.CombineLatest3(
 			backupSeed.isEnabled_publisher,            // CurrentValueSubject<Bool, Never>
@@ -160,8 +160,8 @@ extension Prefs {
 			
 			let prefs = Prefs.shared
 			
-			let backupSeed_hasUploadedSeed = prefs.backupSeed.hasUploadedSeed(encryptedNodeId: encryptedNodeId)
-			let manualBackup_taskDone = prefs.backupSeed.manualBackup_taskDone(encryptedNodeId: encryptedNodeId)
+			let backupSeed_hasUploadedSeed = prefs.backupSeed.hasUploadedSeed(walletId)
+			let manualBackup_taskDone = prefs.backupSeed.manualBackup_taskDone(walletId)
 			
 			if backupSeed_isEnabled {
 				if backupSeed_hasUploadedSeed {

--- a/phoenix-ios/phoenix-ios/prefs/Prefs+BackupTransactions.swift
+++ b/phoenix-ios/phoenix-ios/prefs/Prefs+BackupTransactions.swift
@@ -90,16 +90,16 @@ class Prefs_BackupTransactions {
 		}
 	}
 	
-	private func recordZoneCreatedKey(_ encryptedNodeId: String) -> String {
-		return "\(Key.hasCKRecordZone_v2.rawValue)-\(encryptedNodeId)"
+	private func recordZoneCreatedKey(_ walletId: WalletIdentifier) -> String {
+		return "\(Key.hasCKRecordZone_v2.rawValue)-\(walletId.prefsKeySuffix)"
 	}
 	
-	func recordZoneCreated(_ encryptedNodeId: String) -> Bool {
-		return defaults.bool(forKey: recordZoneCreatedKey(encryptedNodeId))
+	func recordZoneCreated(_ walletId: WalletIdentifier) -> Bool {
+		return defaults.bool(forKey: recordZoneCreatedKey(walletId))
 	}
 	
-	func setRecordZoneCreated(_ value: Bool, _ encryptedNodeId: String) {
-		let key = recordZoneCreatedKey(encryptedNodeId)
+	func setRecordZoneCreated(_ value: Bool, _ walletId: WalletIdentifier) {
+		let key = recordZoneCreatedKey(walletId)
 		if value == true {
 			defaults.setValue(value, forKey: key)
 		} else {
@@ -107,35 +107,35 @@ class Prefs_BackupTransactions {
 		}
 	}
 	
-	private func hasDownloadedPaymentsKey(_ encryptedNodeId: String) -> String {
-		return "\(Key.hasDownloadedPayments.rawValue)-\(encryptedNodeId)"
+	private func hasDownloadedPaymentsKey(_ walletId: WalletIdentifier) -> String {
+		return "\(Key.hasDownloadedPayments.rawValue)-\(walletId.prefsKeySuffix)"
 	}
 	
-	func hasDownloadedPayments(_ encryptedNodeId: String) -> Bool {
-		return defaults.bool(forKey: hasDownloadedPaymentsKey(encryptedNodeId))
+	func hasDownloadedPayments(_ walletId: WalletIdentifier) -> Bool {
+		return defaults.bool(forKey: hasDownloadedPaymentsKey(walletId))
 	}
 	
-	func markHasDownloadedPayments(_ encryptedNodeId: String) {
-		defaults.setValue(true, forKey: hasDownloadedPaymentsKey(encryptedNodeId))
+	func markHasDownloadedPayments(_ walletId: WalletIdentifier) {
+		defaults.setValue(true, forKey: hasDownloadedPaymentsKey(walletId))
 	}
 	
-	private func hasDownloadedContactsKey(_ encryptedNodeId: String) -> String {
-		return "\(Key.hasDownloadedContacts.rawValue)-\(encryptedNodeId)"
+	private func hasDownloadedContactsKey(_ walletId: WalletIdentifier) -> String {
+		return "\(Key.hasDownloadedContacts.rawValue)-\(walletId.prefsKeySuffix)"
 	}
 	
-	func hasDownloadedContacts(_ encryptedNodeId: String) -> Bool {
-		return defaults.bool(forKey: hasDownloadedContactsKey(encryptedNodeId))
+	func hasDownloadedContacts(_ walletId: WalletIdentifier) -> Bool {
+		return defaults.bool(forKey: hasDownloadedContactsKey(walletId))
 	}
 	
-	func markHasDownloadedContacts(_ encryptedNodeId: String) {
-		defaults.setValue(true, forKey: hasDownloadedContactsKey(encryptedNodeId))
+	func markHasDownloadedContacts(_ walletId: WalletIdentifier) {
+		defaults.setValue(true, forKey: hasDownloadedContactsKey(walletId))
 	}
 	
-	func resetWallet(encryptedNodeId: String) {
+	func resetWallet(_ walletId: WalletIdentifier) {
 		
-		defaults.removeObject(forKey: recordZoneCreatedKey(encryptedNodeId))
-		defaults.removeObject(forKey: hasDownloadedPaymentsKey(encryptedNodeId))
-		defaults.removeObject(forKey: hasDownloadedContactsKey(encryptedNodeId))
+		defaults.removeObject(forKey: recordZoneCreatedKey(walletId))
+		defaults.removeObject(forKey: hasDownloadedPaymentsKey(walletId))
+		defaults.removeObject(forKey: hasDownloadedContactsKey(walletId))
 		defaults.removeObject(forKey: Key.backupTransactions_enabled.rawValue)
 		defaults.removeObject(forKey: Key.backupTransactions_useCellularData.rawValue)
 		defaults.removeObject(forKey: Key.backupTransactions_useUploadDelay.rawValue)

--- a/phoenix-ios/phoenix-ios/prefs/Prefs.swift
+++ b/phoenix-ios/phoenix-ios/prefs/Prefs.swift
@@ -239,7 +239,7 @@ class Prefs {
 	// MARK: Reset Wallet
 	// --------------------------------------------------
 
-	func resetWallet(encryptedNodeId: String) {
+	func resetWallet(_ walletId: WalletIdentifier) {
 
 		// Purposefully not resetting:
 		// - Key.theme: App feels weird when this changes unexpectedly.
@@ -258,8 +258,8 @@ class Prefs {
 		defaults.removeObject(forKey: Key.allowOverpayment.rawValue)
 		defaults.removeObject(forKey: Key.doNotShowChannelImpactWarning.rawValue)
 		
-		self.backupTransactions.resetWallet(encryptedNodeId: encryptedNodeId)
-		self.backupSeed.resetWallet(encryptedNodeId: encryptedNodeId)
+		self.backupTransactions.resetWallet(walletId)
+		self.backupSeed.resetWallet(walletId)
 	}
 
 	// --------------------------------------------------

--- a/phoenix-ios/phoenix-ios/sync/SyncBackupManager+Contacts.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncBackupManager+Contacts.swift
@@ -227,7 +227,7 @@ extension SyncBackupManager {
 				
 				log.trace("downloadContacts(): finish: success")
 				
-				Prefs.shared.backupTransactions.markHasDownloadedContacts(self.walletInfo.encryptedNodeId)
+				Prefs.shared.backupTransactions.markHasDownloadedContacts(walletId)
 				self.consecutiveErrorCount = 0
 				
 				if let newState = await self.actor.didDownloadContacts() {

--- a/phoenix-ios/phoenix-ios/sync/SyncBackupManager+Payments.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncBackupManager+Payments.swift
@@ -238,7 +238,7 @@ extension SyncBackupManager {
 				
 				log.trace("downloadPayments(): finish: success")
 				
-				Prefs.shared.backupTransactions.markHasDownloadedPayments(self.encryptedNodeId)
+				Prefs.shared.backupTransactions.markHasDownloadedPayments(walletId)
 				self.consecutiveErrorCount = 0
 				
 				if let newState = await self.actor.didDownloadPayments() {

--- a/phoenix-ios/phoenix-ios/sync/SyncManager.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncManager.swift
@@ -36,6 +36,7 @@ class SyncManager {
 			walletInfo: walletInfo
 		)
 		syncBackupManager = SyncBackupManager(
+			chain: chain,
 			walletInfo: walletInfo
 		)
 		

--- a/phoenix-ios/phoenix-ios/sync/SyncSeedManager.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncSeedManager.swift
@@ -49,9 +49,10 @@ class SyncSeedManager: SyncManagerProtcol {
 	///
 	private let recoveryPhrase: RecoveryPhrase
 	
-	/// The wallet info, such as nodeID, cloudKey, etc.
+	/// The wallet's unique identification in the cloud.
+	/// Also used in Prefs.
 	///
-	private let walletInfo: WalletManager.WalletInfo
+	private let walletId: WalletIdentifier
 	
 	/// Informs the user interface regarding the activities of the SyncSeedManager.
 	/// This includes various errors & active upload progress.
@@ -78,13 +79,13 @@ class SyncSeedManager: SyncManagerProtcol {
 		
 		self.chain = chain
 		self.recoveryPhrase = recoveryPhrase
-		self.walletInfo = walletInfo
+		
+		let _walletId = WalletIdentifier(chain: chain, walletInfo: walletInfo)
+		self.walletId = _walletId
 		
 		actor = SyncSeedManager_Actor(
 			isEnabled: Prefs.shared.backupSeed.isEnabled,
-			hasUploadedSeed: Prefs.shared.backupSeed.hasUploadedSeed(
-				encryptedNodeId: walletInfo.encryptedNodeId
-			)
+			hasUploadedSeed: Prefs.shared.backupSeed.hasUploadedSeed(_walletId)
 		)
 		statePublisher = CurrentValueSubject<SyncSeedManager_State, Never>(actor.initialState)
 		
@@ -92,10 +93,6 @@ class SyncSeedManager: SyncManagerProtcol {
 		startNameMonitor()
 		
 		startUpgradeTask()
-	}
-	
-	var encryptedNodeId: String {
-		walletInfo.encryptedNodeId
 	}
 	
 	// ----------------------------------------
@@ -558,7 +555,7 @@ class SyncSeedManager: SyncManagerProtcol {
 	private func uploadSeed() {
 		log.trace("uploadSeed()")
 		
-		let uploadedName = Prefs.shared.backupSeed.name(encryptedNodeId: encryptedNodeId) ?? ""
+		let uploadedName = Prefs.shared.backupSeed.name(walletId) ?? ""
 		Task {
 			log.trace("uploadSeed(): starting task")
 			
@@ -632,14 +629,14 @@ class SyncSeedManager: SyncManagerProtcol {
 					// Since this is an async process, the user may have changed the seed name again
 					// while we were uploading the original name. So we need to check for that.
 					
-					let currentName = Prefs.shared.backupSeed.name(encryptedNodeId: self.encryptedNodeId) ?? ""
+					let currentName = Prefs.shared.backupSeed.name(walletId) ?? ""
 					let needsReUpload = currentName != uploadedName
 					
 					if needsReUpload {
 						log.debug("uploadSeed(): finished: needsReUpload")
 					} else {
 						log.trace("uploadSeed(): finished: success")
-						Prefs.shared.backupSeed.setHasUploadedSeed(true, encryptedNodeId: self.encryptedNodeId)
+						Prefs.shared.backupSeed.setHasUploadedSeed(true, walletId)
 					}
 					self.consecutiveErrorCount = 0
 					
@@ -730,7 +727,7 @@ class SyncSeedManager: SyncManagerProtcol {
 					
 					log.trace("deleteSeed(): finish: success")
 					
-					Prefs.shared.backupSeed.setHasUploadedSeed(false, encryptedNodeId: self.encryptedNodeId)
+					Prefs.shared.backupSeed.setHasUploadedSeed(false, walletId)
 					self.consecutiveErrorCount = 0
 					
 					Task {
@@ -765,7 +762,7 @@ class SyncSeedManager: SyncManagerProtcol {
 	private func recordID() -> CKRecord.ID {
 		
 		return CKRecord.ID(
-			recordName: encryptedNodeId,
+			recordName: walletId.encryptedNodeId,
 			zoneID: CKRecordZone.default().zoneID
 		)
 	}

--- a/phoenix-ios/phoenix-ios/utils/WalletIdentifier.swift
+++ b/phoenix-ios/phoenix-ios/utils/WalletIdentifier.swift
@@ -1,0 +1,24 @@
+import Foundation
+import PhoenixShared
+
+struct WalletIdentifier {
+	let chain: Bitcoin_kmpChain
+	let encryptedNodeId: String
+	
+	init(chain: Bitcoin_kmpChain, encryptedNodeId: String) {
+		self.chain = chain
+		self.encryptedNodeId = encryptedNodeId
+	}
+	
+	init(chain: Bitcoin_kmpChain, walletInfo: WalletManager.WalletInfo) {
+		self.init(chain: chain, encryptedNodeId: walletInfo.encryptedNodeId)
+	}
+	
+	var prefsKeySuffix: String {
+		if chain.isMainnet() {
+			return encryptedNodeId
+		} else {
+			return "\(encryptedNodeId)-\(chain.phoenixName)"
+		}
+	}
+}

--- a/phoenix-ios/phoenix-ios/views/configuration/ConfigurationView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/ConfigurationView.swift
@@ -56,7 +56,7 @@ struct ConfigurationList: View {
 	@State private var backupSeedState: BackupSeedState = .safelyBackedUp
 	let backupSeedStatePublisher: AnyPublisher<BackupSeedState, Never>
 	
-	@State var firstAppearance = false
+	@State var didAppear = false
 	
 	@State var biometricSupport = AppSecurity.shared.deviceBiometricSupport()
 	
@@ -488,8 +488,8 @@ struct ConfigurationList: View {
 	func onAppear() {
 		log.trace("onAppear()")
 		
-		if firstAppearance {
-			firstAppearance = false
+		if !didAppear {
+			didAppear = true
 			
 			if let deepLink = deepLinkManager.deepLink {
 				DispatchQueue.main.async {

--- a/phoenix-ios/phoenix-ios/views/configuration/ConfigurationView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/ConfigurationView.swift
@@ -100,8 +100,8 @@ struct ConfigurationList: View {
 	init(scrollViewProxy: ScrollViewProxy) {
 		
 		self.scrollViewProxy = scrollViewProxy
-		if let encryptedNodeId = Biz.encryptedNodeId {
-			backupSeedStatePublisher = Prefs.shared.backupSeedStatePublisher(encryptedNodeId)
+		if let walletId = Biz.walletId {
+			backupSeedStatePublisher = Prefs.shared.backupSeedStatePublisher(walletId)
 		} else {
 			backupSeedStatePublisher = PassthroughSubject<BackupSeedState, Never>().eraseToAnyPublisher()
 		}

--- a/phoenix-ios/phoenix-ios/views/configuration/danger zone/drain wallet/DrainWalletView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/danger zone/drain wallet/DrainWalletView.swift
@@ -20,7 +20,6 @@ struct DrainWalletView: MVIView {
 	var factory: ControllerFactory { return factoryEnv }
 	
 	let popTo: (PopToDestination) -> Void
-	let encryptedNodeId = Biz.encryptedNodeId!
 	
 	@State var didAppear = false
 

--- a/phoenix-ios/phoenix-ios/views/configuration/danger zone/drain wallet/DrainWalletView_Confirm.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/danger zone/drain wallet/DrainWalletView_Confirm.swift
@@ -94,6 +94,7 @@ struct DrainWalletView_Confirm: MVISubView {
 					.font(.system(.callout, design: .monospaced).weight(.semibold))
 				
 			} // </VStack>
+			.frame(maxWidth: .infinity)
 			.multilineTextAlignment(.center)
 			.padding(.vertical, 5)
 			

--- a/phoenix-ios/phoenix-ios/views/configuration/danger zone/reset wallet/ResetWalletView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/danger zone/reset wallet/ResetWalletView.swift
@@ -19,7 +19,7 @@ struct ResetWalletView: MVIView {
 	@Environment(\.controllerFactory) var factoryEnv
 	var factory: ControllerFactory { return factoryEnv }
 	
-	let encryptedNodeId = Biz.encryptedNodeId!
+	let walletId = Biz.walletId!
 	
 	@State var deleteSeedBackup: Bool = false
 	@State var deleteTransactionHistory: Bool = false
@@ -33,9 +33,7 @@ struct ResetWalletView: MVIView {
 	@State var backupSeed_enabled = Prefs.shared.backupSeed.isEnabled
 	
 	let manualBackup_taskDone_publisher = Prefs.shared.backupSeed.manualBackup_taskDone_publisher
-	@State var manualBackup_taskDone = Prefs.shared.backupSeed.manualBackup_taskDone(
-		encryptedNodeId: Biz.encryptedNodeId!
-	)
+	@State var manualBackup_taskDone = Prefs.shared.backupSeed.manualBackup_taskDone(Biz.walletId!)
 	
 	// <iOS_16_workarounds>
 	@State var navLinkTag: NavLinkTag? = nil
@@ -75,8 +73,7 @@ struct ResetWalletView: MVIView {
 			self.backupSeed_enabled = $0
 		}
 		.onReceive(manualBackup_taskDone_publisher) {
-			self.manualBackup_taskDone =
-				Prefs.shared.backupSeed.manualBackup_taskDone(encryptedNodeId: encryptedNodeId)
+			self.manualBackup_taskDone = Prefs.shared.backupSeed.manualBackup_taskDone(walletId)
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/configuration/general/payment options/PaymentOptionsView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/general/payment options/PaymentOptionsView.swift
@@ -35,7 +35,7 @@ struct PaymentOptionsList: View {
 	
 	@State var notificationSettings = NotificationsManager.shared.settings.value
 	
-	@State var firstAppearance = true
+	@State var didAppear = false
 	
 	// <iOS_16_workarounds>
 	@State var navLinkTag: NavLinkTag? = nil
@@ -312,8 +312,8 @@ struct PaymentOptionsList: View {
 	func onAppear() {
 		log.trace("onAppear()")
 		
-		if firstAppearance {
-			firstAppearance = false
+		if !didAppear {
+			didAppear = true
 			
 			if let deepLink = deepLinkManager.deepLink {
 				DispatchQueue.main.async { // iOS 14 issues workaround

--- a/phoenix-ios/phoenix-ios/views/configuration/privacy and security/app access/AppAccessView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/privacy and security/app access/AppAccessView.swift
@@ -57,8 +57,8 @@ struct AppAccessView : View {
 		
 		_customPinSet = State(initialValue: AppSecurity.shared.hasCustomPin())
 		
-		if let encryptedNodeId = Biz.encryptedNodeId {
-			backupSeedStatePublisher = Prefs.shared.backupSeedStatePublisher(encryptedNodeId)
+		if let walletId = Biz.walletId {
+			backupSeedStatePublisher = Prefs.shared.backupSeedStatePublisher(walletId)
 		} else {
 			backupSeedStatePublisher = PassthroughSubject<BackupSeedState, Never>().eraseToAnyPublisher()
 		}

--- a/phoenix-ios/phoenix-ios/views/configuration/privacy and security/recovery phrase/CloudBackupView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/privacy and security/recovery phrase/CloudBackupView.swift
@@ -21,7 +21,7 @@ struct CloudBackupView: View {
 	
 	@State var animatingLegalToggleColor = false
 	
-	let encryptedNodeId: String
+	let walletId: WalletIdentifier
 	@State var originalName: String = ""
 	@State var name: String = ""
 	
@@ -31,7 +31,7 @@ struct CloudBackupView: View {
 	init(backupSeed_enabled: Binding<Bool>) {
 		
 		self._backupSeed_enabled = backupSeed_enabled
-		self.encryptedNodeId = Biz.encryptedNodeId!
+		self.walletId = Biz.walletId!
 	}
 	
 	// --------------------------------------------------
@@ -308,7 +308,7 @@ struct CloudBackupView: View {
 		legal_appleRisk = original_appleRisk
 		legal_governmentRisk = original_governmentRisk
 		
-		originalName = Prefs.shared.backupSeed.name(encryptedNodeId: encryptedNodeId) ?? ""
+		originalName = Prefs.shared.backupSeed.name(walletId) ?? ""
 		name = originalName
 	}
 	
@@ -372,11 +372,11 @@ struct CloudBackupView: View {
 			// But it might result in 2 uploads.
 			//
 			if toggle_enabled {
-				Prefs.shared.backupSeed.setName(name, encryptedNodeId: encryptedNodeId)
+				Prefs.shared.backupSeed.setName(name, walletId)
 				Prefs.shared.backupSeed.isEnabled = toggle_enabled
 			} else {
 				Prefs.shared.backupSeed.isEnabled = toggle_enabled
-				Prefs.shared.backupSeed.setName(name, encryptedNodeId: encryptedNodeId)
+				Prefs.shared.backupSeed.setName(name, walletId)
 			}
 		} else {
 			log.trace("!hasChanges || !canSave")

--- a/phoenix-ios/phoenix-ios/views/configuration/privacy and security/recovery phrase/RecoveryPhraseView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/privacy and security/recovery phrase/RecoveryPhraseView.swift
@@ -27,7 +27,7 @@ struct RecoveryPhraseList: View {
 	}
 	
 	let scrollViewProxy: ScrollViewProxy
-	let encryptedNodeId: String
+	let walletId: WalletIdentifier
 	
 	@State var manualBackup_taskDone: Bool
 	@State var backupSeed_enabled: Bool
@@ -68,11 +68,11 @@ struct RecoveryPhraseList: View {
 	init(scrollViewProxy: ScrollViewProxy) {
 		self.scrollViewProxy = scrollViewProxy
 		
-		let encryptedNodeId = Biz.encryptedNodeId!
-		self.encryptedNodeId = encryptedNodeId
+		let walletId = Biz.walletId!
+		self.walletId = walletId
 		self.syncSeedManager = Biz.syncManager!.syncSeedManager
 		
-		let manualBackup_taskDone = Prefs.shared.backupSeed.manualBackup_taskDone(encryptedNodeId: encryptedNodeId)
+		let manualBackup_taskDone = Prefs.shared.backupSeed.manualBackup_taskDone(walletId)
 		self._manualBackup_taskDone = State<Bool>(initialValue: manualBackup_taskDone)
 		
 		let backupSeed_enabled = Prefs.shared.backupSeed.isEnabled
@@ -564,7 +564,7 @@ struct RecoveryPhraseList: View {
 		if taskDone != manualBackup_taskDone {
 			
 			manualBackup_taskDone = taskDone
-			Prefs.shared.backupSeed.manualBackup_setTaskDone(taskDone, encryptedNodeId: encryptedNodeId)
+			Prefs.shared.backupSeed.manualBackup_setTaskDone(taskDone, walletId)
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/DetailsView.swift
@@ -1113,7 +1113,7 @@ fileprivate struct DetailsInfoGrid: InfoGridView {
 				Button {
 					requestSwitchToPayment(paymentId)
 				} label: {
-					Text(paymentId.dbId)
+					Text(verbatim: "\(paymentId.dbId.prefix(maxLength: 8))…")
 						.lineLimit(1)
 						.truncationMode(.middle)
 				}

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryInfoGrid.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryInfoGrid.swift
@@ -645,7 +645,7 @@ struct SummaryInfoGrid: InfoGridView { // See InfoGridView for architecture disc
 					Button {
 						switchToPayment(paymentId)
 					} label: {
-						Text(paymentId.dbId)
+						Text(verbatim: "\(paymentId.dbId.prefix(maxLength: 8))…")
 							.lineLimit(1)
 							.truncationMode(.middle)
 					}

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryInfoGrid.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryInfoGrid.swift
@@ -87,9 +87,6 @@ struct SummaryInfoGrid: InfoGridView { // See InfoGridView for architecture disc
 			paymentErrorRow()
 		}
 		.padding([.leading, .trailing])
-		.onAppear {
-			onAppear()
-		}
 	}
 	
 	@ViewBuilder
@@ -690,27 +687,6 @@ struct SummaryInfoGrid: InfoGridView { // See InfoGridView for architecture disc
 				Text(pError)
 				
 			} // </InfoGridRow>
-		}
-	}
-	
-	// --------------------------------------------------
-	// MARK: Notifications
-	// --------------------------------------------------
-	
-	func onAppear() {
-		log.trace("onAppear()")
-		
-		if let liquidity = paymentInfo.payment as? Lightning_kmpInboundLiquidityOutgoingPayment {
-			log.debug("is: Lightning_kmpInboundLiquidityOutgoingPayment")
-			
-			if let paymentId = liquidity.relatedPaymentIds().first {
-				log.debug("paymentId = \(paymentId.dbId)")
-			} else {
-				log.debug("paymentId = nil")
-			}
-			
-		} else {
-			log.debug("is NOT: Lightning_kmpInboundLiquidityOutgoingPayment")
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
@@ -1116,12 +1116,26 @@ struct SummaryView: View {
 			
 			// First time displaying the SummaryView (coming from HomeView)
 			
+			// Not triggered in this particular case, so we need to trigger it manually.
+			//
+			// Note:
+			// The flow below won't automatically trigger `paymentInfoChanged` if:
+			// - !paymentInfoIsState
+			// - or the fetched payment is equal to the existing payment
+			//
+			// The latter happens when:
+			// - lastCompletedPaymentPublisher fires
+			// - HomeView fetches the payment with FetchOptions.All
+			// - HomeView displays the PaymentView with fetched `paymentInfo`
+			// - If we fetch the payment again here, it's equal to the existing payment
+			//
+			paymentInfoChanged()
+			
 			if paymentInfoIsStale {
 				// We either don't have the full payment information (missing metadata info),
 				// or the payment information is possibly stale, and needs to be refreshed.
 				
 				if let row = paymentInfo.toOrderRow() {
-
 					Biz.business.paymentsManager.fetcher.getPayment(row: row, options: fetchOptions) {
 						(result: WalletPaymentInfo?, _) in
 						
@@ -1129,9 +1143,7 @@ struct SummaryView: View {
 							paymentInfo = result
 						}
 					}
-
 				} else {
-				
 					Biz.business.paymentsManager.getPayment(id: paymentInfo.id(), options: fetchOptions) {
 						(result: WalletPaymentInfo?, _) in
 						
@@ -1140,9 +1152,6 @@ struct SummaryView: View {
 						}
 					}
 				}
-			} else {
-				// Not triggered in this particular case, so we need to trigger it manually.
-				paymentInfoChanged()
 			}
 			
 		} else {

--- a/phoenix-ios/phoenix-ios/views/notifications/NoticeMonitor.swift
+++ b/phoenix-ios/phoenix-ios/views/notifications/NoticeMonitor.swift
@@ -13,9 +13,7 @@ class NoticeMonitor: ObservableObject {
 	
 	@Published private var isNewWallet = Prefs.shared.isNewWallet
 	@Published private var backupSeed_enabled = Prefs.shared.backupSeed.isEnabled
-	@Published private var manualBackup_taskDone = Prefs.shared.backupSeed.manualBackup_taskDone(
-		encryptedNodeId: Biz.encryptedNodeId!
-	)
+	@Published private var manualBackup_taskDone = Prefs.shared.backupSeed.manualBackup_taskDone(Biz.walletId!)
 	
 	@Published private var walletContext: WalletContext? = nil
 	
@@ -44,9 +42,7 @@ class NoticeMonitor: ObservableObject {
 		
 		Prefs.shared.backupSeed.manualBackup_taskDone_publisher
 			.sink {[weak self] _ in
-				self?.manualBackup_taskDone = Prefs.shared.backupSeed.manualBackup_taskDone(
-					encryptedNodeId: Biz.encryptedNodeId!
-				)
+				self?.manualBackup_taskDone = Prefs.shared.backupSeed.manualBackup_taskDone(Biz.walletId!)
 			}
 			.store(in: &cancellables)
 		


### PR DESCRIPTION
Various UI bugs have been fixed:

> a) upon receiving a payment that opens a channel (i.e., this is the case where the incoming payment should show the fee), then the splash screen does not show the fee. However it you close the details, then opens it again (for the same payment), then it shows the fee correctly.

Fixed in ab99997cba564f2ebac7af1ae427df859a402d39

> b) the "caused by" link button should have a max width (like show the first 8 chars), it would look better and it would also make the `?` button more visible (right now the `?` is squished at the edge of the screen)

Fixed in b5fd857b9e3d0ae03417328e32bd7fbb19675a10

> c) payment details screen from Home: the Details / Edit buttons are too tall (see the grey line separator)

Fixed in c65e28418a7aa6cc907db05e6f9ba3c062bd85e6
(bug only reproduces in iOS 16)

> d) payment details screen from payments history: the Details / Edit / Delete buttons are weirdly aligned

Fixed in c65e28418a7aa6cc907db05e6f9ba3c062bd85e6
(bug only reproduces in iOS 16)

> e) if the payment is unconfirmed, then first we show a spinner while we check Electrum for confirmation -- section which height is X -- and once we got that confirmation status, we display "0 confirmation" + "broadcast at ...." -- section which height is Y. Since X < Y, then the whole UI is jumps around when we get the confirmation result, which does not look good

Fixed in 1000bc56ac93098d6b55283d44f596723aba894a

f) clicking on the "backup your recovery phrase" notification in the Home navigates to the settings screen and not the recovery phrase screen

Fixed in 80c08270d1abeeed09d2fec4d497374018111c92
(bug only reproduces in iOS 16)

---

We also encountered some issues because we were testing with the same seed on both testnet & mainnet. Part of the problem was due to overlapping Preference keys.

For example, we had a key called `hasDownloadedPayments`, that was stored using the name `hasDownloadedPayments-(encryptedNodeID)`. This would help us differentiate between different wallets, but didn't properly differentiate in the above scenario.

So now we use a smarter key structure:
- on mainnet: `(keyName)-(encryptedNodeID)` (same as before)
- on testnet: `(keyName)-(encryptedNodeID)-(chainName)`