### PR TITLE
(ios) Adding ability to receive a payment via NFC (bolt card)

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 		DCCFE6C22B7140FA002FFF11 /* LoggerFactory+Foreground.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCFE6C12B7140FA002FFF11 /* LoggerFactory+Foreground.swift */; };
 		DCCFE6C52B714226002FFF11 /* LoggerFactory+Background.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCFE6C32B714171002FFF11 /* LoggerFactory+Background.swift */; };
 		DCD1208728663F4A00EB39C5 /* TransactionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD1208628663F4A00EB39C5 /* TransactionsView.swift */; };
+		DCD1BFD62CE775E900C2B811 /* NfcReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD1BFD52CE775E500C2B811 /* NfcReader.swift */; };
 		DCD5FF4326A0D34B009CC666 /* EqualSizes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD5FF4226A0D34B009CC666 /* EqualSizes.swift */; };
 		DCD777D226DE9FE800979A12 /* DelayedSave.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD777D126DE9FE800979A12 /* DelayedSave.swift */; };
 		DCD7E0AC28EC32CB009C30E5 /* BusinessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD7E0AB28EC32CB009C30E5 /* BusinessManager.swift */; };
@@ -700,6 +701,7 @@
 		DCCFE6C12B7140FA002FFF11 /* LoggerFactory+Foreground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoggerFactory+Foreground.swift"; sourceTree = "<group>"; };
 		DCCFE6C32B714171002FFF11 /* LoggerFactory+Background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoggerFactory+Background.swift"; sourceTree = "<group>"; };
 		DCD1208628663F4A00EB39C5 /* TransactionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsView.swift; sourceTree = "<group>"; };
+		DCD1BFD52CE775E500C2B811 /* NfcReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NfcReader.swift; sourceTree = "<group>"; };
 		DCD5FF4226A0D34B009CC666 /* EqualSizes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualSizes.swift; sourceTree = "<group>"; };
 		DCD777D126DE9FE800979A12 /* DelayedSave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelayedSave.swift; sourceTree = "<group>"; };
 		DCD7E0AB28EC32CB009C30E5 /* BusinessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessManager.swift; sourceTree = "<group>"; };
@@ -929,6 +931,7 @@
 				53BEF1337AFCFF0AE82A46BD /* utils */,
 				DCACF6EE2566D0A60009B01E /* extensions */,
 				DCA6DEC42829BD060073C658 /* xpc */,
+				DCD1BFD42CE775CE00C2B811 /* nfc */,
 				DCE3C7A92A6AD39E00F4D385 /* mempool */,
 				DCCFE6AC2B6430BD002FFF11 /* logging */,
 			);
@@ -1477,6 +1480,14 @@
 			path = transactions;
 			sourceTree = "<group>";
 		};
