### PR TITLE
Replace home with migration screen in legacy app

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/receive/ReceiveLightningView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/receive/ReceiveLightningView.kt
@@ -193,23 +193,11 @@ fun LightningInvoiceView(
         TorWarning()
         HSeparator(width = 50.dp)
         Spacer(modifier = Modifier.height(24.dp))
-        Box {
-            FilledButton(
-                text = stringResource(id = R.string.receive_toggle_offer_button),
-                icon = R.drawable.ic_qrcode,
-                onClick = { showOfferDialog = true },
-            )
-            Text(
-                text = stringResource(id = R.string.receive_toggle_offer_new_overlay),
-                modifier = Modifier
-                    .rotate(-38f)
-                    .offset((-9).dp, (-4).dp)
-                    .background(red500)
-                    .padding(horizontal = 4.dp, vertical = 2.dp),
-                color = MaterialTheme.colors.onPrimary,
-                fontSize = 12.sp
-            )
-        }
+        FilledButton(
+            text = stringResource(id = R.string.receive_toggle_offer_button),
+            icon = R.drawable.ic_qrcode,
+            onClick = { showOfferDialog = true },
+        )
     }
 }
 

--- a/phoenix-android/src/main/res/values-cs/strings.xml
+++ b/phoenix-android/src/main/res/values-cs/strings.xml
@@ -91,7 +91,6 @@
     <string name="receive_lightning_share_subject">Lightningová faktura</string>
     <string name="receive_lightning_share_title">Sdílet tuto Lightningovou fakturu s…</string>
     <string name="receive_lnurl_button">Skenovat</string>
-    <string name="receive_toggle_offer_new_overlay">NOVINKA!</string>
 
     <string name="receive_offer_share_title">Statická Lightning faktura</string>
     <string name="receive_offer_share_subject">Sdílet tuto statickou Lightning fakturu s…</string>

--- a/phoenix-android/src/main/res/values-sk/strings.xml
+++ b/phoenix-android/src/main/res/values-sk/strings.xml
@@ -112,7 +112,6 @@
     <string name="receive_lightning_share_subject">Lightningová faktúra</string>
     <string name="receive_lightning_share_title">Zdieľať túto Lightningovú faktúru s…</string>
     <string name="receive_lnurl_button">Skenovanie</string>
-    <string name="receive_toggle_offer_new_overlay">NOVÉ!</string>
 
     <string name="receive_offer_share_title">Statická Lightningová faktúra</string>
     <string name="receive_offer_share_subject">Zdieľajte túto statickú Lightningovú faktúru s…</string>

--- a/phoenix-android/src/main/res/values-sw/strings.xml
+++ b/phoenix-android/src/main/res/values-sw/strings.xml
@@ -123,7 +123,6 @@
     <string name="receive_lightning_share_subject">Hati ya Lightning</string>
     <string name="receive_lightning_share_title">Shiriki hati ya Lightning na…</string>
     <string name="receive_lnurl_button">Piga picha</string>
-    <string name="receive_toggle_offer_new_overlay">MPYA!</string>
 
     <string name="receive_offer_share_title">Mkodishaji wa Bolt12</string>
     <string name="receive_offer_share_subject">Shiriki msimbo huu wa Bolt12 na…</string>

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -126,7 +126,6 @@
     <string name="receive_lightning_share_subject">Lightning invoice</string>
     <string name="receive_lightning_share_title">Share this Lightning invoice with…</string>
     <string name="receive_lnurl_button">Scan</string>
-    <string name="receive_toggle_offer_new_overlay">NEW!</string>
 
     <string name="receive_offer_share_title">Bolt12 payment code</string>
     <string name="receive_offer_share_subject">Share this Bolt12 payment code with…</string>

--- a/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/main/MainFragment.kt
+++ b/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/main/MainFragment.kt
@@ -16,282 +16,148 @@
 
 package fr.acinq.phoenix.legacy.main
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
-import android.content.Intent
-import android.content.SharedPreferences
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.animation.Animation
-import android.view.animation.AnimationUtils
+import android.widget.Toast
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.map
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.fragment.findNavController
-import androidx.preference.PreferenceManager
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import fr.acinq.eclair.MilliSatoshi
-import fr.acinq.eclair.WatchListener
-import fr.acinq.eclair.channel.HasCommitments
-import fr.acinq.eclair.channel.`WAIT_FOR_FUNDING_CONFIRMED$`
+import fr.acinq.bitcoin.scala.Satoshi
+import fr.acinq.eclair.`JsonSerializers$`
+import fr.acinq.phoenix.legacy.AppViewModel
 import fr.acinq.phoenix.legacy.BaseFragment
 import fr.acinq.phoenix.legacy.R
-import fr.acinq.phoenix.legacy.background.ChannelStateChange
-import fr.acinq.phoenix.legacy.background.KitState
-import fr.acinq.phoenix.legacy.background.PaymentPending
-import fr.acinq.phoenix.legacy.databinding.FragmentMainBinding
+import fr.acinq.phoenix.legacy.databinding.FragmentMainSunsetBinding
 import fr.acinq.phoenix.legacy.utils.Constants
