### PR TITLE
(ios) Fixing crash in iOS

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/notifications/ContactQueries.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/notifications/ContactQueries.kt
@@ -73,6 +73,14 @@ class ContactQueries(val database: AppDatabase) {
         }
     }
 
+    fun existsContact(contactId: UUID): Boolean {
+        return database.transactionWithResult {
+            queries.existsContact(
+                id = contactId.toString()
+            ).executeAsOne() > 0
+        }
+    }
+
     fun getContact(contactId: UUID): ContactInfo? {
         return database.transactionWithResult {
             queries.getContact(contactId = contactId.toString()).executeAsOneOrNull()?.let {

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/CloudKitContactsDb.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/CloudKitContactsDb.kt
@@ -121,9 +121,14 @@ class CloudKitContactsDb(
                 // Fetch the corresponding contact info from the database.
 
                 uniqueContactIds.forEach { contactId ->
-                    appDb.contactQueries.getContact(contactId)?.let {
-                        rowMap[contactId] = it
+                    if (appDb.contactQueries.existsContact(contactId)) {
+                        // appDb.contactQueries.getContact() throws if the contact
+                        // doesn't exist in database.
+                        appDb.contactQueries.getContact(contactId)?.let {
+                            rowMap[contactId] = it
+                        }
                     }
+
                 }
 
                 // Step 4 of 5:


### PR DESCRIPTION
Steps to reproduce:

> if you delete a contact then the ios app crashes (and will keep crashing). The issue is in CloudKitContactsDb.fetchQueueBatch which assumes that a contact exist (line 124) and if does not the db query fails and the app crashes

The problem function:

```kotlin
fun getContact(contactId: UUID): ContactInfo? {
  return database.transactionWithResult {
    queries.getContact(contactId = contactId.toString()).executeAsOneOrNull()?.let {
      val offers = it.offers.split(",").map {
        OfferTypes.Offer.decode(it)
      }.filterIsInstance<Try.Success<OfferTypes.Offer>>().map {
        it.get()
      }
      ContactInfo(contactId, it.name, it.photo_uri, it.use_offer_key, offers)
    }
  }
}
```

Even though the function signature suggests there's no problem if the contact doesn't exist, it still crashes when that's the case. My understanding is that it's due to the complex query being performed under the hood:

```
getContact:
SELECT
  id,
  name,
  photo_uri,
  use_offer_key,
  contacts.created_at,
  updated_at,
  group_concat(offer, ',') AS offers
FROM contacts AS contacts
JOIN contact_offers AS contact_offers ON contact_id = id
WHERE id = :contactId
ORDER BY contact_offers.created_at;
```

In other words, a simple query like the one below wouldn't suffer the same crash, and would just return an empty result set:

```
getContact2:
SELECT *
FROM contacts
WHERE id = :contactId;
```

So I've fixed the crash by adding an extra check to see if the contact exists before fetching it.

Note also that this crash is fixed via PR #640, because the query has been changed to the simple version above.