### PR TITLE
(ios) Fixing iOS-18 bug

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		DC9B15442B7D0DCB0023743B /* AsyncAlgorithms in Frameworks */ = {isa = PBXBuildFile; productRef = DC9B15432B7D0DCB0023743B /* AsyncAlgorithms */; };
 		DC9B8EE225D72CC200E13818 /* ForceCloseChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9B8EE125D72CC200E13818 /* ForceCloseChannelsView.swift */; };
 		DC9CF83D2D2C6D37003F3B0F /* ScrollView_18.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9CF83C2D2C6D31003F3B0F /* ScrollView_18.swift */; };
+		DC9CF83F2D2DC3F3003F3B0F /* GeometryGroup_17.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9CF83E2D2DC3ED003F3B0F /* GeometryGroup_17.swift */; };
 		DC9E7EC32A12955300A5F1D0 /* LiquidityHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9E7EC22A12955300A5F1D0 /* LiquidityHTML.swift */; };
 		DC9E7EC62A1295B100A5F1D0 /* liquidity.html in Resources */ = {isa = PBXBuildFile; fileRef = DC9E7EC82A1295B100A5F1D0 /* liquidity.html */; };
 		DCA02B9D2BD065BF0080520F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = DCA02B9C2BD065BF0080520F /* PrivacyInfo.xcprivacy */; };
@@ -628,6 +629,7 @@
 		DC9AD20C2C9C90A20019BEE9 /* ParseResultHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseResultHelper.swift; sourceTree = "<group>"; };
 		DC9B8EE125D72CC200E13818 /* ForceCloseChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForceCloseChannelsView.swift; sourceTree = "<group>"; };
 		DC9CF83C2D2C6D31003F3B0F /* ScrollView_18.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollView_18.swift; sourceTree = "<group>"; };
+		DC9CF83E2D2DC3ED003F3B0F /* GeometryGroup_17.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeometryGroup_17.swift; sourceTree = "<group>"; };
 		DC9E7EC22A12955300A5F1D0 /* LiquidityHTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidityHTML.swift; sourceTree = "<group>"; };
 		DC9E7EC72A1295B100A5F1D0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = Base; path = Base.lproj/liquidity.html; sourceTree = "<group>"; };
 		DCA02B9C2BD065BF0080520F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -1291,6 +1293,7 @@
 		DCAC9FC42968793D0098D769 /* compatibility */ = {
 			isa = PBXGroup;
 			children = (
+				DC9CF83E2D2DC3ED003F3B0F /* GeometryGroup_17.swift */,
 				DC9CF83C2D2C6D31003F3B0F /* ScrollView_18.swift */,
 				DC6CF35A2938F32E001837EE /* ListBackgroundColor.swift */,
 				DC5E28CB2C63EF8E0037B3D3 /* NavigationLink_16.swift */,
@@ -1861,6 +1864,7 @@
 				DC4309702A795F9900E28995 /* UtxoWrapper.swift in Sources */,
 				DC355E1D2A4398A8008E8A8E /* NoticeBox.swift in Sources */,
 				7555FF81242A565900829871 /* SceneDelegate.swift in Sources */,
+				DC9CF83F2D2DC3F3003F3B0F /* GeometryGroup_17.swift in Sources */,
 				DCC9D99A267BD28600EA36DD /* SyncBackupManager.swift in Sources */,
 				DCB876302735AA7300657570 /* UserDefaults+Serialization.swift in Sources */,
 				DC5F1C4C28DDF702007A55ED /* DrainWalletView_Action.swift in Sources */,

--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		DC9AD20D2C9C90A20019BEE9 /* ParseResultHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9AD20C2C9C90A20019BEE9 /* ParseResultHelper.swift */; };
 		DC9B15442B7D0DCB0023743B /* AsyncAlgorithms in Frameworks */ = {isa = PBXBuildFile; productRef = DC9B15432B7D0DCB0023743B /* AsyncAlgorithms */; };
 		DC9B8EE225D72CC200E13818 /* ForceCloseChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9B8EE125D72CC200E13818 /* ForceCloseChannelsView.swift */; };