+		DCD1BFD42CE775CE00C2B811 /* nfc */ = {
+			isa = PBXGroup;
+			children = (
+				DCD1BFD52CE775E500C2B811 /* NfcReader.swift */,
+			);
+			path = nfc;
+			sourceTree = "<group>";
+		};
 		DCDD9ECC28637390001800A3 /* main */ = {
 			isa = PBXGroup;
 			children = (
@@ -1996,6 +2007,7 @@
 				C8D7AA4B09B32AD99C88BB5E /* DisplayConfigurationView.swift in Sources */,
 				DCE77A5827C671D600F0FA24 /* ElectrumAddressSheet.swift in Sources */,
 				DC384D81265C12B700131772 /* Cache.swift in Sources */,
+				DCD1BFD62CE775E900C2B811 /* NfcReader.swift in Sources */,
 				DC4CF3CC2BE93311003A957F /* String+PIN.swift in Sources */,
 				DCB30E592A0C3F8200E7D7A2 /* LiquidityPolicyView.swift in Sources */,
 				DCEAE5B72943CC7400320C46 /* RangeSheet.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/Info.plist
+++ b/phoenix-ios/phoenix-ios/Info.plist
@@ -85,12 +85,16 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED</key>
+	<true/>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NFCReaderUsageDescription</key>
+	<string>The app would like to scan an NFC card.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Phoenix would like to use the camera to scan payment requests.</string>
 	<key>NSFaceIDUsageDescription</key>
@@ -136,7 +140,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED</key>
-	<true/>
 </dict>
 </plist>

--- a/phoenix-ios/phoenix-ios/InfoPlist.xcstrings
+++ b/phoenix-ios/phoenix-ios/InfoPlist.xcstrings
@@ -37,6 +37,18 @@
         }
       }
     },
+    "NFCReaderUsageDescription" : {
+      "comment" : "Privacy - NFC Scan Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The app would like to scan an NFC card."
+          }
+        }
+      }
+    },
     "NSCameraUsageDescription" : {
       "comment" : "Privacy - Camera Usage Description",
       "extractionState" : "extracted_with_value",

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -6579,6 +6579,9 @@
         }
       }
     },
+    "Amount required for card payment" : {
+
+    },
     "amount sent" : {
       "comment" : "Label in DetailsView_IncomingPayment",
       "localizations" : {
@@ -7801,6 +7804,9 @@
           }
         }
       }
+    },
+    "Awaiting payment…" : {
+
     },
     "Back" : {
       "localizations" : {
@@ -9780,6 +9786,9 @@
         }
       }
     },
+    "card" : {
+      "comment" : "button label - try to make it short"
+    },
     "caused by" : {
 
     },
@@ -11532,6 +11541,9 @@
         }
       }
     },
+    "Communicating with card's host…" : {
+
+    },
     "completed at" : {
       "comment" : "Label in DetailsView_IncomingPayment",
       "extractionState" : "manual",
@@ -13276,6 +13288,12 @@
         }
       }
     },
+    "Could not communicate with card's wallet" : {
+      "comment" : "Error message - scanning lightning invoice"
+    },
+    "Could not connect to card's host" : {
+      "comment" : "Error message - processing bolt card payment"
+    },
     "Could not connect to host:" : {
       "localizations" : {
         "ar" : {
@@ -13482,6 +13500,9 @@
           }
         }
       }
+    },
+    "Cound not communicate with card's wallet" : {
+
     },
     "Create new wallet" : {
       "localizations" : {
@@ -16064,6 +16085,9 @@
         }
       }
     },
+    "Does not appear to be a bolt card." : {
+
+    },
     "Don't lose your funds:" : {
       "localizations" : {
         "ar" : {
@@ -17516,6 +17540,9 @@
           }
         }
       }
+    },
+    "Error reading tag" : {
+
     },
     "Error: %@" : {
       "localizations" : {
@@ -27702,6 +27729,12 @@
         }
       }
     },
+    "NFC cababilities not available on this device" : {
+
+    },
+    "NFC reader is already scanning" : {
+
+    },
     "No" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -28228,6 +28261,9 @@
         }
       }
     },
+    "No URI detected in NFC tag" : {
+
+    },
     "Node id" : {
       "localizations" : {
         "ar" : {
@@ -28470,6 +28506,9 @@
           }
         }
       }
+    },
+    "Nothing scanned" : {
+
     },
     "Notifications" : {
       "localizations" : {
@@ -33898,6 +33937,9 @@
           }
         }
       }
+    },
+    "Requesting payment…" : {
+
     },
     "Requesting Swap-In Address..." : {
       "extractionState" : "manual",
@@ -39394,6 +39436,12 @@
         }
       }
     },
+    "The card's host returned error code: %d" : {
+      "comment" : "Error message - processing bolt card payment"
+    },
+    "The card's host returned error message: %@" : {
+      "comment" : "Error message - processing bolt card payment"
+    },
     "The closing transaction is in your transactions list." : {
       "comment" : "label text",
       "localizations" : {
@@ -41401,6 +41449,7 @@
       }
     },
     "This appears to be a website (not a lightning invoice):" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -41439,6 +41488,9 @@
           }
         }
       }
+    },
+    "This appears to be a website:" : {
+
     },
     "This doesn't appear to be a Lightning invoice" : {
       "comment" : "Error message - scanning lightning invoice",
@@ -44565,6 +44617,9 @@
           }
         }
       }
+    },
+    "Unreadable response from card's host" : {
+      "comment" : "Error message - processing bolt card payment"
     },
     "Unreadable response from service: (origin)" : {
       "comment" : "Error message - scanning lightning invoice",

--- a/phoenix-ios/phoenix-ios/Phoenix.entitlements
+++ b/phoenix-ios/phoenix-ios/Phoenix.entitlements
@@ -12,6 +12,10 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>TAG</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.co.acinq.phoenix</string>

--- a/phoenix-ios/phoenix-ios/nfc/NfcReader.swift
+++ b/phoenix-ios/phoenix-ios/nfc/NfcReader.swift
@@ -1,0 +1,154 @@
+import Foundation
+import CoreNFC
+
+fileprivate let filename = "NfcReader"
+#if DEBUG
+fileprivate let log = LoggerFactory.shared.logger(filename, .trace)
+#else
+fileprivate var log = LoggerFactory.shared.logger(filename, .warning)
+#endif
+
+class NfcReader: NSObject, NFCNDEFReaderSessionDelegate {
+	
+	enum ReadError: Error {
+		case readingNotAvailable
+		case alreadyStarted
+		case errorReadingTag
+		case scanningTerminated(NFCReaderError)
+	}
+	
+	static let shared = NfcReader()
+	
+	private let queue: DispatchQueue
+	
+	private var session: NFCNDEFReaderSession? = nil
+	private var callback: ((Result<NFCNDEFMessage, ReadError>) -> Void)? = nil
+	
+	override init() {
+		queue = DispatchQueue(label: "NfcReader")
+	}
+	
+	func readCard(_ callback: @escaping (Result<NFCNDEFMessage, ReadError>) -> Void) {
+		log.trace("readCard()")
+		
+		let fail = { (error: ReadError) in
+			DispatchQueue.main.async {
+				callback(Result.failure(error))
+			}
+		}
+		
+		queue.async { [self] in
+			
+			guard NFCReaderSession.readingAvailable else {
+				log.error("NFCReaderSession.readingAvailable is false")
+				return fail(.readingNotAvailable)
+			}
+			
+			guard session == nil else {
+				log.error("session is already started")
+				return fail(.alreadyStarted)
+			}
+			
+			session = NFCNDEFReaderSession(delegate: self, queue: queue, invalidateAfterFirstRead: true)
+			session?.alertMessage = "Hold your card near the device to read it."
+			
+			self.callback = callback
+			session?.begin()
+			
+			log.info("session is ready")
+		}
+	}
+	
+	// --------------------------------------------------
+	// MARK: Private
+	// --------------------------------------------------
+	
+	private func finishWithSuccess(_ message: NFCNDEFMessage) {
+		
+		guard let session, let callback else {
+			return
+		}
+		log.trace("finishWithSuccess()")
+		
+		session.invalidate()
+		self.session = nil
+		self.callback = nil
+		DispatchQueue.main.async {
+			callback(.success(message))
+		}
+	}
+	
+	private func finishWithError(_ error: ReadError) {
+		
+		guard let session, let callback else {
+			return
+		}
+		log.trace("finishWithError()")
+		
+		session.invalidate()
+		self.session = nil
+		self.callback = nil
+		
+		DispatchQueue.main.async {
+			callback(.failure(error))
+		}
+	}
+	
+	// --------------------------------------------------
+	// MARK: NFCNDEFReaderSessionDelegate
+	// --------------------------------------------------
+	
+	func readerSessionDidBecomeActive(_ session: NFCNDEFReaderSession) {
+		log.trace("readerSessionDidBecomeActive(_)")
+	}
+	
+	func readerSession(_ session: NFCNDEFReaderSession, didInvalidateWithError error: any Error) {
+		log.trace("readerSession(_, didInvalidateWithError:)")
+		log.trace("error: \(error)")
+		
+		let nfcError = (error as? NFCReaderError) ??                                   // this is always the case
+			NFCReaderError(NFCReaderError.readerSessionInvalidationErrorSessionTimeout) // but just to be safe
+		
+		if let _ = error as? NFCReaderError {
+			log.debug("is NFCReaderError")
+		} else {
+			log.debug("!is NFCReaderError")
+		}
+		finishWithError(.scanningTerminated(nfcError))
+	}
+	
+	func readerSession(_ session: NFCNDEFReaderSession, didDetectNDEFs messages: [NFCNDEFMessage]) {
+		log.trace("readerSession(_, didDetectNDEFs:)")
+		log.trace("messages.count = \(messages.count)")
+		
+		if messages.count > 1 {
+			log.warning("NfcReader: Multiple messages detected: this is unsupported, only the first will be read")
+		}
+		
+		if let message = messages.first {
+			finishWithSuccess(message)
+		}
+	}
+	
+	func readerSession(_ session: NFCNDEFReaderSession, didDetect tags: [any NFCNDEFTag]) {
+		log.trace("readerSession(_, didDetectTags:)")
+		log.trace("messages.count = \(tags.count)")
+		
+		if tags.count > 1 {
+			log.warning("NfcReader: Multiple tags detected: this is unsupported, only the first will be read")
+		}
+		
+		if let tag = tags.first {
+			tag.readNDEF { [self] (result, error) in
+				
+				if let result {
+					finishWithSuccess(result)
+					
+				} else if let error {
+					log.error("readNDEF: error = \(error)")
+					finishWithError(.errorReadingTag)
+				}
+			}
+		}
+	}
+}

--- a/phoenix-ios/phoenix-ios/views/receive/LightningDualView.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/LightningDualView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PhoenixShared
+import CoreNFC
 
 fileprivate let filename = "LightningDualView"
 #if DEBUG && true
@@ -40,8 +41,20 @@ struct LightningDualView: View {
 	@State var notificationPermissions = NotificationsManager.shared.permissions.value
 	
 	@State var modificationAmount: CurrencyAmount? = nil
+	@State var modificationTitleType: ModifyInvoiceSheet.TitleType = .normal
 	
-	let lastIncomingPaymentPublisher = Biz.business.paymentsManager.lastIncomingPaymentPublisher()
+	@State var nfcPending: Bool = false
+	@State var nfcErrorMessage: String? = nil
+	
+	@State var nfcScanning: Bool = false
+	@State var nfcParsing: Bool = false
+	@State var nfcRequesting: Bool = false
+	@State var nfcReceiving: Bool = false
+	
+	@State var nfcParseIndex: Int = 0
+	@State var nfcRequestIndex: Int = 0
+	
+	@State var nfcParseProgress: SendManager.ParseProgress? = nil
 	
 	// For the cicular buttons: [copy, share, edit]
 	enum MaxButtonWidth: Preference {}
@@ -50,6 +63,8 @@ struct LightningDualView: View {
 		value: { [$0.size.width] }
 	)
 	@State var maxButtonWidth: CGFloat? = nil
+	
+	let lastIncomingPaymentPublisher = Biz.business.paymentsManager.lastIncomingPaymentPublisher()
 	
 	// To workaround a bug in SwiftUI, we're using multiple namespaces for our animation.
 	// In particular, animating the border around the qrcode doesn't work well.
@@ -170,11 +185,15 @@ struct LightningDualView: View {
 			actionButtons()
 				.padding(.bottom)
 			
-			switchTypeButton()
-			
-			if activeType == .bolt12_offer {
-				howToUseButton()
-					.padding(.top)
+			if nfcScanning || nfcParsing || nfcRequesting || nfcReceiving {
+				nfcActivity()
+				
+			} else {
+				switchTypeButton()
+				if activeType == .bolt12_offer {
+					howToUseButton()
+						.padding(.top)
+				}
 			}
 			
 			if notificationPermissions == .disabled {
@@ -307,12 +326,12 @@ struct LightningDualView: View {
 		
 			if activeType == .bolt11_invoice {
 				invoiceAmountView()
-					.font(.footnote)
+					.font(.callout)
 					.foregroundColor(.secondary)
 			
 				invoiceDescriptionView()
 					.lineLimit(1)
-					.font(.footnote)
+					.font(.callout)
 					.foregroundColor(.secondary)
 				
 			} else {
@@ -321,7 +340,7 @@ struct LightningDualView: View {
 					bip353AddressView(address)
 						.lineLimit(2)
 						.multilineTextAlignment(.center)
-						.font(.footnote)
+						.font(.callout)
 						.foregroundColor(.secondary)
 					
 				} else {
@@ -415,6 +434,7 @@ struct LightningDualView: View {
 			shareButton()
 			if activeType == .bolt11_invoice {
 				editButton()
+				cardButton()
 			}
 		}
 		.assignMaxPreference(for: maxButtonWidthReader.key, to: $maxButtonWidth)
@@ -468,7 +488,7 @@ struct LightningDualView: View {
 	func copyButton() -> some View {
 		
 		actionButton(
-			text: NSLocalizedString("copy", comment: "button label - try to make it short"),
+			text: String(localized: "copy", comment: "button label - try to make it short"),
 			image: Image(systemName: "square.on.square"),
 			width: 20, height: 20,
 			xOffset: 0, yOffset: 0
@@ -485,7 +505,7 @@ struct LightningDualView: View {
 	func shareButton() -> some View {
 		
 		actionButton(
-			text: NSLocalizedString("share", comment: "button label - try to make it short"),
+			text: String(localized: "share", comment: "button label - try to make it short"),
 			image: Image(systemName: "square.and.arrow.up"),
 			width: 21, height: 21,
 			xOffset: 0, yOffset: -1
@@ -502,7 +522,7 @@ struct LightningDualView: View {
 	func editButton() -> some View {
 		
 		actionButton(
-			text: NSLocalizedString("edit", comment: "button label - try to make it short"),
+			text: String(localized: "edit", comment: "button label - try to make it short"),
 			image: Image(systemName: "square.and.pencil"),
 			width: 19, height: 19,
 			xOffset: 1, yOffset: -1
@@ -510,6 +530,20 @@ struct LightningDualView: View {
 			didTapEditButton()
 		}
 		.disabled(!(mvi.model is Receive.Model_Generated))
+	}
+	
+	@ViewBuilder
+	func cardButton() -> some View {
+		
+		actionButton(
+			text: String(localized: "card", comment: "button label - try to make it short"),
+			image: Image(systemName: "creditcard"),
+			width: 21, height: 21,
+			xOffset: 0, yOffset: 0
+		) {
+			didTapCardButton()
+		}
+		.disabled(nfcScanning || nfcParsing || nfcRequesting || nfcReceiving)
 	}
 	
 	@ViewBuilder
@@ -560,6 +594,34 @@ struct LightningDualView: View {
 			showBolt12Sheet()
 		} label: {
 			Label("How to use", systemImage: "info.circle")
+		}
+	}
+	
+	@ViewBuilder
+	func nfcActivity() -> some View {
+		
+		if nfcParsing || nfcRequesting || nfcReceiving {
+			
+			VStack(alignment: HorizontalAlignment.center, spacing: 0) {
+				
+				HorizontalActivity(color: .appAccent, diameter: 10, speed: 1.6)
+					.frame(width: 240, height: 10)
+					.padding(.horizontal)
+					.padding(.bottom, 4)
+				
+				Group {
+					if nfcParsing {
+						Text("Communicating with card's host…")
+					} else if nfcRequesting {
+						Text("Requesting payment…")
+					} else {
+						Text("Awaiting payment…")
+					}
+				}
+				.multilineTextAlignment(.center)
+				
+			} // </VStack>
+			.padding(.top)
 		}
 	}
 	
@@ -659,7 +721,7 @@ struct LightningDualView: View {
 	// MARK: View Transitions
 	// --------------------------------------------------
 	
-	func onAppear() -> Void {
+	func onAppear() {
 		log.trace("onAppear()")
 		
 		// Careful: this function may be called multiple times
@@ -714,6 +776,12 @@ struct LightningDualView: View {
 				original: m.request,
 				rendered: m.request.uppercased()
 			))
+			
+			if nfcPending {
+				nfcPending = false
+				
+				startNfcReader()
+			}
 		}
 	}
 	
@@ -760,6 +828,14 @@ struct LightningDualView: View {
 		))
 	}
 	
+	func modifyInvoiceSheetDidCancel() {
+		log.trace("modifyInvoiceSheetDidCancel()")
+		
+		if nfcPending {
+			nfcPending = false
+		}
+	}
+	
 	func currencyConverterDidChange(_ amount: CurrencyAmount?) {
 		log.trace("currencyConverterDidChange()")
 		
@@ -779,11 +855,13 @@ struct LightningDualView: View {
 		smartModalState.display(dismissable: true) {
 			
 			ModifyInvoiceSheet(
+				titleType: modificationTitleType,
 				savedAmount: $modificationAmount,
 				amount: amount,
 				desc: desc ?? "",
 				openCurrencyConverter: openCurrencyConverter,
-				didSave: modifyInvoiceSheetDidSave
+				didSave: modifyInvoiceSheetDidSave,
+				didCancel: modifyInvoiceSheetDidCancel
 			)
 		}
 	}
@@ -906,19 +984,55 @@ struct LightningDualView: View {
 		log.trace("didTapEditButton()")
 		
 		// The edit button is only displayed for Bolt 11 invoices.
+		guard let model = mvi.model as? Receive.Model_Generated else {
+			log.warning("didTapEditButton(): ignoring: model is not Receive.Model_Generated")
+			return
+		}
 		
-		if let model = mvi.model as? Receive.Model_Generated {
+		modificationTitleType = .normal
+		smartModalState.display(dismissable: true) {
 			
+			ModifyInvoiceSheet(
+				titleType: modificationTitleType,
+				savedAmount: $modificationAmount,
+				amount: model.amount,
+				desc: model.desc ?? "",
+				openCurrencyConverter: openCurrencyConverter,
+				didSave: modifyInvoiceSheetDidSave,
+				didCancel: modifyInvoiceSheetDidCancel
+			)
+		}
+	}
+	
+	func didTapCardButton() {
+		log.trace("didCardEditButton()")
+		
+		// The card button is only displayed for Bolt 11 invoices.
+		guard let model = mvi.model as? Receive.Model_Generated else {
+			log.warning("didTapCardButton(): ignoring: model is not Receive.Model_Generated")
+			return
+		}
+		
+		if model.amount == nil {
+			// We need the user to enter an amount first.
+			
+			nfcPending = true
+			modificationTitleType = .cardPaymentNeedsAmount
 			smartModalState.display(dismissable: true) {
 				
 				ModifyInvoiceSheet(
+					titleType: modificationTitleType,
 					savedAmount: $modificationAmount,
 					amount: model.amount,
 					desc: model.desc ?? "",
 					openCurrencyConverter: openCurrencyConverter,
-					didSave: modifyInvoiceSheetDidSave
+					didSave: modifyInvoiceSheetDidSave,
+					didCancel: modifyInvoiceSheetDidCancel
 				)
 			}
+			
+		} else {
+			startNfcReader()
 		}
 	}
 	
@@ -1024,5 +1138,237 @@ struct LightningDualView: View {
 		let uiImg = UIImage(cgImage: cgImage)
 		activeSheet = ActiveSheet.sharingImage(image: uiImg)
 	}
+	
+	// --------------------------------------------------
+	// MARK: Card Payment
+	// --------------------------------------------------
+	
+	func startNfcReader() {
+		log.trace("startNfcReader()")
+		
+		nfcScanning = true
+		NfcReader.shared.readCard { result in
+			
+			nfcScanning = false
+			switch result {
+			case .failure(let failure):
+				switch failure {
+				case .readingNotAvailable:
+					nfcErrorMessage = String(localized: "NFC cababilities not available on this device")
+				case .alreadyStarted:
+					nfcErrorMessage = String(localized: "NFC reader is already scanning")
+				case .scanningTerminated(_):
+					nfcErrorMessage = String(localized: "Nothing scanned")
+				case .errorReadingTag:
+					nfcErrorMessage = String(localized: "Error reading tag")
+				}
+				
+			case .success(let result):
+				log.debug("NFCNDEFMessage: \(result)")
+				
+				var scannedUri: URL? = nil
+				
+				result.records.forEach { payload in
+					if let uri = payload.wellKnownTypeURIPayload() {
+						log.debug("found uri = \(uri)")
+						if scannedUri == nil {
+							scannedUri = uri
+						}
+						
+					} else if let text = payload.wellKnownTypeTextPayload().0 {
+						log.debug("found text = \(text)")
+						
+					} else {
+						log.debug("found tag with unknown type")
+					}
+				}
+				
+				if let scannedUri {
+					nfcErrorMessage = nil
+					handleScannedUri(scannedUri)
+					
+				} else {
+					nfcErrorMessage = String(localized: "No URI detected in NFC tag")
+				}
+			}
+		}
+	}
+	
+	func handleScannedUri(_ scannedUri: URL) {
+		log.trace("handleScannedUri(\(scannedUri.absoluteString))")
+		
+		nfcParsing = true
+		nfcParseIndex += 1
+		let index = nfcParseIndex
+		
+		Task { @MainActor in
+			do {
+				let progressHandler = {(progress: SendManager.ParseProgress) -> Void in
+					if index == nfcParseIndex {
+						nfcParseProgress = progress
+					} else {
+						log.warning("handleScannedUri: progressHandler: ignoring: cancelled")
+					}
+				}
+				
+				let result: SendManager.ParseResult = try await Biz.business.sendManager.parse(
+					request: scannedUri.absoluteString,
+					progress: progressHandler
+				)
+				
+				if index == nfcParseIndex {
+					nfcParsing = false
+					nfcParseProgress = nil
+					handleParseResult(result)
+				} else {
+					log.info("handleScannedUri: result: ignoring: cancelled")
+				}
+				
+			} catch {
+				log.error("handleScannedUri: error: \(error)")
+				
+				if index == nfcParseIndex {
+					nfcParsing = false
+					nfcParseProgress = nil
+					nfcErrorMessage = String(localized: "Could not communicate with card's wallet")
+				} else {
+					log.info("handleScannedUri: error: ignoring: cancelled")
+				}
+			}
+			
+		} // </Task>
+	}
+	
+	func handleParseResult(_ result: SendManager.ParseResult) {
+		log.trace("handleParseResult()")
+		
+		guard let expectedResult = result as? SendManager.ParseResult_Lnurl_Withdraw else {
+			handleParseError(result)
+			return
+		}
+		
+		guard let model = mvi.model as? Receive.Model_Generated else {
+			return
+		}
+		
+		nfcRequesting = true
+		nfcRequestIndex += 1
+		let index = nfcRequestIndex
+		
+		Task { @MainActor in
+			do {
+				
+				let err: SendManager.LnurlWithdrawError? =
+					try await Biz.business.sendManager.lnurlWithdraw_sendInvoice(
+						lnurlWithdraw: expectedResult.lnurlWithdraw,
+						invoice: model.invoice
+					)
+				
+				if index == nfcRequestIndex {
+					nfcRequesting = false
+					if let remoteErr = err as? SendManager.LnurlWithdrawErrorRemoteError {
+						handleRequestError(remoteErr)
+					} else {
+						nfcReceiving = true
+					}
+				} else {
+					log.info("handleParseResult: result: ignoring: cancelled")
+				}
+				
+			} catch {
+				log.error("handleParseResult: error: \(error)")
+				
+				if index == nfcRequestIndex {
+					nfcRequesting = false
+					nfcErrorMessage = String(localized: "Cound not communicate with card's wallet")
+				} else {
+					log.error("handleParseResult: error: ignoring: cancelled")
+				}
+			}
+		} // </Task>
+	}
+	
+	func handleParseError(_ result: SendManager.ParseResult) {
+		log.trace("handleParseError()")
+		
+		var msg = String(localized: "Does not appear to be a bolt card.")
+		var websiteLink: URL? = nil
+		
+		if let badRequest = result as? SendManager.ParseResult_BadRequest {
+			
+			if let serviceError = badRequest.reason as? SendManager.BadRequestReason_ServiceError {
+				
+				let remoteFailure: LnurlError.RemoteFailure = serviceError.error
+				let origin = remoteFailure.origin
+				
+				if remoteFailure is LnurlError.RemoteFailure_IsWebsite {
+					websiteLink = URL(string: serviceError.url.description())
+					msg = String(
+						localized: "Unreadable response from service: \(origin)",
+						comment: "Error message - scanning lightning invoice"
+					)
+				}
+			}
+		}
+		
+		if let websiteLink {
+			popoverState.display(dismissable: true) {
+				WebsiteLinkPopover(
+					link: websiteLink,
+					didCopyLink: didCopyLink,
+					didOpenLink: nil
+				)
+			}
+			
+		} else {
+			nfcErrorMessage = msg
+		}
+	}
+	
+	func handleRequestError(_ result: SendManager.LnurlWithdrawErrorRemoteError) {
+		log.trace("handleRequestError()")
+		
+		let remoteFailure = result.err
+		switch remoteFailure {
+		
+		case is LnurlError.RemoteFailure_CouldNotConnect:
+			nfcErrorMessage = String(
+				localized: "Could not connect to card's host",
+				comment: "Error message - processing bolt card payment"
+			)
+			
+		case is LnurlError.RemoteFailure_Unreadable:
+			nfcErrorMessage = String(
+				localized: "Unreadable response from card's host",
+				comment: "Error message - processing bolt card payment"
+			)
+			
+		case let rfDetailed as LnurlError.RemoteFailure_Detailed:
+			nfcErrorMessage = String(
+				localized: "The card's host returned error message: \(rfDetailed.reason)",
+				comment: "Error message - processing bolt card payment"
+			)
+			
+		case let rfCode as LnurlError.RemoteFailure_Code:
+			nfcErrorMessage = String(
+				localized: "The card's host returned error code: \(rfCode.code.value)",
+				comment: "Error message - processing bolt card payment"
+			)
+			
+		default:
+			nfcErrorMessage = String(
+				localized: "Could not communicate with card's wallet",
+				comment: "Error message - scanning lightning invoice"
+			)
+		}
+	}
+	
+	func didCopyLink() {
+		log.trace("didCopyLink()")
+		
+		toast.pop(
+			NSLocalizedString("Copied to pasteboard!", comment: "Toast message"),
+			colorScheme: colorScheme.opposite
+		)
+	}
 }
-

--- a/phoenix-ios/phoenix-ios/views/receive/ModifyInvoiceSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/ModifyInvoiceSheet.swift
@@ -10,11 +10,18 @@ fileprivate var log = LoggerFactory.shared.logger(filename, .warning)
 
 struct ModifyInvoiceSheet: View {
 
+	enum TitleType {
+		case normal
+		case cardPaymentNeedsAmount
+	}
+	let titleType: TitleType
+	
 	@Binding var savedAmount: CurrencyAmount?
 	let initialAmount: Lightning_kmpMilliSatoshi?
 	
 	let openCurrencyConverter: () -> Void
 	let didSave: (Lightning_kmpMilliSatoshi?, String) -> Void
+	let didCancel: () -> Void
 	
 	@State var desc: String
 	
@@ -26,6 +33,8 @@ struct ModifyInvoiceSheet: View {
 	@State var parsedAmount: Result<Double, TextFieldCurrencyStylerError> = Result.failure(.emptyInput)
 	
 	@State var altAmount: String = ""
+	
+	@State var didTapSave: Bool = false
 	
 	@EnvironmentObject var currencyPrefs: CurrencyPrefs
 	@EnvironmentObject var smartModalState: SmartModalState
@@ -39,17 +48,21 @@ struct ModifyInvoiceSheet: View {
 	@State var textHeight: CGFloat? = nil
 
 	init(
+		titleType: TitleType,
 		savedAmount: Binding<CurrencyAmount?>,
 		amount: Lightning_kmpMilliSatoshi?,
 		desc: String,
 		openCurrencyConverter: @escaping () -> Void,
-		didSave: @escaping (Lightning_kmpMilliSatoshi?, String) -> Void
+		didSave: @escaping (Lightning_kmpMilliSatoshi?, String) -> Void,
+		didCancel: @escaping () -> Void
 	) {
+		self.titleType = titleType
 		self._savedAmount = savedAmount
 		self.initialAmount = amount
 		self._desc = State<String>(initialValue: desc)
 		self.openCurrencyConverter = openCurrencyConverter
 		self.didSave = didSave
+		self.didCancel = didCancel
 	}
 	
 	// --------------------------------------------------
@@ -60,10 +73,18 @@ struct ModifyInvoiceSheet: View {
 	var body: some View {
 		
 		VStack(alignment: .leading) {
-			Text("Edit payment request")
-				.font(.title3)
-				.padding([.top, .bottom])
-				.accessibilityAddTraits(.isHeader)
+			
+			Group {
+				switch titleType {
+				case .normal:
+					Text("Edit payment request")
+				case .cardPaymentNeedsAmount:
+					Text("Amount required for card payment").foregroundStyle(Color.appNegative).bold()
+				}
+			}
+			.font(.title3)
+			.padding([.top, .bottom])
+			.accessibilityAddTraits(.isHeader)
 
 			HStack {
 				TextField(
@@ -268,6 +289,12 @@ struct ModifyInvoiceSheet: View {
 		
 		currencyList = Currency.displayable(currencyPrefs: currencyPrefs, plus: currency)
 		currencyPickerChoice = CurrencyPickerOption.currency(currency)
+		
+		smartModalState.onNextDidDisappear {
+			if !didTapSave {
+				didCancel()
+			}
+		}
 	}
 	
 	func amountDidChange() -> Void {
@@ -402,6 +429,7 @@ struct ModifyInvoiceSheet: View {
 			savedAmount = nil
 		}
 		
+		didTapSave = true
 		smartModalState.close(animationCompletion: {
 			didSave(msat, trimmedDesc)
 		})

--- a/phoenix-ios/phoenix-ios/views/send/WebsiteLinkPopover.swift
+++ b/phoenix-ios/phoenix-ios/views/send/WebsiteLinkPopover.swift
@@ -27,7 +27,7 @@ struct WebsiteLinkPopover: View {
 		
 		VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
 			
-			Text("This appears to be a website (not a lightning invoice):")
+			Text("This appears to be a website:")
 				.padding(.bottom, 10)
 			
 			Text(verbatim: link.absoluteString)

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/Receive.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/Receive.kt
@@ -1,6 +1,7 @@
 package fr.acinq.phoenix.controllers.payments
 
 import fr.acinq.lightning.MilliSatoshi
+import fr.acinq.lightning.payment.Bolt11Invoice
 import fr.acinq.phoenix.controllers.MVI
 
 object Receive {
@@ -8,7 +9,13 @@ object Receive {
     sealed class Model : MVI.Model() {
         object Awaiting : Model()
         object Generating: Model()
-        data class Generated(val request: String, val paymentHash: String, val amount: MilliSatoshi?, val desc: String?): Model()
+        data class Generated(
+            val invoice: Bolt11Invoice,
+            val request: String,
+            val paymentHash: String,
+            val amount: MilliSatoshi?,
+            val desc: String?
+        ): Model()
     }
 
     sealed class Intent : MVI.Intent() {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/ReceiveController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/payments/ReceiveController.kt
@@ -51,7 +51,13 @@ class AppReceiveController(
                         description = Either.Left(intent.description),
                         expiry = intent.expirySeconds.seconds
                     )
-                    model(Receive.Model.Generated(paymentRequest.write(), paymentRequest.paymentHash.toHex(), paymentRequest.amount, paymentRequest.description))
+                    model(Receive.Model.Generated(
+                        invoice = paymentRequest,
+                        request = paymentRequest.write(),
+                        paymentHash = paymentRequest.paymentHash.toHex(),
+                        amount = paymentRequest.amount,
+                        desc = paymentRequest.description
+                    ))
                 }
             }
         }


### PR DESCRIPTION
The [Bolt Card](https://www.boltcard.org/) allows for bitcoin payments over the lightning network using a contactless payment card.

In order to support **receiving** payments via a Bolt Card, all we have to do is:

1. Scan a standard NDEF tag via NFC
2. The resulting URI is a lnurl-withdraw (which we already fully support)

This basically means the only work we have to do is add support for scanning an NFC tag.

https://github.com/user-attachments/assets/c7644b85-ffe0-47a1-aeb8-db86807d3d51

Notes:
There is a separate PR to add support for linking a Bolt Card to a Phoenix wallet. Which means you could then use the card to make contactless payments from your Phoenix wallet.