-import fr.acinq.phoenix.legacy.utils.Converter
-import fr.acinq.phoenix.legacy.utils.Prefs
 import fr.acinq.phoenix.legacy.utils.Wallet
 import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Request
+import okhttp3.Response
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.json.JSONObject
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.text.DateFormat
-import java.util.*
+import upickle.`default$`
+import java.io.IOException
+import java.text.NumberFormat
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
-class MainFragment : BaseFragment(), SharedPreferences.OnSharedPreferenceChangeListener {
+class MainFragment : BaseFragment() {
 
   override val log: Logger = LoggerFactory.getLogger(this::class.java)
-  private lateinit var mBinding: FragmentMainBinding
-  private lateinit var model: MainViewModel
-
-  private lateinit var paymentsAdapter: PaymentsAdapter
-  private lateinit var paymentsManager: RecyclerView.LayoutManager
-
-  private lateinit var notificationsAdapter: NotificationsAdapter
-  private lateinit var notificationsManager: RecyclerView.LayoutManager
-
-  private lateinit var blinkingAnimation: Animation
-
-  private val prefsListener = SharedPreferences.OnSharedPreferenceChangeListener { _: SharedPreferences, key: String? ->
-    if (key == Prefs.PREFS_SHOW_AMOUNT_IN_FIAT) {
-      refreshIncomingFundsAmountField()
-    }
-  }
+  private lateinit var mBinding: FragmentMainSunsetBinding
+  private lateinit var model: MainSunsetViewModel
 
   override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-    mBinding = FragmentMainBinding.inflate(inflater, container, false)
+    mBinding = FragmentMainSunsetBinding.inflate(inflater, container, false)
     mBinding.lifecycleOwner = this
-
-    // init payment recycler view
-    paymentsManager = LinearLayoutManager(context)
-    paymentsAdapter = PaymentsAdapter()
-    paymentsAdapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
-      override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-        mBinding.paymentList.scrollToPosition(0)
-      }
-    })
-    mBinding.paymentList.apply {
-      setHasFixedSize(true)
-      layoutManager = paymentsManager
-      adapter = paymentsAdapter
-    }
-    // init notification recycler view
-    notificationsManager = LinearLayoutManager(context)
-    notificationsAdapter = NotificationsAdapter(mutableListOf())
-    mBinding.notificationList.apply {
-      setHasFixedSize(true)
-      layoutManager = notificationsManager
-      adapter = notificationsAdapter
-    }
-    blinkingAnimation = AnimationUtils.loadAnimation(context, R.anim.blinking)
     return mBinding.root
   }
 
   override fun onActivityCreated(savedInstanceState: Bundle?) {
     super.onActivityCreated(savedInstanceState)
-    model = ViewModelProvider(this).get(MainViewModel::class.java)
-    context?.let { ctx ->
-      appContext(ctx).notifications.observe(viewLifecycleOwner) {
-        notificationsAdapter.update(it)
-      }
-      app.networkInfo.observe(viewLifecycleOwner) {
-        if (it.electrumServer == null || !it.lightningConnected) {
-          if (mBinding.connectivityButton.animation == null || !mBinding.connectivityButton.animation.hasStarted()) {
-            mBinding.connectivityButton.startAnimation(blinkingAnimation)
-          }
-          mBinding.connectivityButton.visibility = View.VISIBLE
-          mBinding.torConnectedButton.visibility = View.GONE
-        } else if (Prefs.isTorEnabled(ctx)) {
-          if (it.torConnections.isEmpty()) {
-            if (mBinding.connectivityButton.animation == null || !mBinding.connectivityButton.animation.hasStarted()) {
-              mBinding.connectivityButton.startAnimation(blinkingAnimation)
-            }
-            mBinding.connectivityButton.visibility = View.VISIBLE
-            mBinding.torConnectedButton.visibility = View.GONE
-          } else {
-            mBinding.connectivityButton.clearAnimation()
-            mBinding.connectivityButton.visibility = View.GONE
-            mBinding.torConnectedButton.visibility = View.VISIBLE
-          }
-        } else {
-          mBinding.connectivityButton.clearAnimation()
-          mBinding.connectivityButton.visibility = View.GONE
-          mBinding.torConnectedButton.visibility = View.GONE
-        }
-      }
-      appContext(ctx).balance.observe(viewLifecycleOwner) {
-        mBinding.balance.setAmount(it.sendable)
-      }
-    }
-    app.pendingSwapIns.observe(viewLifecycleOwner) {
-      refreshIncomingFunds()
-    }
-    app.payments.observe(viewLifecycleOwner) { (paymentsCount, payments) ->
-      paymentsAdapter.submitList(
-        showFooter = paymentsCount > Constants.LATEST_PAYMENTS_COUNT,
-        list = payments.take(Constants.LATEST_PAYMENTS_COUNT)
-      )
-    }
-    model.incomingFunds.observe(viewLifecycleOwner) { amount ->
-      if (amount.`$greater`(MilliSatoshi(0))) {
-        refreshIncomingFundsAmountField()
-        mBinding.incomingFundsNotif.visibility = View.VISIBLE
-      } else {
-        mBinding.incomingFundsNotif.visibility = View.INVISIBLE
-      }
-    }
+    model = ViewModelProvider(this).get(MainSunsetViewModel::class.java)
+    mBinding.model = model
+    model.getFinalWalletBalance(app)
   }
 
   override fun onStart() {
     super.onStart()
-    if (!EventBus.getDefault().isRegistered(this)) {
-      EventBus.getDefault().register(this)
-    }
-    Wallet.hideKeyboard(context, mBinding.main)
-    context?.let { PreferenceManager.getDefaultSharedPreferences(it).registerOnSharedPreferenceChangeListener(prefsListener) }
-
-    context?.let {
-      refreshNotifications(it)
-      refreshBalanceDisplay(it)
-    }
 
     mBinding.settingsButton.setOnClickListener { findNavController().navigate(R.id.action_main_to_settings) }
-    mBinding.receiveButton.setOnClickListener { findNavController().navigate(R.id.action_main_to_receive) }
-    mBinding.sendButton.setOnClickListener { findNavController().navigate(R.id.action_main_to_read_input) }
-    mBinding.helpButton.setOnClickListener { startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://phoenix.acinq.co/faq"))) }
-    mBinding.torConnectedButton.setOnClickListener { findNavController().navigate(R.id.global_action_any_to_tor) }
-    mBinding.connectivityButton.setOnClickListener { findNavController().navigate(R.id.action_main_to_connectivity) }
-  }
-
-  override fun onStop() {
-    super.onStop()
-    EventBus.getDefault().unregister(this)
-    context?.let { PreferenceManager.getDefaultSharedPreferences(it).unregisterOnSharedPreferenceChangeListener(prefsListener) }
-  }
-
-  override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
-    context?.let {
-      when (key) {
-        Prefs.PREFS_SHOW_BALANCE_HOME -> refreshBalanceDisplay(it)
-        else -> refreshNotifications(it)
+    mBinding.upgradeButton.setOnClickListener { findNavController().navigate(R.id.action_main_to_migration) }
+    mBinding.copyDebugButton.setOnClickListener {
+      lifecycleScope.launch(CoroutineExceptionHandler { _, exception ->
+        log.error("error when retrieving list of channels: ", exception)
+        Toast.makeText(context, "Could not copy channel data", Toast.LENGTH_SHORT).show()
+      }) {
+        val finalAddress = app.requireService.state.value?.kit()?.wallet()?.receiveAddress?.value()?.get()?.get()
+        val channels = app.requireService.getChannels(null).toMutableList()
+        val nodeId = app.state.value?.getNodeId()?.toString() ?: getString(R.string.legacy_utils_unknown)
+        val data = channels.joinToString("\n\n", "", "", -1) { `default$`.`MODULE$`.write(it, 1, `JsonSerializers$`.`MODULE$`.cmdResGetinfoReadWriter()) }
+        val clipboard = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        clipboard.setPrimaryClip(ClipData.newPlainText("Legacy channels data", """
+          legacy_node_id=$nodeId
+          final_address=$finalAddress
+          channels_data=${data.takeIf { it.isNotBlank() } ?: "none"}
+        """.trimIndent()))
+        Toast.makeText(context, "Data copied!", Toast.LENGTH_SHORT).show()
       }
     }
   }
+}
 
-  private fun refreshBalanceDisplay(context: Context) {
-    if (Prefs.showBalanceHome(context)) {
-      mBinding.balance.visibility = View.VISIBLE
-    } else {
-      mBinding.balance.visibility = View.GONE
+class MainSunsetViewModel : ViewModel() {
+  val log = LoggerFactory.getLogger(this::class.java)
+  val finalWalletBalance = MutableLiveData<Satoshi?>(null)
+
+  fun getFinalWalletBalance(appViewModel: AppViewModel) {
+    viewModelScope.launch {
+      fetchFinalWalletBalance(appViewModel)
     }
   }
 
-  @Subscribe(threadMode = ThreadMode.MAIN)
-  fun handleEvent(event: PaymentPending) {
-    log.debug("pending payment, refreshing list...")
-    app.refreshLatestPayments()
-  }
-
-  @Subscribe(threadMode = ThreadMode.BACKGROUND)
-  fun handleEvent(event: ChannelStateChange) {
-    log.debug("channel state changed, refreshing incoming funds...")
-    refreshIncomingFunds()
-  }
-
-  private fun refreshIncomingFunds() {
-    lifecycleScope.launch(CoroutineExceptionHandler { _, exception ->
-      log.error("error when refreshing the incoming funds notification: ", exception)
-    }) {
-      val totalSwapIns = app.pendingSwapIns.value?.values?.map { s -> Converter.any2Msat(s.amount()) } ?: emptyList()
-      val totalChannelsWaitingConf = app.service?.getChannels(`WAIT_FOR_FUNDING_CONFIRMED$`.`MODULE$`)?.map { c ->
-        if (c.data() is HasCommitments) {
-          (c.data() as HasCommitments).commitments().availableBalanceForSend()
-        } else {
-          MilliSatoshi(0)
+  private suspend fun fetchFinalWalletBalance(appViewModel: AppViewModel) {
+    val address = appViewModel.service?.state?.value?.kit()?.wallet()?.receiveAddress?.value()?.get()?.get()
+    if (!address.isNullOrBlank()) {
+      Wallet.httpClient.newCall(Request.Builder().url("${Constants.MEMPOOLSPACE_EXPLORER_URL}/api/address/$address").build()).enqueue(object : Callback {
+        override fun onFailure(call: Call, e: IOException) {
+          log.warn("could not retrieve address details from mempool.space: ${e.localizedMessage}")
+          finalWalletBalance.postValue(null)
         }
-      } ?: emptyList()
-      val total = totalSwapIns + totalChannelsWaitingConf
-      model.incomingFunds.postValue(if (total.isEmpty()) {
-        MilliSatoshi(0)
-      } else {
-        total.reduce { acc, amount -> acc.`$plus`(amount) }
-      })
-    }
-  }
 
-  private fun refreshIncomingFundsAmountField() {
-    model.incomingFunds.value?.let { amount ->
-      context?.let { ctx ->
-        mBinding.incomingFundsNotif.text = getString(R.string.legacy_main_swapin_incoming,
-          if (Prefs.getShowAmountInFiat(ctx)) {
-            Converter.printFiatPretty(ctx, amount, withUnit = true)
+        override fun onResponse(call: Call, response: Response) {
+          if (!response.isSuccessful) {
+            log.warn("mempool.space returned error=${response.code()}")
+            finalWalletBalance.postValue(null)
           } else {
-            Converter.printAmountPretty(amount, ctx, withUnit = true)
-          })
-      }
-    }
-  }
-
-  private fun refreshNotifications(context: Context) {
-    checkMnemonics(context)
-    checkBackgroundWorkerCanRun(context)
-  }
-
-  /**
-   * If the background channels watcher has not run since (now) - (DELAY_BEFORE_BACKGROUND_WARNING), we consider that the device is
-   * blocking this application from working in background, and show a notification.
-   *
-   * Some devices vendors are known to aggressively kill applications (including background jobs) in order to save battery,
-   * unless the app is whitelisted by the user in a custom OS setting page. This behaviour is hard to detect and not
-   * standard, and does not happen on a stock android. In this case, the user has to whitelist the app.
-   */
-  private fun checkBackgroundWorkerCanRun(context: Context) {
-    val channelsWatchOutcome = Prefs.getWatcherLastAttemptOutcome(context)
-    if (channelsWatchOutcome.second > 0 && System.currentTimeMillis() - channelsWatchOutcome.second > Constants.DELAY_BEFORE_BACKGROUND_WARNING) {
-      log.warn("watcher has not run since {}", DateFormat.getDateTimeInstance().format(Date(channelsWatchOutcome.second)))
-      appContext(context).notifications.value?.add(InAppNotifications.BACKGROUND_WORKER_CANNOT_RUN)
-      if (app.state.value is KitState.Started) {
-        // the user has been notified once, but since the node has started he is safe anyway
-        // the background watcher notification countdown can be reset so that it does not spam the user
-        Prefs.saveWatcherAttemptOutcome(context, WatchListener.`Ok$`.`MODULE$`)
-      }
+            response.body()?.let {
+              try {
+                val json = JSONObject(it.string())
+                val (funded, spent) = json.getJSONObject("chain_stats").run {
+                  getLong("funded_txo_sum") to getLong("spent_txo_sum")
+                }
+                val (pendingFunded, pendingSpent) = json.getJSONObject("mempool_stats").run {
+                  getLong("funded_txo_sum") to getLong("spent_txo_sum")
+                }
+                val available = (funded - spent) + (pendingFunded - pendingSpent)
+                finalWalletBalance.postValue(Satoshi(available))
+              } catch (e: Exception) {
+                log.error("could not parse address data from mempool.space: ${e.localizedMessage}", e)
+                finalWalletBalance.postValue(null)
+              }
+            }
+          }
+        }
+      })
+      delay(10.minutes)
     } else {
-      appContext(context).notifications.value?.remove(InAppNotifications.BACKGROUND_WORKER_CANNOT_RUN)
+      delay(7.seconds)
     }
+    fetchFinalWalletBalance(appViewModel)
   }
 
-  private fun checkMnemonics(context: Context) {
-    val timestamp = Prefs.getMnemonicsSeenTimestamp(context)
-    if (timestamp == 0L) {
-      appContext(context).notifications.value?.add(InAppNotifications.MNEMONICS_NEVER_SEEN)
-    } else {
-      appContext(context).notifications.value?.remove(InAppNotifications.MNEMONICS_NEVER_SEEN)
+  val finalWalletBalanceDisplay : LiveData<String> = finalWalletBalance.map {
+    when (it) {
+      null -> "scanning address..."
+      else -> "${NumberFormat.getInstance().format(it.toLong())} sat"
     }
   }
-
 }
-
-class MainViewModel : ViewModel() {
-  val incomingFunds = MutableLiveData(MilliSatoshi(0))
-}
-

--- a/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/settings/SettingsFragment.kt
+++ b/phoenix-legacy/src/main/kotlin/fr/acinq/phoenix/legacy/settings/SettingsFragment.kt
@@ -52,26 +52,18 @@ class SettingsFragment : BaseFragment(stayIfNotStarted = true) {
     mBinding.displaySeedButton.visibility = if (isStarted) View.VISIBLE else View.GONE
     mBinding.accessControlButton.visibility = if (isStarted) View.VISIBLE else View.GONE
     mBinding.listAllChannelsButton.visibility = if (isStarted) View.VISIBLE else View.GONE
-    mBinding.mutualCloseButton.visibility = if (isStarted) View.VISIBLE else View.GONE
-    mBinding.forceCloseButton.visibility = if (isStarted) View.VISIBLE else View.GONE
-    mBinding.paymentSettingsButton.visibility = if (isStarted) View.VISIBLE else View.GONE
   }
 
   override fun onStart() {
     super.onStart()
     mBinding.actionBar.setOnBackAction { findNavController().popBackStack() }
-    mBinding.prefsDisplayButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_prefs_display) }
     mBinding.electrumButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_electrum) }
-    mBinding.mutualCloseButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_mutual_close) }
-    mBinding.forceCloseButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_force_close) }
     mBinding.displaySeedButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_display_seed) }
     mBinding.accessControlButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_access_control) }
     mBinding.listAllChannelsButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_list_channels) }
     mBinding.logsButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_logs) }