+		DC9CF83D2D2C6D37003F3B0F /* ScrollView_18.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9CF83C2D2C6D31003F3B0F /* ScrollView_18.swift */; };
 		DC9E7EC32A12955300A5F1D0 /* LiquidityHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9E7EC22A12955300A5F1D0 /* LiquidityHTML.swift */; };
 		DC9E7EC62A1295B100A5F1D0 /* liquidity.html in Resources */ = {isa = PBXBuildFile; fileRef = DC9E7EC82A1295B100A5F1D0 /* liquidity.html */; };
 		DCA02B9D2BD065BF0080520F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = DCA02B9C2BD065BF0080520F /* PrivacyInfo.xcprivacy */; };
@@ -626,6 +627,7 @@
 		DC9AD1F02C9B81450019BEE9 /* PaymentRequestedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentRequestedView.swift; sourceTree = "<group>"; };
 		DC9AD20C2C9C90A20019BEE9 /* ParseResultHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseResultHelper.swift; sourceTree = "<group>"; };
 		DC9B8EE125D72CC200E13818 /* ForceCloseChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForceCloseChannelsView.swift; sourceTree = "<group>"; };
+		DC9CF83C2D2C6D31003F3B0F /* ScrollView_18.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollView_18.swift; sourceTree = "<group>"; };
 		DC9E7EC22A12955300A5F1D0 /* LiquidityHTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidityHTML.swift; sourceTree = "<group>"; };
 		DC9E7EC72A1295B100A5F1D0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = Base; path = Base.lproj/liquidity.html; sourceTree = "<group>"; };
 		DCA02B9C2BD065BF0080520F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -1289,10 +1291,11 @@
 		DCAC9FC42968793D0098D769 /* compatibility */ = {
 			isa = PBXGroup;
 			children = (
+				DC9CF83C2D2C6D31003F3B0F /* ScrollView_18.swift */,
 				DC6CF35A2938F32E001837EE /* ListBackgroundColor.swift */,
-				DC2ABAD62BED081400C11C9C /* VibrationFeedback.swift */,
-				DC5E288D2C62C3DF0037B3D3 /* NavigationStackDestination.swift */,
 				DC5E28CB2C63EF8E0037B3D3 /* NavigationLink_16.swift */,
+				DC5E288D2C62C3DF0037B3D3 /* NavigationStackDestination.swift */,
+				DC2ABAD62BED081400C11C9C /* VibrationFeedback.swift */,
 			);
 			path = compatibility;
 			sourceTree = "<group>";
@@ -1844,6 +1847,7 @@
 				7555FF7F242A565900829871 /* AppDelegate.swift in Sources */,
 				DC74174B270F332700F7E3E3 /* KotlinTypes.swift in Sources */,
 				DC142135261E72320075857A /* AboutHTML.swift in Sources */,
+				DC9CF83D2D2C6D37003F3B0F /* ScrollView_18.swift in Sources */,
 				DC33C5632A7C15D40053D785 /* MainView_BigPrimary.swift in Sources */,
 				DC6F19C12C470F70004EC469 /* PickerResult.swift in Sources */,
 				DCEE8998288605FD00FE42DD /* PaymentCell.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/views/compatibility/GeometryGroup_17.swift
+++ b/phoenix-ios/phoenix-ios/views/compatibility/GeometryGroup_17.swift
@@ -1,0 +1,23 @@
+/// Good description of `.geometryGroup()`
+/// https://fatbobman.com/en/posts/mastring-geometrygroup/
+
+import SwiftUI
+
+struct GeometryGroupViewModifier: ViewModifier {
+	
+	@ViewBuilder
+	func body(content: Content) -> some View {
+		if #available(iOS 17, *) {
+			content.geometryGroup()
+		} else {
+			content
+		}
+	}
+}
+
+extension View {
+	
+	func _geometryGroup() -> some View {
+		modifier(GeometryGroupViewModifier())
+	}
+}

--- a/phoenix-ios/phoenix-ios/views/compatibility/ScrollView_18.swift
+++ b/phoenix-ios/phoenix-ios/views/compatibility/ScrollView_18.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+fileprivate let filename = "ScrollView_18"
+#if DEBUG && true
+fileprivate var log = LoggerFactory.shared.logger(filename, .trace)
+#else
+fileprivate var log = LoggerFactory.shared.logger(filename, .warning)
+#endif
+
+struct ScrollTargetLayoutViewModifier: ViewModifier {
+	
+	@ViewBuilder
+	func body(content: Content) -> some View {
+		if #available(iOS 18, *) {
+			content.scrollTargetLayout()
+		} else {
+			content
+		}
+	}
+}
+
+struct ScrollTargetBehaviorViewModifier: ViewModifier {
+	
+	@ViewBuilder
+	func body(content: Content) -> some View {
+		if #available(iOS 18, *) {
+			content.scrollTargetBehavior(.viewAligned)
+		} else {
+			content
+		}
+	}
+}
+
+enum ScrollAnchorRoleProxy {
+	case alignment
+	case initialOffset
+	case sizeChanges
+	
+	@available(iOS 18.0, *)
+	func convert() -> ScrollAnchorRole {
+		switch self {
+		case .alignment     : return ScrollAnchorRole.alignment
+		case .initialOffset : return ScrollAnchorRole.initialOffset
+		case .sizeChanges   : return ScrollAnchorRole.sizeChanges
+		}
+	}
+}
+
+@available(iOS 18.0, *)
+struct DefaultScrollAnchorViewModifier: ViewModifier {
+	let anchor: UnitPoint
+	let role: ScrollAnchorRoleProxy
+	
+	@ViewBuilder
+	func body(content: Content) -> some View {
+		content
+			.defaultScrollAnchor(anchor, for: role.convert())
+	}
+}
+
+struct ScrollPositionProxy {
+	
+	private var _scrollPosition: Any?
+
+	@available(iOS 18, *)
+	var target: ScrollPosition {
+		get { return _scrollPosition as! ScrollPosition }
+		set { _scrollPosition = newValue }
+	}
+
+	init() {
+		if #available(iOS 18, *) {
+			target = ScrollPosition()
+		}
+	}
+}
+
+@available(iOS 18.0, *)
+struct ScrollPositionViewModifier: ViewModifier {
+	@Binding var position: ScrollPositionProxy
+	let anchor: UnitPoint?
+	
+	@ViewBuilder
+	func body(content: Content) -> some View {
+		content.scrollPosition(_position.target)
+	}
+}
+
+extension View {
+	
+	func _scrollTargetLayout() -> some View {
+		modifier(ScrollTargetLayoutViewModifier())
+	}
+	
+	func _scrollTargetBehavior() -> some View {
+		modifier(ScrollTargetBehaviorViewModifier())
+	}
+	
+	func _defaultScrollAnchor(_ anchor: UnitPoint, for role: ScrollAnchorRoleProxy) -> some View {
+		modifier(__defaultScrollAnchor(anchor, role))
+	}
+	
+	fileprivate func __defaultScrollAnchor(
+		_ anchor: UnitPoint,
+		_ role: ScrollAnchorRoleProxy
+	) -> some ViewModifier {
+		if #available(iOS 18, *) {
+			return DefaultScrollAnchorViewModifier(anchor: anchor, role: role)
+		} else {
+			return EmptyModifier()
+		}
+	}
+	
+	func _scrollPosition(_ position: Binding<ScrollPositionProxy>, anchor: UnitPoint? = nil) -> some View {
+		modifier(__scrollPosition(position, anchor: anchor))
+	}
+	
+	fileprivate func __scrollPosition(
+		_ position: Binding<ScrollPositionProxy>,
+		anchor: UnitPoint?
+	) -> some ViewModifier {
+		if #available(iOS 18, *) {
+			return ScrollPositionViewModifier(position: position, anchor: anchor)
+		} else {
+			return EmptyModifier()
+		}
+	}
+}

--- a/phoenix-ios/phoenix-ios/views/main/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/main/HomeView.swift
@@ -56,7 +56,7 @@ struct HomeView : MVIView {
 	let contactsPublisher = Biz.business.contactsManager.contactsListPublisher()
 	
 	@State var didAppear = false
-	
+		
 	enum NoticeBoxContentHeight: Preference {}
 	let noticeBoxContentHeightReader = GeometryPreferenceReader(
 		key: AppendValue<NoticeBoxContentHeight>.self,
@@ -107,37 +107,37 @@ struct HomeView : MVIView {
 	@ViewBuilder
 	var view: some View {
 		
-		ZStack {
-			content()
-		}
-		.frame(maxWidth: .infinity, maxHeight: .infinity)
-		.onChange(of: mvi.model) { newModel in
-			onModelChange(model: newModel)
-		}
-		.onChange(of: currencyPrefs.hideAmounts) { _ in
-			hideAmountsChanged()
-		}
-		.onReceive(recentPaymentsConfigPublisher) {
-			recentPaymentsConfigChanged($0)
-		}
-		.onReceive(paymentsPagePublisher) {
-			paymentsPageChanged($0)
-		}
-		.onReceive(lastCompletedPaymentPublisher) {
-			lastCompletedPaymentChanged($0)
-		}
-		.onReceive(swapInWalletPublisher) {
-			swapInWalletChanged($0)
-		}
-		.onReceive(channelsPublisher) {
-			channelsChanged($0)
-		}
-		.onReceive(bizNotificationsPublisher) {
-			bizNotificationsChanged($0)
-		}
-		.onReceive(contactsPublisher) {
-			contactsChanged($0)
-		}
+		content()
+			.onAppear {
+				onAppear()
+			}
+			.onChange(of: mvi.model) { newModel in
+				onModelChange(model: newModel)
+			}
+			.onChange(of: currencyPrefs.hideAmounts) { _ in
+				hideAmountsChanged()
+			}
+			.onReceive(recentPaymentsConfigPublisher) {
+				recentPaymentsConfigChanged($0)
+			}
+			.onReceive(paymentsPagePublisher) {
+				paymentsPageChanged($0)
+			}
+			.onReceive(lastCompletedPaymentPublisher) {
+				lastCompletedPaymentChanged($0)
+			}
+			.onReceive(swapInWalletPublisher) {
+				swapInWalletChanged($0)
+			}
+			.onReceive(channelsPublisher) {
+				channelsChanged($0)
+			}
+			.onReceive(bizNotificationsPublisher) {
+				bizNotificationsChanged($0)
+			}
+			.onReceive(contactsPublisher) {
+				contactsChanged($0)
+			}
 	}
 
 	@ViewBuilder
@@ -155,9 +155,7 @@ struct HomeView : MVIView {
 			notices()
 			paymentsList()
 		}
-		.onAppear {
-			onAppear()
-		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity)
 		.sheet(isPresented: Binding( // SwiftUI only allows for 1 ".sheet"
 			get: { activeSheet != nil },
 			set: { if !$0 { activeSheet = nil }}
@@ -559,8 +557,8 @@ struct HomeView : MVIView {
 	@ViewBuilder
 	func paymentsList() -> some View {
 		
-		ScrollView {
-			LazyVStack {
+		ScrollView(.vertical) {
+			VStack {
 				// paymentsPage.rows: [WalletPaymentOrderRow]
 				//
 				// Here's how this works:
@@ -592,8 +590,10 @@ struct HomeView : MVIView {
 					didAppearCallback: footerCellDidAppear
 				)
 				.accessibilitySortPriority(10)
-			}
-		}
+				
+			} // </VStack>
+			
+		} // </ScrollView>
 		.frame(maxWidth: deviceInfo.textColumnMaxWidth)
 	}
 	
@@ -787,7 +787,7 @@ struct HomeView : MVIView {
 	}
 	
 	func paymentsPageChanged(_ page: PaymentsPage) {
-		log.trace("paymentsPageChanged()")
+		log.trace("paymentsPageChanged(count: \(page.count), offset: \(page.offset))")
 		
 		paymentsPage = page
 	}

--- a/phoenix-ios/phoenix-ios/views/widgets/AnimatedClock.swift
+++ b/phoenix-ios/phoenix-ios/views/widgets/AnimatedClock.swift
@@ -89,7 +89,8 @@ struct AnimatedClock: View {
 							.foregroundColor(Color(UIColor.systemGray4))
 					)
 			}
-		}
+		} // </ZStack>
+		._geometryGroup()
 		.onTapGesture {
 			state.toggle()
 		}


### PR DESCRIPTION
On iOS 18, when a new payment was created (either sent or received), it wasn't visible on the Home screen. The issue was that the new row was (for some reason) scrolled out-of-view. This has to do with changes made to the ScrollView API's in iOS 18.

Also I fixed a long-standing animation glitch in the `AnimatedClock`.