### PR TITLE
(ios) Add UI to spend from final wallet

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -95,7 +95,7 @@
 		DC370A892B7FBD7C0093C56F /* BtcAddrOptionsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC370A882B7FBD7C0093C56F /* BtcAddrOptionsSheet.swift */; };
 		DC370A8B2B7FFFC70093C56F /* SwapInAddresses.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC370A8A2B7FFFC70093C56F /* SwapInAddresses.swift */; };
 		DC3780392C04D60400937C8E /* KotlinEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3780382C04D60400937C8E /* KotlinEnums.swift */; };
-		DC37803B2C050F7000937C8E /* SpendExpiredSwapIns.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC37803A2C050F7000937C8E /* SpendExpiredSwapIns.swift */; };
+		DC37803B2C050F7000937C8E /* SpendOnChainFunds.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC37803A2C050F7000937C8E /* SpendOnChainFunds.swift */; };
 		DC37803D2C05215600937C8E /* ScanBitcoinAddressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC37803C2C05215600937C8E /* ScanBitcoinAddressSheet.swift */; };
 		DC37803F2C06338000937C8E /* BtcAddressInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC37803E2C06338000937C8E /* BtcAddressInput.swift */; };
 		DC3780412C077E0300937C8E /* PriorityBoxStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3780402C077E0300937C8E /* PriorityBoxStyle.swift */; };
@@ -515,7 +515,7 @@
 		DC370A882B7FBD7C0093C56F /* BtcAddrOptionsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BtcAddrOptionsSheet.swift; sourceTree = "<group>"; };
 		DC370A8A2B7FFFC70093C56F /* SwapInAddresses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapInAddresses.swift; sourceTree = "<group>"; };
 		DC3780382C04D60400937C8E /* KotlinEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinEnums.swift; sourceTree = "<group>"; };
-		DC37803A2C050F7000937C8E /* SpendExpiredSwapIns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendExpiredSwapIns.swift; sourceTree = "<group>"; };
+		DC37803A2C050F7000937C8E /* SpendOnChainFunds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendOnChainFunds.swift; sourceTree = "<group>"; };
 		DC37803C2C05215600937C8E /* ScanBitcoinAddressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanBitcoinAddressSheet.swift; sourceTree = "<group>"; };
 		DC37803E2C06338000937C8E /* BtcAddressInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BtcAddressInput.swift; sourceTree = "<group>"; };
 		DC3780402C077E0300937C8E /* PriorityBoxStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriorityBoxStyle.swift; sourceTree = "<group>"; };
@@ -1529,7 +1529,7 @@
 				DC43096D2A7953F400E28995 /* FinalWalletDetails.swift */,
 				DC43096F2A795F9900E28995 /* UtxoWrapper.swift */,
 				DC370A8A2B7FFFC70093C56F /* SwapInAddresses.swift */,
-				DC37803A2C050F7000937C8E /* SpendExpiredSwapIns.swift */,
+				DC37803A2C050F7000937C8E /* SpendOnChainFunds.swift */,
 			);
 			path = wallet;
 			sourceTree = "<group>";
@@ -1861,7 +1861,7 @@
 				DCA7263D2C80BC0800600716 /* SyncBackupManager+Contacts.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 				DCFB8DF92A94112A00947698 /* Dictionary+MapKeys.swift in Sources */,
-				DC37803B2C050F7000937C8E /* SpendExpiredSwapIns.swift in Sources */,
+				DC37803B2C050F7000937C8E /* SpendOnChainFunds.swift in Sources */,
 				DCB876322735AAB500657570 /* UserDefaults+Codable.swift in Sources */,
 				DCD777D226DE9FE800979A12 /* DelayedSave.swift in Sources */,
 				DCEE3E542931446A00EB4DFF /* Collections+AsInt.swift in Sources */,
@@ -1895,7 +1895,6 @@
 				DC0C52662BF3C31700143831 /* WhichPinSheet.swift in Sources */,
 				DCD1208728663F4A00EB39C5 /* TransactionsView.swift in Sources */,
 				DC70A99C2BBB6093002DBFF8 /* InboundFeeWarning.swift in Sources */,