-//    mBinding.feesButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_fees) }
     mBinding.torButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_tor) }
     mBinding.aboutButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_about) }
-    mBinding.paymentSettingsButton.setOnClickListener { findNavController().navigate(R.id.action_settings_to_payment_settings) }
   }
 
 }

--- a/phoenix-legacy/src/main/res/layout/fragment_main_sunset.xml
+++ b/phoenix-legacy/src/main/res/layout/fragment_main_sunset.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2019 ACINQ SAS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools">
+
+  <data>
+
+    <variable
+      name="model"
+      type="fr.acinq.phoenix.legacy.main.MainSunsetViewModel" />
+  </data>
+
+  <ScrollView
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:scrollbars="vertical"
+      android:paddingHorizontal="16dp"
+      android:paddingVertical="24dp"
+      android:gravity="center_horizontal"
+      tools:context=".legacy.main.MainFragment">
+
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/rounded"
+        android:padding="16dp"
+        android:gravity="center"
+        android:layout_gravity="center"
+        android:orientation="vertical">
+
+        <TextView
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="@string/legacy_migration_body1" />
+
+        <TextView
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:textStyle="bold"
+          android:layout_marginTop="24dp"
+          android:textAlignment="center"
+          android:text="@string/legacy_migration_available" />
+
+        <TextView
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="8dp"
+          android:textAlignment="center"
+          android:text="@{model.finalWalletBalanceDisplay}" />
+
+        <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
+          android:id="@+id/upgrade_button"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="24dp"
+          android:backgroundTint="?attr/colorPrimary"
+          app:text_color="?attr/altTextColor"
+          app:text="@string/legacy_migration_button" />
+
+      </LinearLayout>
+
+      <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:layout_marginHorizontal="16dp"
+        android:textIsSelectable="true"
+        android:text="@string/legacy_migration_body2" />
+
+      <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
+        android:id="@+id/settings_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        app:icon="@drawable/ic_settings"
+        app:icon_tint="?attr/colorPrimary"
+        app:text="@string/legacy_menu_settings" />
+
+      <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
+        android:id="@+id/copy_debug_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        app:icon="@drawable/ic_copy"
+        app:text="@string/legacy_migration_copy_debug_button" />
+
+    </LinearLayout>
+  </ScrollView>
+</layout>

