### PR TITLE
Ignore empty liquidity purchases

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/InboundLiquidityQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/InboundLiquidityQueries.kt
@@ -43,6 +43,7 @@ class InboundLiquidityQueries(val database: PaymentsDatabase) {
                    is LiquidityAds.Purchase.WithFeeCredit -> "WITH_FEE_CREDIT"
                },
                lease_blob = payment.purchase.encodeAsDb(),
+               liquidity_amount_sat = payment.purchase.amount.sat,
                payment_details_type = when (payment.purchase.paymentDetails) {
                    is LiquidityAds.PaymentDetails.FromChannelBalance -> "FROM_CHANNEL_BALANCE"
                    is LiquidityAds.PaymentDetails.FromFutureHtlc -> "FROM_FUTURE_HTLC"

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/AggregatedQueries.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/AggregatedQueries.sq
@@ -49,6 +49,8 @@ UNION ALL
         locked_at    AS completed_at,
         created_at   AS order_ts
     FROM inbound_liquidity_outgoing_payments
+    -- only retrieve liquidity purchases that are legacy (amount null) or that are not linked to new-otf-swap-ins (which only add 1 sat liquidity)
+    WHERE liquidity_amount_sat IS NULL OR liquidity_amount_sat > 1
 UNION ALL
     SELECT
         1                        AS type,
@@ -77,6 +79,7 @@ SELECT SUM(result) AS result FROM (
     SELECT COUNT(*) AS result FROM splice_cpfp_outgoing_payments
     UNION ALL
     SELECT COUNT(*) AS result FROM inbound_liquidity_outgoing_payments
+    WHERE liquidity_amount_sat IS NULL OR liquidity_amount_sat > 1
     UNION ALL
     SELECT COUNT(*) AS result FROM incoming_payments WHERE received_at IS NOT NULL AND received_with_blob IS NOT NULL
 );
@@ -136,6 +139,7 @@ UNION ALL
         locked_at    AS completed_at
     FROM inbound_liquidity_outgoing_payments
     WHERE locked_at >= :date
+    AND (liquidity_amount_sat IS NULL OR liquidity_amount_sat > 1)
 UNION ALL
     SELECT
         1                        AS type,
@@ -226,6 +230,7 @@ UNION ALL
     FROM inbound_liquidity_outgoing_payments
     WHERE inbound_liquidity_outgoing_payments.locked_at IS NOT NULL
     AND   inbound_liquidity_outgoing_payments.locked_at BETWEEN :startDate AND :endDate
+    AND   (inbound_liquidity_outgoing_payments.liquidity_amount_sat IS NULL OR inbound_liquidity_outgoing_payments.liquidity_amount_sat > 1)
 UNION ALL
     SELECT
         1                        AS type,
@@ -268,6 +273,7 @@ UNION ALL
     FROM inbound_liquidity_outgoing_payments
     WHERE inbound_liquidity_outgoing_payments.locked_at IS NOT NULL
     AND   inbound_liquidity_outgoing_payments.locked_at BETWEEN :startDate AND :endDate
+    AND   (inbound_liquidity_outgoing_payments.liquidity_amount_sat IS NULL OR inbound_liquidity_outgoing_payments.liquidity_amount_sat > 1)
 UNION ALL
     SELECT COUNT(*) AS result FROM incoming_payments
     WHERE incoming_payments.received_at BETWEEN :startDate AND :endDate

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/AggregatedQueries.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/AggregatedQueries.sq
@@ -49,7 +49,7 @@ UNION ALL
         locked_at    AS completed_at,
         created_at   AS order_ts
     FROM inbound_liquidity_outgoing_payments
-    -- only retrieve liquidity purchases that are legacy (amount null) or that are not linked to new-otf-swap-ins (which only add 1 sat liquidity)
+    -- only retrieve liquidity purchases that are legacy (amount=null) or that do not request liquidity (i.e. amount=1 sat, which is a workaround for liquidity ads)
     WHERE liquidity_amount_sat IS NULL OR liquidity_amount_sat > 1
 UNION ALL
     SELECT

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/InboundLiquidityOutgoing.sq
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/InboundLiquidityOutgoing.sq
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS inbound_liquidity_outgoing_payments (
     tx_id BLOB NOT NULL,
     lease_type TEXT NOT NULL,
     lease_blob BLOB NOT NULL,
+    liquidity_amount_sat INTEGER DEFAULT NULL,
     payment_details_type TEXT DEFAULT NULL,
     created_at INTEGER NOT NULL,
     confirmed_at INTEGER DEFAULT NULL,
@@ -15,8 +16,8 @@ CREATE TABLE IF NOT EXISTS inbound_liquidity_outgoing_payments (
 
 insert:
 INSERT INTO inbound_liquidity_outgoing_payments (
-    id, mining_fees_sat, channel_id, tx_id, lease_type, lease_blob, payment_details_type, created_at, confirmed_at, locked_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    id, mining_fees_sat, channel_id, tx_id, lease_type, lease_blob, liquidity_amount_sat, payment_details_type, created_at, confirmed_at, locked_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 setConfirmed:
 UPDATE inbound_liquidity_outgoing_payments SET confirmed_at=? WHERE id=?;

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/10.sqm
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/10.sqm
@@ -1,5 +1,3 @@
-import fr.acinq.phoenix.db.payments.InboundLiquidityLeaseTypeVersion;
-
 -- Migration: v10 -> v11
 --
 -- Changes:

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/10.sqm
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/10.sqm
@@ -1,0 +1,8 @@
+import fr.acinq.phoenix.db.payments.InboundLiquidityLeaseTypeVersion;
+
+-- Migration: v10 -> v11
+--
+-- Changes:
+-- * Added a new column [liquidity_amount_sat] in table [inbound_liquidity_outgoing_payments]
+
+ALTER TABLE inbound_liquidity_outgoing_payments ADD COLUMN liquidity_amount_sat INTEGER DEFAULT NULL;

--- a/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/9.sqm
+++ b/phoenix-shared/src/commonMain/paymentsdb/fr.acinq.phoenix.db/migrations/9.sqm
@@ -1,5 +1,3 @@
-import fr.acinq.phoenix.db.payments.InboundLiquidityLeaseTypeVersion;
-
 -- Migration: v9 -> v10
 --
 -- Changes:


### PR DESCRIPTION
In some scenarios, we may have to execute liquidity purchases that request no liquidity (for example, channel creation from a swap-in). Due to limitations in how liquidity ads works, these purchases must request a minimal liquidity amount (we use 1 sat). This means that the UI displays 1 sat liquidity purchases. Moreover the fee incurred by these swap-ins is displayed twice (once in the liquidity purchase, and once in the swap-in details).

To avoid any confusion, this PR updates the aggregation SQL queries to ignore empty liquidity purchases (includes the CSV export).