-				DC118BFC27B4504B0080BBAC /* ScanView.swift in Sources */,
 				DC8D94142CA7015F00EE844E /* ChannelFundingProblem.swift in Sources */,
 				DC46BAF326CACCF700E760A6 /* KotlinExtensions+Other.swift in Sources */,
 				DCB5D2DF280879460020B8F5 /* DeviceInfo.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -38050,6 +38050,9 @@
         }
       }
     },
+    "Spend from final wallet" : {
+
+    },
     "Spending = pouring water out\nReceiving = adding more water" : {
       "localizations" : {
         "ar" : {
@@ -45094,7 +45097,14 @@
         }
       }
     },
+    "Use this screen to spend funds from your final wallet. These funds come from channels that have been closed in the past. This does not affect your existing Lightning channels." : {
+
+    },
+    "Use this screen to spend your on-chain funds that were not swapped in time. The swap-in request has now expired." : {
+
+    },
     "Use this screen to spend your on-chain funds that were not swapped in time. The swap-in request has now expired. " : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/SwapInWalletDetails.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/SwapInWalletDetails.swift
@@ -397,7 +397,7 @@ struct SwapInWalletDetails: View {
 	func navLinkView(_ tag: NavLinkTag) -> some View {
 		
 		switch tag {
-			case .SpendExpiredSwapIns: SpendExpiredSwapIns()
+		case .SpendExpiredSwapIns: SpendOnChainFunds(source: .expiredSwapIns)
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/send/MinerFeeInfo.swift
+++ b/phoenix-ios/phoenix-ios/views/send/MinerFeeInfo.swift
@@ -2,7 +2,8 @@ import Foundation
 import PhoenixShared
 
 struct MinerFeeInfo {
-	let pubKeyScript: Bitcoin_kmpByteVector
+	let pubKeyScript: Bitcoin_kmpByteVector? // For targets: .spliceOut
+	let transaction: Bitcoin_kmpTransaction? // For targets: .expiredSwapIn, .finalWallet
 	let feerate: Lightning_kmpFeeratePerKw
 	let minerFee: Bitcoin_kmpSatoshi
 }

--- a/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/ValidateView.swift
@@ -1863,8 +1863,11 @@ struct ValidateView: View {
 			log.warning("ignore: peer == nil")
 			return
 		}
-		guard let minerFeeInfo else {
-			log.warning("ignore: minerFeeInfo == nil")
+		guard
+			let minerFeeInfo,
+			let scriptPubKey = minerFeeInfo.pubKeyScript
+		else {
+			log.warning("ignore: minerFeeInfo info missing")
 			return
 		}
 		
@@ -1876,7 +1879,7 @@ struct ValidateView: View {
 			do {
 				let response = try await peer.spliceOut(
 					amount: amountSat,
-					scriptPubKey: minerFeeInfo.pubKeyScript,
+					scriptPubKey: scriptPubKey,
 					feerate: minerFeeInfo.feerate
 				)
 				

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
@@ -424,11 +424,3 @@ suspend fun Peer.betterPayOffer(
     send(PayOffer(paymentId, payerKey, payerNote, amount, offer, fetchInvoiceTimeoutInSeconds.seconds))
     return res.await()
 }
-
-fun fakeWallet(amount: Satoshi, swapInParams: SwapInParams): WalletState.WalletWithConfirmations {
-    val txIn = listOf(TxIn(OutPoint(TxId(randomBytes32()), 2), 0))
-    val txOut = listOf(TxOut(amount, Script.pay2wpkh(randomKey().publicKey())))
-    val parentTx = Transaction(2, txIn, txOut, 0)
-    val utxo = WalletState.Utxo(parentTx.txid, 0, 42, parentTx, WalletState.AddressMeta.Single)
-    return WalletState.WalletWithConfirmations(swapInParams, 100, listOf(utxo))
-}


### PR DESCRIPTION
This is the iOS version of #633 

<img height="450" src="https://github.com/user-attachments/assets/5e391457-32b9-445b-9778-7b33b49e65af"/>
&nbsp;&nbsp;&nbsp;&nbsp;
<img height="450" src="https://github.com/user-attachments/assets/b4b497c8-6a8b-4c47-bf49-ea9026f2e362"/>
&nbsp;&nbsp;&nbsp;
<img height="450" src="https://github.com/user-attachments/assets/98dbf7cb-7d15-4466-a15a-c682f96981a7"/>

On iOS, we re-used the same UI screen we were using for spending expired swap-ins. So just a little bit of refactoring was needed.