--- a/phoenix-legacy/src/main/res/layout/fragment_migration.xml
+++ b/phoenix-legacy/src/main/res/layout/fragment_migration.xml
@@ -45,42 +45,23 @@
         android:visibility="@{model.state instanceof MigrationScreenState.Ready}"
         app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-          android:id="@+id/ready_title"
-          style="@style/dialog_title"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:text="@string/legacy_migration_title"
-          app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-          android:id="@+id/ready_message"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_marginTop="@dimen/space_sm"
-          android:text="@string/legacy_migration_ready_message"
-          app:layout_constraintTop_toBottomOf="@id/ready_title" />
-
         <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
           android:id="@+id/upgrade_button"
-          android:layout_width="wrap_content"
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginTop="@dimen/space_lg"
           android:background="@drawable/button_bg_primary_border"
           app:icon="@drawable/ic_arrow_right_circle"
           app:is_paused="@{!model.isConnected}"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintTop_toBottomOf="@id/ready_message"
+          app:layout_constraintTop_toTopOf="parent"
           app:paused_text="@string/legacy_migration_prepare_button_disconnected"
           app:text="@string/legacy_migration_prepare_button" />
 
         <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
           android:id="@+id/dismiss_button"
-          android:layout_width="wrap_content"
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/space_md"
           android:background="@drawable/button_bg_no_border"
