### PR TITLE
(ios) Fixing compiler warnings (Xcode 16.2)

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -280,6 +280,7 @@
 		DCBA60CD2C909C7600878895 /* SendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBA60CC2C909C7600878895 /* SendView.swift */; };
 		DCBA60CF2C90E41000878895 /* ScanQrCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBA60CE2C90E41000878895 /* ScanQrCodeView.swift */; };
 		DCBA60D42C93544C00878895 /* InsetGroupBoxStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBA60D32C93544C00878895 /* InsetGroupBoxStyle.swift */; };
+		DCBBEEA82D1314CA00B0A9EB /* CurrencyAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC118C0B27B561210080BBAC /* CurrencyAmount.swift */; };
 		DCC3E57F2D08A63900CCDA40 /* XPC+Foreground.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC3E57E2D08A63500CCDA40 /* XPC+Foreground.swift */; };
 		DCC3E5822D08A65400CCDA40 /* XPC+Background.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC3E5812D08A65000CCDA40 /* XPC+Background.swift */; };
 		DCC46F1625C3521C005D32D9 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = DC72C31825A3CF87008A927A /* FirebaseMessaging */; };
@@ -2145,6 +2146,7 @@
 				DCA6DECE282AB12B0073C658 /* SecurityFile.swift in Sources */,
 				DCCFE6BE2B713FB8002FFF11 /* LogFileInfo.swift in Sources */,
 				DC49FE9C2AC49E0400D8D2E2 /* KotlinExtensions+Lightning.swift in Sources */,
+				DCBBEEA82D1314CA00B0A9EB /* CurrencyAmount.swift in Sources */,
 				DC6ACC592B10F4FE0079179B /* RecoveryPhrase.swift in Sources */,
 				DCA6DEC72829BFD70073C658 /* XPC.swift in Sources */,
 				DCE81C172BC883BE0094B950 /* KotlinFlow.swift in Sources */,

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -2354,7 +2354,6 @@
 		7555FFA6242A565B00829871 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Blue";
 				CODE_SIGN_ENTITLEMENTS = "phoenix-ios/Phoenix.entitlements";
 				CODE_SIGN_STYLE = Automatic;
@@ -2379,7 +2378,6 @@
 		7555FFA7242A565B00829871 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Blue";
 				CODE_SIGN_ENTITLEMENTS = "phoenix-ios/Phoenix.entitlements";
 				CODE_SIGN_STYLE = Automatic;
@@ -2404,7 +2402,6 @@
 		7555FFA9242A565B00829871 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = XD77LN4376;
@@ -2424,7 +2421,6 @@
 		7555FFAA242A565B00829871 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = XD77LN4376;
@@ -2444,7 +2440,6 @@
 		7555FFAC242A565B00829871 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = "phoenix-iosUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2463,7 +2458,6 @@
 		7555FFAD242A565B00829871 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = "phoenix-iosUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/phoenix-ios/phoenix-ios/extensions/FileHandle+Async.swift
+++ b/phoenix-ios/phoenix-ios/extensions/FileHandle+Async.swift
@@ -7,32 +7,14 @@ extension FileHandle {
 		qos: DispatchQoS.QoSClass = .userInitiated
 	) async throws {
 		
-		return try await withCheckedThrowingContinuation { continuation in
-			DispatchQueue.global(qos: qos).async {
-				do {
-					try self.write(contentsOf: data)
-					continuation.resume(with: .success)
-				} catch {
-					continuation.resume(with: .failure(error))
-				}
-			}
-		}
+		try self.write(contentsOf: data)
 	}
 	
 	func asyncSyncAndClose(
 		qos: DispatchQoS.QoSClass = .userInitiated
 	) async throws {
 		
-		try await withCheckedThrowingContinuation { continuation in
-			DispatchQueue.global(qos: qos).async {
-				do {
-					try self.synchronize()
-					try self.close()
-					continuation.resume(with: .success)
-				} catch {
-					continuation.resume(with: .failure(error))
-				}
-			}
-		}
+		try self.synchronize()
+		try self.close()
 	}
 }

