### PR TITLE
(android) Fix settings text of experimental features

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/SettingsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/SettingsView.kt
@@ -109,7 +109,7 @@ fun SettingsView(
         Card {
             MenuButton(text = stringResource(R.string.settings_wallet_info), icon = R.drawable.ic_box, onClick = { nc.navigate(Screen.WalletInfo) })
             MenuButton(text = stringResource(R.string.settings_list_channels), icon = R.drawable.ic_zap, onClick = { nc.navigate(Screen.Channels) })
-            MenuButton(text = "Experimental features", icon = R.drawable.ic_experimental, onClick = { nc.navigate(Screen.Experimental) })
+            MenuButton(text = stringResource(R.string.experimental_title), icon = R.drawable.ic_experimental, onClick = { nc.navigate(Screen.Experimental) })
             MenuButton(text = stringResource(R.string.settings_logs), icon = R.drawable.ic_text, onClick = { nc.navigate(Screen.Logs) })
         }
         // -- advanced

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/SettingsView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/SettingsView.kt
@@ -109,7 +109,7 @@ fun SettingsView(
         Card {
             MenuButton(text = stringResource(R.string.settings_wallet_info), icon = R.drawable.ic_box, onClick = { nc.navigate(Screen.WalletInfo) })
             MenuButton(text = stringResource(R.string.settings_list_channels), icon = R.drawable.ic_zap, onClick = { nc.navigate(Screen.Channels) })
-            MenuButton(text = stringResource(R.string.experimental_title), icon = R.drawable.ic_experimental, onClick = { nc.navigate(Screen.Experimental) })
+            MenuButton(text = "Experimental features", icon = R.drawable.ic_experimental, onClick = { nc.navigate(Screen.Experimental) })
             MenuButton(text = stringResource(R.string.settings_logs), icon = R.drawable.ic_text, onClick = { nc.navigate(Screen.Logs) })
         }
         // -- advanced


### PR DESCRIPTION
## Context of the issue
I've noticed that in the settings page, the "Experimental features" button was NOT translated even though upon clicking it, the settings title was shown translated (it is the same text).
Below are 2 screenshots. The first one shows the untranslated text, the second one shows the same text but available in French.
![tempFileForShare_20241107-162325](https://github.com/user-attachments/assets/48802fb2-088f-428c-bdf5-67bcdfa77fa0)
![tempFileForShare_20241107-162344](https://github.com/user-attachments/assets/b0bcf4a2-01e0-47c9-aa13-61f3be3246ac)


So I figured the stringResource() might be missing, and it seems to be what's happening.
So here's a simple attempt at fixing it.

## Disclaimer
I'm very new to this... both Git and AndroidStudio.
I've NOT tested my commit
Please review accordingly 😅 