-          app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintTop_toBottomOf="@id/upgrade_button"
           app:text="@string/legacy_migration_dismiss_button" />
       </androidx.constraintlayout.widget.ConstraintLayout>

--- a/phoenix-legacy/src/main/res/layout/fragment_settings.xml
+++ b/phoenix-legacy/src/main/res/layout/fragment_settings.xml
@@ -62,18 +62,6 @@
           app:text="@string/legacy_settings_about" />
 
         <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
-          android:id="@+id/prefs_display_button"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:background="@drawable/button_bg_square"
-          android:padding="@dimen/space_md"
-          app:hz_bias="0"
-          app:icon="@drawable/ic_brush"
-          app:layout_constraintTop_toBottomOf="@id/about_button"
-          app:spacer_size="@dimen/space_md"
-          app:text="@string/legacy_settings_display_prefs" />
-
-        <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
           android:id="@+id/electrum_button"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
@@ -81,7 +69,7 @@
           android:padding="@dimen/space_md"
           app:hz_bias="0"
           app:icon="@drawable/ic_chain"
-          app:layout_constraintTop_toBottomOf="@id/prefs_display_button"
+          app:layout_constraintTop_toBottomOf="@id/about_button"
           app:spacer_size="@dimen/space_md"
           app:text="@string/legacy_settings_electrum" />
 