--- a/phoenix-ios/phoenix-ios/extensions/UIApplicationState+Phoenix.swift
+++ b/phoenix-ios/phoenix-ios/extensions/UIApplicationState+Phoenix.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 
-extension UIApplication.State: CustomStringConvertible {
+extension UIApplication.State: @retroactive CustomStringConvertible {
 	
 	public var description: String {
 		switch self {

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Manager.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Manager.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PhoenixShared
+@preconcurrency import PhoenixShared
 import Combine
 
 extension BalanceManager {

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinIdentifiable.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinIdentifiable.swift
@@ -1,14 +1,14 @@
 import Foundation
 import PhoenixShared
 
-extension Lightning_kmpUUID: Identifiable {
+extension Lightning_kmpUUID: @retroactive Identifiable {
 	
 	public var id: String {
 		return self.description
 	}
 }
 
-extension WalletPaymentId: Identifiable {
+extension WalletPaymentId: @retroactive Identifiable {
 	
 	/// Returns a unique identifier, in the form of:
 	/// - "outgoing|id"
@@ -19,7 +19,7 @@ extension WalletPaymentId: Identifiable {
 	}
 }
 
-extension WalletPaymentOrderRow: Identifiable {
+extension WalletPaymentOrderRow: @retroactive Identifiable {
 	
 	/// In kotlin the variable is called `id`, but that's a reserved property name in objective-c.
 	/// So it gets automatically overwritten, and is inaccessible to us.
@@ -37,7 +37,7 @@ extension WalletPaymentOrderRow: Identifiable {
 	}
 }
 
-extension BitcoinUnit: Identifiable {
+extension BitcoinUnit: @retroactive Identifiable {
 	
 	public var id: String {
 		// BitcoinUnit is an enum in Kotlin.
@@ -46,7 +46,7 @@ extension BitcoinUnit: Identifiable {
 	}
 }
 
-extension FiatCurrency: Identifiable {
+extension FiatCurrency: @retroactive Identifiable {
 	
 	public var id: String {
 		// FiatCurrency is an enum in Kotlin.
@@ -55,7 +55,7 @@ extension FiatCurrency: Identifiable {
 	}
 }
 
-extension ContactInfo: Identifiable {
+extension ContactInfo: @retroactive Identifiable {
 	
 	/// In kotlin the variable is called `id`, but that's a reserved property name in objective-c.
 	/// So it gets automatically overwritten, and is inaccessible to us.
@@ -69,14 +69,14 @@ extension ContactInfo: Identifiable {
 	}
 }
 
-extension Lightning_kmpWalletState.Utxo: Identifiable {
+extension Lightning_kmpWalletState.Utxo: @retroactive Identifiable {
 	
 	public var id: String {
 		return "\(previousTx.txid.toHex()):\(outputIndex):\(blockHeight)"
 	}
 }
 
-extension Lightning_kmpSensitiveTaskEventsTaskIdentifier.InteractiveTx: Identifiable {
+extension Lightning_kmpSensitiveTaskEventsTaskIdentifier.InteractiveTx: @retroactive Identifiable {
 	
 	public var id: String {
 		return "\(self.channelId.toHex()):\(self.fundingTxIndex)"

--- a/phoenix-ios/phoenix-ios/logging/OSLogHandler.swift
+++ b/phoenix-ios/phoenix-ios/logging/OSLogHandler.swift
@@ -35,6 +35,7 @@ struct OSLogHandler: LogHandler {
 		level: Logging.Logger.Level,
 		message: Logging.Logger.Message,
 		metadata: Logging.Logger.Metadata?,
+		source: String,
 		file: String,
 		function: String,
 		line: UInt

--- a/phoenix-ios/phoenix-ios/logging/fileLogging/LogFileHandler.swift
+++ b/phoenix-ios/phoenix-ios/logging/fileLogging/LogFileHandler.swift
@@ -38,6 +38,7 @@ struct LogFileHandler: LogHandler {
 		level: Logging.Logger.Level,
 		message: Logging.Logger.Message,
 		metadata: Logging.Logger.Metadata?,
+		source: String,
 		file: String,
 		function: String,
 		line: UInt

--- a/phoenix-ios/phoenix-ios/security/GenericPasswordConvertible.swift
+++ b/phoenix-ios/phoenix-ios/security/GenericPasswordConvertible.swift
@@ -29,10 +29,14 @@ extension GenericPasswordConvertible {
 }
 
 // Declare that the Curve25519 keys are generic password convertible.
+extension Curve25519.KeyAgreement.PrivateKey: @retroactive CustomStringConvertible {}
 extension Curve25519.KeyAgreement.PrivateKey: GenericPasswordConvertible {}
+
+extension Curve25519.Signing.PrivateKey: @retroactive CustomStringConvertible {}
 extension Curve25519.Signing.PrivateKey: GenericPasswordConvertible {}
 
 // Extend SymmetricKey to conform to GenericPasswordConvertible.
+extension SymmetricKey: @retroactive CustomStringConvertible {}
 extension SymmetricKey: GenericPasswordConvertible {
 	
     init<D>(rawRepresentation data: D) throws where D: ContiguousBytes {
@@ -45,6 +49,7 @@ extension SymmetricKey: GenericPasswordConvertible {
 }
 
 // Extend SecureEnclave keys to conform to GenericPasswordConvertible.
+extension SecureEnclave.P256.KeyAgreement.PrivateKey: @retroactive CustomStringConvertible {}
 extension SecureEnclave.P256.KeyAgreement.PrivateKey: GenericPasswordConvertible {
 	
     init<D>(rawRepresentation data: D) throws where D: ContiguousBytes {
@@ -55,7 +60,7 @@ extension SecureEnclave.P256.KeyAgreement.PrivateKey: GenericPasswordConvertible
         return dataRepresentation  // Contiguous bytes repackaged as a Data instance.
     }
 }
-
+extension SecureEnclave.P256.Signing.PrivateKey: @retroactive CustomStringConvertible {}
 extension SecureEnclave.P256.Signing.PrivateKey: GenericPasswordConvertible {
 	
     init<D>(rawRepresentation data: D) throws where D: ContiguousBytes {

--- a/phoenix-ios/phoenix-ios/sync/SyncBackupManager+Contacts.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncBackupManager+Contacts.swift
@@ -289,7 +289,7 @@ extension SyncBackupManager {
 						record[contacts_record_column_data] = ciphertext
 						
 						if let fileName = contactInfo.photoUri {
-							let fileUrl = PhotosManager.shared.urlForPhoto(fileName: fileName)
+							let fileUrl = PhotosManager.urlForPhoto(fileName: fileName)
 							record[contacts_record_column_photo] = CKAsset(fileURL: fileUrl)
 						}
 						
@@ -720,8 +720,8 @@ extension SyncBackupManager {
 			
 			if let srcFileURL = asset.fileURL {
 				
-				let dstFileName = PhotosManager.shared.genFileName()
-				let dstFileURL = PhotosManager.shared.urlForPhoto(fileName: dstFileName)
+				let dstFileName = PhotosManager.genFileName()
+				let dstFileURL = PhotosManager.urlForPhoto(fileName: dstFileName)
 				
 				do {
 					try FileManager.default.copyItem(at: srcFileURL, to: dstFileURL)

--- a/phoenix-ios/phoenix-ios/sync/SyncBackupManager.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncBackupManager.swift
@@ -43,7 +43,7 @@ struct ConsecutivePartialFailure {
 
 /// Encompasses the logic for syncing data with Apple's CloudKit database.
 ///
-class SyncBackupManager {
+class SyncBackupManager: @unchecked Sendable {
 	
 	/// Access to parent for shared logic.
 	///

--- a/phoenix-ios/phoenix-ios/sync/SyncBackupManager_State.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncBackupManager_State.swift
@@ -156,7 +156,7 @@ enum SyncBackupManager_State: Equatable, CustomStringConvertible {
 
 /// Details concerning the type of changes being made to the CloudKit container(s).
 ///
-class SyncBackupManager_State_UpdatingCloud: Equatable {
+final class SyncBackupManager_State_UpdatingCloud: Equatable, @unchecked Sendable {
 	
 	enum Kind {
 		case creatingRecordZone
@@ -187,7 +187,7 @@ class SyncBackupManager_State_UpdatingCloud: Equatable {
 /// Exposes an ObservableObject that can be used by the UI for various purposes.
 /// All changes to `@Published` properties will be made on the UI thread.
 ///
-class SyncBackupManager_State_Downloading: ObservableObject, Equatable {
+class SyncBackupManager_State_Downloading: ObservableObject, Equatable, @unchecked Sendable {
 	
 	let needsDownloadPayments: Bool
 	let needsDownloadContacts: Bool
@@ -383,7 +383,7 @@ class SyncBackupManager_State_Uploading: ObservableObject, Equatable {
 /// Details concerning what/why the SyncBackupManager is temporarily paused.
 /// Sometimes these delays can be manually cancelled by the user.
 ///
-class SyncBackupManager_State_Waiting: Equatable {
+final class SyncBackupManager_State_Waiting: Equatable, Sendable {
 	
 	enum Kind: Equatable {
 		case forInternet
@@ -406,8 +406,6 @@ class SyncBackupManager_State_Waiting: Equatable {
 		}
 	}
 	
-	let kind: Kind
-	
 	struct WaitingUntil: Equatable {
 		weak var parent: SyncBackupManager?
 		let delay: TimeInterval
@@ -424,6 +422,7 @@ class SyncBackupManager_State_Waiting: Equatable {
 		}
 	}
 	
+	let kind: Kind
 	let until: WaitingUntil?
 	
 	init(kind: Kind) {

--- a/phoenix-ios/phoenix-ios/sync/SyncSeedManager.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncSeedManager.swift
@@ -1,7 +1,7 @@
 import Foundation
-import PhoenixShared
+@preconcurrency import PhoenixShared
 import CloudKit
-import Combine
+@preconcurrency import Combine
 import Network
 
 fileprivate let filename = "SyncSeedManager"
@@ -35,7 +35,7 @@ enum FetchSeedsError: Error {
 
 /// Encompasses the logic for syncing seeds with Apple's CloudKit database.
 ///
-class SyncSeedManager: SyncManagerProtcol {
+class SyncSeedManager: SyncManagerProtcol, @unchecked Sendable {
 	
 	/// Access to parent for shared logic.
 	///

--- a/phoenix-ios/phoenix-ios/sync/SyncSeedManager_Actor.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncSeedManager_Actor.swift
@@ -21,7 +21,7 @@ actor SyncSeedManager_Actor {
 	
 	private var state: SyncSeedManager_State
 	
-	let initialState: SyncSeedManager_State
+	nonisolated let initialState: SyncSeedManager_State
 	
 	var activeState: SyncSeedManager_State {
 		return state

--- a/phoenix-ios/phoenix-ios/sync/SyncSeedManager_State.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncSeedManager_State.swift
@@ -101,7 +101,7 @@ enum SyncSeedManager_State: Equatable, CustomStringConvertible {
 /// Details concerning what/why the SyncSeedManager is temporarily paused.
 /// Sometimes these delays can be manually cancelled by the user.
 ///
-class SyncSeedManager_State_Waiting: Equatable {
+final class SyncSeedManager_State_Waiting: Equatable, Sendable {
 	
 	enum Kind: Equatable {
 		case forInternet

--- a/phoenix-ios/phoenix-ios/views/contacts/ManageContact.swift
+++ b/phoenix-ios/phoenix-ios/views/contacts/ManageContact.swift
@@ -1092,7 +1092,7 @@ struct ManageContact: View {
 				
 				if let oldPhotoName, oldPhotoName != newPhotoName {
 					log.debug("Deleting old photo from disk...")
-					try await PhotosManager.shared.deleteFromDisk(fileName: oldPhotoName)
+					await PhotosManager.shared.deleteFromDisk(fileName: oldPhotoName)
 				}
 				
 				success = true

--- a/phoenix-ios/phoenix-ios/views/receive/InboundFeeState.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/InboundFeeState.swift
@@ -9,6 +9,7 @@ fileprivate var log = LoggerFactory.shared.logger(filename, .trace)
 fileprivate var log = LoggerFactory.shared.logger(filename, .warning)
 #endif
 
+@MainActor
 class InboundFeeState: ObservableObject {
 	
 	@Published var connections: Connections = Biz.business.connectionsManager.currentValue

--- a/phoenix-ios/phoenix-ios/views/receive/ModifyInvoiceSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/ModifyInvoiceSheet.swift
@@ -182,7 +182,7 @@ struct ModifyInvoiceSheet: View {
 	var isEmptyAmount: Bool {
 		
 		switch parsedAmount {
-		case .success(let amt):
+		case .success(_):
 			return false
 			
 		case .failure(let reason):

--- a/phoenix-ios/phoenix-ios/views/style/TruncatableView.swift
+++ b/phoenix-ios/phoenix-ios/views/style/TruncatableView.swift
@@ -146,7 +146,7 @@ private struct SizePreferenceKey: PreferenceKey {
 	static func reduce(value: inout CGSize, nextValue: () -> CGSize) {}
 }
 
-extension DynamicTypeSize: CustomStringConvertible {
+extension DynamicTypeSize: @retroactive CustomStringConvertible {
 	public var description: String {
 		switch self {
 			case .xSmall         : return "xSmall"

--- a/phoenix-ios/phoenix-ios/views/widgets/ImagePicker.swift
+++ b/phoenix-ios/phoenix-ios/views/widgets/ImagePicker.swift
@@ -93,4 +93,4 @@ struct ImagePicker: UIViewControllerRepresentable {
 //
 // This just silences the compiler until Apple marks NSItemProvider as Sendable
 //
-extension NSItemProvider: @unchecked Sendable { }
+extension NSItemProvider: @unchecked @retroactive Sendable { }

--- a/phoenix-ios/phoenix-ios/views/widgets/LocalWebView.swift
+++ b/phoenix-ios/phoenix-ios/views/widgets/LocalWebView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import WebKit
+@preconcurrency import WebKit
 
 /// Allows you to display an embedded HTML file.
 ///


### PR DESCRIPTION
Xcode 16.2 introduces a lot of new compiler warnings. Most about non-conformance with Sendable protocol.

(In a future Xcode release, we'll probably have to make more changes to conform with Swift 6 concurrency checking.)