@@ -97,24 +85,12 @@
           app:spacer_size="@dimen/space_md"
           app:text="@string/legacy_settings_tor" />
 
-        <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
-          android:id="@+id/payment_settings_button"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:background="@drawable/button_bg_square"
-          android:padding="@dimen/space_md"
-          app:hz_bias="0"
-          app:icon="@drawable/ic_tool"
-          app:layout_constraintTop_toBottomOf="@id/tor_button"
-          app:spacer_size="@dimen/space_md"
-          app:text="@string/legacy_settings_payment_settings" />
-
         <TextView
           android:id="@+id/security_title"
           style="@style/SettingsCategory"
           android:text="@string/legacy_settings_security_title"
           app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@id/payment_settings_button" />
+          app:layout_constraintTop_toBottomOf="@id/tor_button" />
 
         <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
           android:id="@+id/access_control_button"
@@ -170,32 +146,6 @@
           app:layout_constraintTop_toBottomOf="@id/list_all_channels_button"
           app:spacer_size="@dimen/space_md"
           app:text="@string/legacy_settings_logs" />
-
-        <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
-          android:id="@+id/mutual_close_button"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:background="@drawable/button_bg_square"
-          android:padding="@dimen/space_md"
-          app:hz_bias="0"
-          app:icon="@drawable/ic_cross_circle"
-          app:layout_constraintTop_toBottomOf="@id/logs_button"
-          app:spacer_size="@dimen/space_md"
-          app:text="@string/legacy_settings_mutual_close" />
-
-        <fr.acinq.phoenix.legacy.utils.customviews.ButtonView
-          android:id="@+id/force_close_button"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:background="@drawable/button_bg_square"
-          android:padding="@dimen/space_md"
-          app:hz_bias="0"
-          app:icon="@drawable/ic_alert_triangle"
-          app:icon_tint="?attr/negativeColor"
-          app:layout_constraintTop_toBottomOf="@id/mutual_close_button"
-          app:spacer_size="@dimen/space_md"
-          app:text="@string/legacy_settings_force_close"
-          app:text_color="?attr/negativeColor" />
 
       </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/phoenix-legacy/src/main/res/navigation/nav_graph_main.xml
+++ b/phoenix-legacy/src/main/res/navigation/nav_graph_main.xml
@@ -121,6 +121,9 @@
       android:id="@+id/action_main_to_migration"
       app:destination="@id/migration_fragment" />
     <action
+      android:id="@+id/action_main_to_channel_import"
+      app:destination="@id/channels_import" />
+    <action
       android:id="@+id/action_main_payments_history"
       app:destination="@id/payments_history_fragment" />
   </fragment>

--- a/phoenix-legacy/src/main/res/values-cs/strings.xml
+++ b/phoenix-legacy/src/main/res/values-cs/strings.xml
@@ -421,8 +421,11 @@
 
   <!-- //////////////// Migration to KMP //////////////// -->
 
-  <string name="legacy_migration_title">Phoenix upgrade</string>
-  <string name="legacy_migration_ready_message">Tato peněženka používá zastaralý formát kanálů. Většina funkcí je vypnuta.\n\nPřejděte na Phoenix v2 a získejte swapy bez důvěry, splicing, statické adresy a mnoho dalšího.\n\nOd října 2024 budou kanály, které nebyly migrovány, uzavřeny.</string>
+  <string name="legacy_migration_body1">Starší peněženky jsou zastaralé. Kanály byly uzavřeny a finanční prostředky byly přesunuty zpět do řetězce.</string>
+  <string name="legacy_migration_body2">Pokud máte problémy nebo očekáváte více prostředků v konečné peněžence, kontaktujte podporu na adrese phoenix@acinq.co a poskytněte informace o ladění</string>
+  <string name="legacy_migration_available">Prostředky dostupné v konečné peněžence:</string>
+  <string name="legacy_migration_button">Upgradujte na Phoenix V2</string>
+  <string name="legacy_migration_copy_debug_button">Kopírování ladicích dat</string>
   <string name="legacy_migration_prepare_button">Upgrade</string>
   <string name="legacy_migration_prepare_button_disconnected">Připojení…</string>
   <string name="legacy_migration_dismiss_button">Teď ne</string>

--- a/phoenix-legacy/src/main/res/values-de/strings.xml
+++ b/phoenix-legacy/src/main/res/values-de/strings.xml
@@ -814,8 +814,11 @@
 
   <!-- //////////////// Migration to KMP //////////////// -->
 
-  <string name="legacy_migration_title">Phoenix Upgrade</string>
-  <string name="legacy_migration_ready_message">Diese Wallet verwendet ein veraltetes Channel-Format. Die meisten Funktionen sind deaktiviert.\n\nWerden Sie auf Phoenix v2 upgraden und erhalten Sie vertrauenslose Swaps, Splicing, statische Adressen und vieles mehr.\n\nAb Oktober 2024 werden die Kanäle, die nicht migriert wurden, geschlossen.</string>
+  <string name="legacy_migration_body1">Legacy-Wallets werden nicht mehr unterstützt. Kanäle wurden geschlossen und Gelder zurück On-Chain verschoben.</string>
+  <string name="legacy_migration_body2">Wenn Sie Probleme haben oder mehr Gelder in der endgültigen Wallet erwarten, wenden Sie sich an den Support unter phoenix@acinq.co und stellen Sie die Debug-Daten bereit.</string>
+  <string name="legacy_migration_available">In der Final Wallet verfügbare Gelder:</string>
+  <string name="legacy_migration_button">Upgrade auf Phoenix V2</string>
+  <string name="legacy_migration_copy_debug_button">Debug-Daten kopieren</string>
   <string name="legacy_migration_prepare_button">Upgrade</string>
   <string name="legacy_migration_prepare_button_disconnected">Verbindung herstellen…</string>
   <string name="legacy_migration_dismiss_button">Nicht jetzt</string>

--- a/phoenix-legacy/src/main/res/values-es/strings.xml
+++ b/phoenix-legacy/src/main/res/values-es/strings.xml
@@ -465,8 +465,11 @@
 
   <!-- //////////////// Migration to KMP //////////////// -->
 
-  <string name="legacy_migration_title">Actualización de Phoenix</string>
-  <string name="legacy_migration_ready_message">Este monedero utiliza un formato de canales obsoleto. La mayoría de las características están deshabilitadas.\n\nActualízate a Phoenix v2 y obtén swaps sin confianza, splicing, direcciones estáticas y mucho más.\n\nA partir de octubre de 2024, los canales que no hayan sido migrados serán cerrados.</string>
+  <string name="legacy_migration_body1">Las billeteras antiguas están obsoletas. Los canales se cerraron y los fondos se volvieron a transferir a la cadena.</string>
+  <string name="legacy_migration_body2">Si tiene problemas o espera más fondos en la billetera final, comuníquese con el servicio de asistencia a phoenix@acinq.co y proporcione los datos de debug.</string>
+  <string name="legacy_migration_available">Fondos disponibles en la billetera final:</string>
+  <string name="legacy_migration_button">Actualizar a Phoenix V2</string>
+  <string name="legacy_migration_copy_debug_button">Copiar datos de debug</string>
   <string name="legacy_migration_prepare_button">Actualizar</string>
   <string name="legacy_migration_prepare_button_disconnected">Connecting…</string>
   <string name="legacy_migration_dismiss_button">Ahora no</string>

--- a/phoenix-legacy/src/main/res/values-fr/strings.xml
+++ b/phoenix-legacy/src/main/res/values-fr/strings.xml
@@ -691,8 +691,11 @@
 
   <!-- //////////////// Migration to KMP //////////////// -->
 
-  <string name="legacy_migration_title">Mise à niveau de Phoenix</string>
-  <string name="legacy_migration_ready_message">Ce wallet utilise un format de canaux obsolète. La majorité des fonctionnalités sont inactives.\n\nPassez à Phoenix v2 et profitez de swaps sans tiers de confiance, de splicing, des adresses statiques, et bien plus encore.\n\nÀ partir d\'octobre 2024, les canaux qui n\'ont pas été migrés seront fermés.</string>
+  <string name="legacy_migration_body1">Les portefeuilles legacy sont dépréciés. Les canaux ont été fermés et les fonds ont été retournés sur la chaîne.</string>
+  <string name="legacy_migration_body2">Si vous rencontrez des problèmes ou si vous vous attendez à avoir davantage de fonds dans le portefeuille final, contactez le support à l\'adresse phoenix@acinq.co en fournissez les données de débogage.</string>
+  <string name="legacy_migration_available">Fonds disponibles dans le portefeuille final :</string>
+  <string name="legacy_migration_button">Passer à Phoenix V2</string>
+  <string name="legacy_migration_copy_debug_button">Copier les données de débogage</string>
   <string name="legacy_migration_prepare_button">Mettre à jour</string>
   <string name="legacy_migration_prepare_button_disconnected">Connexion…</string>
   <string name="legacy_migration_dismiss_button">Plus tard</string>

--- a/phoenix-legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/phoenix-legacy/src/main/res/values-pt-rBR/strings.xml
@@ -751,8 +751,11 @@
 
   <!-- //////////////// Migration to KMP //////////////// -->
 
-  <string name="legacy_migration_title">Atualização do Phoenix</string>
-  <string name="legacy_migration_ready_message">Esta carteira está usando um formato de canais obsoleto. A maioria dos recursos está desativada.\n\nAtualize para a Phoenix v2 e obtenha swaps sem confiança, splicing, endereços estáticos e muito mais.\n\nA partir de outubro de 2024, os canais que não tiverem sido migrados serão fechados.</string>
+  <string name="legacy_migration_body1">As carteiras legadas estão obsoletas. Os canais foram fechados e os fundos foram movidos de volta para a cadeia.</string>
+  <string name="legacy_migration_body2">Se você tiver problemas ou esperar mais fundos na carteira final, entre em contato com o suporte em phoenix@acinq.co e forneça os dados de depuração.</string>
+  <string name="legacy_migration_available">Fundos disponíveis na carteira final:</string>
+  <string name="legacy_migration_button">Atualizar para Phoenix V2</string>
+  <string name="legacy_migration_copy_debug_button">Copiar dados de depuração</string>
   <string name="legacy_migration_prepare_button">Upgrade</string>
   <string name="legacy_migration_prepare_button_disconnected">Conectando…</string>
   <string name="legacy_migration_dismiss_button">Não agora</string>

--- a/phoenix-legacy/src/main/res/values/strings.xml
+++ b/phoenix-legacy/src/main/res/values/strings.xml
@@ -785,11 +785,14 @@ legacy_
 
   <!-- //////////////// Migration to KMP //////////////// -->
 
-  <string name="legacy_migration_title">Upgrade to Phoenix v2</string>
-  <string name="legacy_migration_ready_message">This wallet is using an obsolete channels format. Most features are disabled.\n\nUpgrade to Phoenix v2 and get trustless swaps, splicing, static addresses, and much more.\n\nStarting in October 2024, channels that have not been migrated will be closed.</string>
+  <string name="legacy_migration_body1">Legacy wallets have reached end of life. Channels have been closed, and funds moved back on-chain.</string>
+  <string name="legacy_migration_body2">If you have issues or expect more funds in the final wallet, contact support at phoenix@acinq.co and provide the debug data.</string>
+  <string name="legacy_migration_available">Funds available in final wallet:</string>
+  <string name="legacy_migration_button">Upgrade to Phoenix V2</string>
+  <string name="legacy_migration_copy_debug_button">Copy debug data</string>
   <string name="legacy_migration_prepare_button">Upgrade now</string>
   <string name="legacy_migration_prepare_button_disconnected">Connecting…</string>
-  <string name="legacy_migration_dismiss_button">Not now</string>
+  <string name="legacy_migration_dismiss_button">Later</string>
 
   <string name="legacy_migration_paused_swap_in">You cannot upgrade now: an on-chain deposit is pending.\n\nTry again later when this deposit has confirmed.</string>
   <string name="legacy_migration_paused_opening">You cannot upgrade now: some channels are currently being opened.\n\nTry again later when these channels have been opened and are active.</string>


### PR DESCRIPTION
For context, pre-splice channels (used by the legacy Android app a.k.a v1) needed to be migrated to v2 since September 2023. A free migration flow was available until October 2024.

See this post for details about the splicing v2 update: https://acinq.co/blog/phoenix-splicing-update

In October 2024, all remaining legacy channel have been closed (i.e. funds are moved back on-chain to the "final wallet"). In some cases, for some specific channels type, the closing also needs interaction from the wallet to complete. To perform this interaction the legacy code must be used, so the legacy app still needs to be available.

To help with this migration and let users understand where their funds are, the legacy main screen now only contains the migration prompt with the final wallet balance, as well as access to the settings in case the user needs to complete the channels closing.

### Migration prompt (in v1)

<img src="https://github.com/user-attachments/assets/d333b4f6-323f-4d1e-ab87-155e1679b12e" width=240 />
<img src="https://github.com/user-attachments/assets/1b18cdda-d861-4025-b223-ba27d9455c21" width=240 />

### Spending from final wallet (in v2)

<img src="https://github.com/user-attachments/assets/d9542555-c4a9-4a47-b391-33f3179e9d25" width=240 />
<img src="https://github.com/user-attachments/assets/df3dd83e-24b5-4bdd-8486-cb67cdaf925d " width=240 />
