### PR TITLE
Clarify UI for automated liquidity purchases

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-lightningkmp = "1.8.5-SNAPSHOT"
+lightningkmp = "1.9.0"
 secp256k1 = "0.17.1"
 
 kotlin = "2.1.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ logback = "3.0.0"
 fcm = "24.1.0"
 playservices = "18.5.0"
 
+junit = "4.13"
 espresso = "3.3.0"
 robolectric = "4.13"
 agp = "8.8.0"

--- a/phoenix-android/build.gradle.kts
+++ b/phoenix-android/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "fr.acinq.phoenix.testnet"
         minSdk = 26
         targetSdk = 34
-        versionCode = 98
+        versionCode = 99
         versionName = gitCommitHash()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/phoenix-android/build.gradle.kts
+++ b/phoenix-android/build.gradle.kts
@@ -144,6 +144,7 @@ dependencies {
     implementation("com.google.firebase:firebase-messaging:${libs.versions.fcm.get()}")
     implementation("com.google.android.gms:play-services-base:${libs.versions.playservices.get()}")
 
+    testImplementation("junit:junit:${libs.versions.junit.get()}")
     testImplementation("app.cash.sqldelight:sqlite-driver:${libs.versions.sqldelight.get()}")
     androidTestImplementation("androidx.test.ext:junit:${libs.versions.androidx.junit.get()}")
     androidTestImplementation("androidx.test.espresso:espresso-core:${libs.versions.espresso.get()}")

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/scanner/ScannerView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/components/scanner/ScannerView.kt
@@ -23,6 +23,8 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
 import androidx.camera.core.CameraSelector
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.view.CameraController
 import androidx.camera.view.LifecycleCameraController
 import androidx.camera.view.PreviewView
@@ -98,6 +100,10 @@ fun BoxScope.ScannerView(
             view.post {
                 cameraController.cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
                 cameraController.setEnabledUseCases(CameraController.IMAGE_ANALYSIS)
+                cameraController.imageAnalysisResolutionSelector = ResolutionSelector.Builder()
+                    .setResolutionStrategy(ResolutionStrategy(ZxingQrCodeAnalyzer.DEFAULT_RESOLUTION, ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER))
+                    .setAllowedResolutionMode(ResolutionSelector.PREFER_HIGHER_RESOLUTION_OVER_CAPTURE_RATE)
+                    .build()
                 cameraController.setImageAnalysisAnalyzer(analyserExecutor, ZxingQrCodeAnalyzer { result ->
                     scannedText = result.text.trim().takeIf { it.isNotBlank() }
                 })

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/details/splash/SplashOutgoingAutoLiquidityPurchase.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/details/splash/SplashOutgoingAutoLiquidityPurchase.kt
@@ -16,22 +16,32 @@
 
 package fr.acinq.phoenix.android.payments.details.splash
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import fr.acinq.lightning.db.AutomaticLiquidityPurchasePayment
-import fr.acinq.lightning.db.ManualLiquidityPurchasePayment
+import fr.acinq.lightning.db.WalletPayment
 import fr.acinq.phoenix.android.LocalBitcoinUnit
 import fr.acinq.phoenix.android.R
+import fr.acinq.phoenix.android.business
+import fr.acinq.phoenix.android.components.Button
 import fr.acinq.phoenix.android.components.SplashLabelRow
+import fr.acinq.phoenix.android.navController
+import fr.acinq.phoenix.android.navigateToPaymentDetails
 import fr.acinq.phoenix.android.utils.Converter.toPrettyString
 import fr.acinq.phoenix.android.utils.Converter.toRelativeDateString
 import fr.acinq.phoenix.android.utils.MSatDisplayPolicy
 import fr.acinq.phoenix.android.utils.annotatedStringResource
+import fr.acinq.phoenix.android.utils.mutedBgColor
 import fr.acinq.phoenix.android.utils.mutedTextColor
 import fr.acinq.phoenix.android.utils.positiveColor
 import fr.acinq.phoenix.utils.extensions.state
@@ -44,6 +54,33 @@ fun SplashAutoLiquidityPurchase(
     SplashLabelRow(label = stringResource(id = R.string.paymentdetails_liquidity_purchase_label)) {
         Text(text = payment.liquidityPurchase.amount.toPrettyString(LocalBitcoinUnit.current, withUnit = true, mSatDisplayPolicy = MSatDisplayPolicy.SHOW_IF_ZERO_SATS))
     }
+
+    val navController = navController
+    val paymentsManager = business.paymentsManager
+    val relatedPayment by produceState<WalletPayment?>(null) {
+        if (payment.incomingPaymentReceivedAt != null) {
+            value = paymentsManager.getIncomingPaymentForTxId(payment.txId)
+        }
+    }
+    relatedPayment?.let {
+        SplashLabelRow(
+            label = stringResource(id = R.string.paymentdetails_liquidity_caused_by_label),
+            helpMessage = stringResource(id = R.string.paymentdetails_liquidity_caused_by_help),
+            helpLink = stringResource(id = R.string.paymentdetails_liquidity_caused_by_help_link) to "https://acinq.co/faq#what-is-inbound-liquidity",
+        ) {
+            Button(
+                text = it.id.toString(),
+                onClick = { navigateToPaymentDetails(navController, it.id, isFromEvent = false) },
+                maxLines = 1,
+                padding = PaddingValues(horizontal = 7.dp, vertical = 5.dp),
+                space = 4.dp,
+                shape = RoundedCornerShape(12.dp),
+                backgroundColor = mutedBgColor,
+                modifier = Modifier.widthIn(max = 130.dp)
+            )
+        }
+    }
+
     SplashFee(payment = payment)
 }
 

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/history/PaymentLine.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/history/PaymentLine.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import fr.acinq.lightning.db.AutomaticLiquidityPurchasePayment
 import fr.acinq.lightning.db.LightningIncomingPayment
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.db.SpliceCpfpOutgoingPayment
@@ -87,12 +88,12 @@ fun PaymentLine(
             Row {
                 PaymentDescription(paymentInfo = paymentInfo, contactInfo = contactInfo, modifier = Modifier.weight(1.0f))
                 Spacer(modifier = Modifier.width(16.dp))
-                val hideAmount = payment.state() == WalletPaymentState.Failure
+                val hideAmount = payment.state() == WalletPaymentState.Failure || (payment is AutomaticLiquidityPurchasePayment && payment.incomingPaymentReceivedAt != null)
                 if (!hideAmount) {
-                    val isOutgoing = payment is OutgoingPayment
                     if (isAmountRedacted) {
                         Text(text = "****")
                     } else {
+                        val isOutgoing = payment is OutgoingPayment
                         AmountView(
                             amount = payment.amount,
                             amountTextStyle = MaterialTheme.typography.body1.copy(color = if (isOutgoing) negativeColor else positiveColor),

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/images/QRCodeAnalyser.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/utils/images/QRCodeAnalyser.kt
@@ -17,6 +17,7 @@
 package fr.acinq.phoenix.android.utils.images
 
 import android.graphics.ImageFormat
+import android.util.Size
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
 import com.google.zxing.*
@@ -31,6 +32,10 @@ class ZxingQrCodeAnalyzer(
 
     private val log = LoggerFactory.getLogger(this::class.java)
     private val reader = QRCodeReader()
+
+    override fun getDefaultTargetResolution(): Size {
+        return DEFAULT_RESOLUTION
+    }
 
     override fun analyze(image: ImageProxy) {
         if (image.format != ImageFormat.YUV_420_888) {
@@ -68,5 +73,9 @@ class ZxingQrCodeAnalyzer(
             log.debug("error when decoding: ", e)
         }
         image.close()
+    }
+
+    companion object {
+        val DEFAULT_RESOLUTION = Size(1200, 1600)
     }
 }

--- a/phoenix-android/src/test/kotlin/fr/acinq/phoenix/utils/LnurlAuthTest.kt
+++ b/phoenix-android/src/test/kotlin/fr/acinq/phoenix/utils/LnurlAuthTest.kt
@@ -3,29 +3,22 @@ package fr.acinq.phoenix.utils
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Chain
 import fr.acinq.bitcoin.Crypto
-import fr.acinq.bitcoin.byteVector64
-import fr.acinq.bitcoin.scala.Block
-import fr.acinq.bitcoin.scala.`MnemonicCode$`
+import fr.acinq.bitcoin.MnemonicCode
+import fr.acinq.bitcoin.byteVector
 import fr.acinq.lightning.crypto.LocalKeyManager
 import fr.acinq.phoenix.data.lnurl.LnurlAuth
-import fr.acinq.phoenix.legacy.lnurl.LNUrlAuthFragment
 import io.ktor.http.*
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.junit.Assert
 import org.junit.Test
 
 class LnurlAuthTest {
 
-    /**
-     * Checks that the kmp default scheme generates a DIFFERENT key/sig tuple for a non-legacy domain
-     * than the kmp legacy scheme and the legacy android app (whose key/tuple should still match).
-     */
+    /** Checks that the default scheme generates a DIFFERENT key/sig tuple for a non-legacy domain than the legacy scheme. */
     @Test
     fun legacy_domain_different_keys() {
-        val seed = `MnemonicCode$`.`MODULE$`.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", "")
-        val legacyKeyManager = fr.acinq.eclair.crypto.LocalKeyManager(seed, Block.TestnetGenesisBlock().hash())
+        val seed = MnemonicCode.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", "")
         val kmpKeyManager = LocalKeyManager(
-            seed = seed.toArray().byteVector64(),
+            seed = seed.byteVector(),
             chain = Chain.Testnet3,
             remoteSwapInExtendedPublicKey = "tpubDDt5vQap1awkyDXx1z1cP7QFKSZHDCCpbU8nSq9jy7X2grTjUVZDePexf6gc6AHtRRzkgfPW87K6EKUVV6t3Hu2hg7YkHkmMeLSfrP85x41"
         )
@@ -33,38 +26,32 @@ class LnurlAuthTest {
         val k1 = "179062fdf971ec045883a6297fb1d260333358905086c33a9f44ff26f63bb425"
         val url = Url("https://api.lnmarkets.com/v1/lnurl/auth?tag=login&k1=$k1&hmac=75344d9151fe788345e620aa3de0e69b51698e759fd667272e3ea682a2bbcd12")
 
-        // legacy key
-        val (legacySignedK1, legacyAuthKey) = LNUrlAuthFragment.signLnurlAuthK1WithKey(legacyKeyManager, k1, url.toString().toHttpUrlOrNull()!!)
-        // kmp key when using the legacy friendly scheme
-        val kmpLegacyAuthKey = LnurlAuth.getAuthLinkingKey(kmpKeyManager, url, LnurlAuth.Scheme.ANDROID_LEGACY_SCHEME)
-        val kmpLegacySignedK1 = Crypto.compact2der(Crypto.sign(data = ByteVector32.fromValidHex(k1), privateKey = kmpLegacyAuthKey)).toHex()
-        // kmp key when using the default scheme
-        val kmpNewAuthKey = LnurlAuth.getAuthLinkingKey(kmpKeyManager, url, LnurlAuth.Scheme.DEFAULT_SCHEME)
-        val kmpNewSignedK1 = Crypto.compact2der(Crypto.sign(data = ByteVector32.fromValidHex(k1), privateKey = kmpNewAuthKey)).toHex()
+        // key when using the legacy friendly scheme
+        val legacyAuthKey = LnurlAuth.getAuthLinkingKey(kmpKeyManager, url, LnurlAuth.Scheme.ANDROID_LEGACY_SCHEME)
+        val legacySignedK1 = Crypto.compact2der(Crypto.sign(data = ByteVector32.fromValidHex(k1), privateKey = legacyAuthKey)).toHex()
+        // key when using the default scheme
+        val defaultAuthKey = LnurlAuth.getAuthLinkingKey(kmpKeyManager, url, LnurlAuth.Scheme.DEFAULT_SCHEME)
+        val defaultSignedK1 = Crypto.compact2der(Crypto.sign(data = ByteVector32.fromValidHex(k1), privateKey = defaultAuthKey)).toHex()
 
         val expectedLegacyPubkey = "024d82b199464c9568f5cce92cf7370a8154d9ec0571905b596a4e9dcae69136d8"
         val expectedNewPubkey = "03702494face111dcd61be4ab4a13fa4cd4ac720b2d3b47e95feee58484f573630"
         Assert.assertEquals(expectedLegacyPubkey, legacyAuthKey.publicKey().toString())
-        Assert.assertEquals(expectedLegacyPubkey, kmpLegacyAuthKey.publicKey().toString())
-        Assert.assertEquals(expectedNewPubkey, kmpNewAuthKey.publicKey().toString())
+        Assert.assertEquals(expectedLegacyPubkey, legacyAuthKey.publicKey().toString())
+        Assert.assertEquals(expectedNewPubkey, defaultAuthKey.publicKey().toString())
 
         val expectedLegacySig = "3044022056299db29f515fa2941e5212bfc6de7bd64ca0edd6067e3575a4753ca00be1ec02200f63e9905eef29b1ba8b54c79cfcf41c1380bc6eeb8ca8e5c2748a79c962b663"
         val expectedNewSig = "304402204cc2411cebd5c5c9722da29aad92788434026744fd6e5aa6a98a5a3f30f2595f022044fdeeb8158611a270ee933510779b117493653011dc3e30172167ca721056a5"
         Assert.assertEquals(expectedLegacySig, legacySignedK1)
-        Assert.assertEquals(expectedLegacySig, kmpLegacySignedK1)
-        Assert.assertEquals(expectedNewSig, kmpNewSignedK1)
+        Assert.assertEquals(expectedLegacySig, legacySignedK1)
+        Assert.assertEquals(expectedNewSig, defaultSignedK1)
     }
 
-    /**
-     * Checks that the new kmp and the legacy code generate the SAME pubkey/signature for a non-legacy domain whatever
-     * the scheme used.
-     */
+    /** Checks that the app generates the SAME pubkey/signature for a non-legacy domain whatever the scheme used. */
     @Test
     fun standard_domain_same_key() {
-        val seed = `MnemonicCode$`.`MODULE$`.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", "")
-        val legacyKeyManager = fr.acinq.eclair.crypto.LocalKeyManager(seed, Block.LivenetGenesisBlock().hash())
+        val seed = MnemonicCode.toSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", "")
         val kmpKeyManager = LocalKeyManager(
-            seed = seed.toArray().byteVector64(),
+            seed = seed.byteVector(),
             chain = Chain.Testnet3,
             remoteSwapInExtendedPublicKey = "tpubDDt5vQap1awkyDXx1z1cP7QFKSZHDCCpbU8nSq9jy7X2grTjUVZDePexf6gc6AHtRRzkgfPW87K6EKUVV6t3Hu2hg7YkHkmMeLSfrP85x41"
         )
@@ -72,23 +59,19 @@ class LnurlAuthTest {
         val k1 = "32c56da24a28e09d24832e1cba0cc391049c48036c197e228c7656d022a5eb1f"
         val url = Url("https://foo.bar.com/auth?tag=login&k1=$k1")
 
-        // legacy key
-        val (legacySignedK1, legacyAuthKey) = LNUrlAuthFragment.signLnurlAuthK1WithKey(legacyKeyManager, k1, url.toString().toHttpUrlOrNull()!!)
-        // kmp key when using the legacy friendly scheme
-        val kmpLegacyAuthKey = LnurlAuth.getAuthLinkingKey(kmpKeyManager, url, LnurlAuth.Scheme.ANDROID_LEGACY_SCHEME)
-        val kmpLegacySignedK1 = Crypto.compact2der(Crypto.sign(data = ByteVector32.fromValidHex(k1), privateKey = kmpLegacyAuthKey)).toHex()
-        // kmp key when using the default scheme
-        val kmpNewAuthKey = LnurlAuth.getAuthLinkingKey(kmpKeyManager, url, LnurlAuth.Scheme.DEFAULT_SCHEME)
-        val kmpNewSignedK1 = Crypto.compact2der(Crypto.sign(data = ByteVector32.fromValidHex(k1), privateKey = kmpNewAuthKey)).toHex()
+        // key when using the legacy friendly scheme
+        val legacyAuthKey = LnurlAuth.getAuthLinkingKey(kmpKeyManager, url, LnurlAuth.Scheme.ANDROID_LEGACY_SCHEME)
+        val legacySignedK1 = Crypto.compact2der(Crypto.sign(data = ByteVector32.fromValidHex(k1), privateKey = legacyAuthKey)).toHex()
+        // key when using the default scheme
+        val defaultNewAuthKey = LnurlAuth.getAuthLinkingKey(kmpKeyManager, url, LnurlAuth.Scheme.DEFAULT_SCHEME)
+        val defaultNewSignedK1 = Crypto.compact2der(Crypto.sign(data = ByteVector32.fromValidHex(k1), privateKey = defaultNewAuthKey)).toHex()
 
         val expectedPubkey = "02ebfff275eccdd929a3843eff9481a53b0445cdae9a931fd43baa91dcd35836e9"
         Assert.assertEquals(expectedPubkey, legacyAuthKey.publicKey().toString())
-        Assert.assertEquals(expectedPubkey, kmpLegacyAuthKey.publicKey().toString())
-        Assert.assertEquals(expectedPubkey, kmpNewAuthKey.publicKey().toString())
+        Assert.assertEquals(expectedPubkey, defaultNewAuthKey.publicKey().toString())
 
         val expectedSignature = "3045022100f3710b22bd3433b1aa56fa61b1ad9ced79d4e5010430d0afa8d6c7dc77481ef502201a80ab49a2facf8810652bf9e0f85d6c834f6e9fd59f312e7eeece36e51ce957"
         Assert.assertEquals(expectedSignature, legacySignedK1)
-        Assert.assertEquals(expectedSignature, kmpLegacySignedK1)
-        Assert.assertEquals(expectedSignature, kmpNewSignedK1)
+        Assert.assertEquals(expectedSignature, defaultNewSignedK1)
     }
 }

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -7700,9 +7700,6 @@
         }
       }
     },
-    "Automated liquidity" : {
-      "comment" : "Payment description for inbound liquidity"
-    },
     "Automatic Channel Creation" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -9814,6 +9811,9 @@
         }
       }
     },
+    "Caused by" : {
+
+    },
     "Chain mismatch" : {
       "comment" : "Error title",
       "localizations" : {
@@ -10063,7 +10063,7 @@
 
     },
     "Channel management" : {
-      "comment" : "Navigation Bar Title",
+      "comment" : "Navigation Bar Title\nPayment description for inbound liquidity",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -10104,9 +10104,6 @@
       }
     },
     "Channel operation (new or splice-in)" : {
-
-    },
-    "Channel Resized" : {
 
     },
     "Channel size impacted" : {
@@ -26110,9 +26107,6 @@
           }
         }
       }
-    },
-    "Manual liquidity" : {
-      "comment" : "Payment description for inbound liquidity"
     },
     "Manual restore" : {
       "comment" : "Navigation bar title",
@@ -42177,6 +42171,9 @@
           }
         }
       }
+    },
+    "This liquidity was required to receive a payment" : {
+
     },
     "This means you will not be able to receive payments when Phoenix is in the background. To receive payments, Phoenix must be open and in the foreground." : {
       "extractionState" : "manual",

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Payments.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Payments.swift
@@ -108,10 +108,10 @@ extension WalletPaymentInfo {
 				return String(localized: "Bump fees", comment: "Payment description for splice CPFP")
 				
 			} else if let _ = outgoingPayment as? Lightning_kmpManualLiquidityPurchasePayment {
-				return String(localized: "Manual liquidity", comment: "Payment description for inbound liquidity")
+				return String(localized: "Channel management", comment: "Payment description for inbound liquidity")
 				
 			} else if let _ = outgoingPayment as? Lightning_kmpAutomaticLiquidityPurchasePayment {
-				return String(localized: "Automated liquidity", comment: "Payment description for inbound liquidity")
+				return String(localized: "Channel management", comment: "Payment description for inbound liquidity")
 			}
 		}
 	

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryInfoGrid.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryInfoGrid.swift
@@ -11,6 +11,7 @@ fileprivate var log = LoggerFactory.shared.logger(filename, .warning)
 struct SummaryInfoGrid: InfoGridView { // See InfoGridView for architecture discussion
 	
 	@Binding var paymentInfo: WalletPaymentInfo
+	@Binding var causedBy: Lightning_kmpWalletPayment?
 	@Binding var showOriginalFiatValue: Bool
 	
 	let showContactView: (_ contact: ContactInfo) -> Void
@@ -62,6 +63,7 @@ struct SummaryInfoGrid: InfoGridView { // See InfoGridView for architecture disc
 			paymentFeesRow_MinerFees()
 			paymentFeesRow_ServiceFees()
 			
+			causedByRow()
 			paymentErrorRow()
 		}
 		.padding([.leading, .trailing])
@@ -570,6 +572,53 @@ struct SummaryInfoGrid: InfoGridView { // See InfoGridView for architecture disc
 			} // </HStack>
 			
 		} // </InfoGridRow>
+	}
+	
+	@ViewBuilder
+	func causedByRow() -> some View {
+		let identifier: String = #function
+		
+		if let paymentId = causedBy?.id {
+			
+			InfoGridRow(
+				identifier: identifier,
+				vAlignment: .firstTextBaseline,
+				hSpacing: horizontalSpacingBetweenColumns,
+				keyColumnWidth: keyColumnWidth(identifier: identifier),
+				keyColumnAlignment: .trailing
+			) {
+				
+				keyColumn("Caused by")
+				
+			} valueColumn: {
+				
+				HStack(alignment: VerticalAlignment.center, spacing: 6) {
+					
+					Button {
+						switchToPayment(paymentId)
+					} label: {
+						Text(verbatim: "\(paymentId.description().prefix(maxLength: 8))…")
+							.lineLimit(1)
+							.truncationMode(.middle)
+					}
+					
+					Button {
+						popoverPresent_liquidityCause.toggle()
+					} label: {
+						Image(systemName: "questionmark.circle")
+							.renderingMode(.template)
+							.foregroundColor(.secondary)
+							.font(.body)
+					}
+					.popover(present: $popoverPresent_liquidityCause) {
+						InfoPopoverWindow {
+							Text("This liquidity was required to receive a payment")
+						}
+					}
+				}
+				
+			} // </InfoGridRow>
+		}
 	}
 	
 	@ViewBuilder

--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
@@ -31,6 +31,7 @@ struct SummaryView: View {
 	let location: PaymentView.Location
 	
 	@State var paymentInfo: WalletPaymentInfo
+	@State var causedBy: Lightning_kmpWalletPayment? = nil
 	
 	@State var blockchainConfirmations: Int? = nil
 	@State var showBlockchainExplorerOptions = false
@@ -191,7 +192,7 @@ struct SummaryView: View {
 					if payment is Lightning_kmpAutomaticLiquidityPurchasePayment ||
 					   payment is Lightning_kmpManualLiquidityPurchasePayment
 					{
-						Text("Channel Resized")
+						Text("Channel management")
 					}
 					else if payment is Lightning_kmpOutgoingPayment {
 						Text("SENT")
@@ -501,6 +502,7 @@ struct SummaryView: View {
 		
 		SummaryInfoGrid(
 			paymentInfo: $paymentInfo,
+			causedBy: $causedBy,
 			showOriginalFiatValue: $showOriginalFiatValue,
 			showContactView: showContactView,
 			switchToPayment: switchToPayment
@@ -1129,6 +1131,21 @@ struct SummaryView: View {
 		log.trace("paymentInfoChanged()")
 
 		blockchainMonitorState.paymentInfoPublisher.send(paymentInfo)
+		
+		if let liquidity = paymentInfo.payment as? Lightning_kmpAutomaticLiquidityPurchasePayment {
+			Task { @MainActor in
+				do {
+					let paymentsManager = Biz.business.paymentsManager
+					causedBy = try await paymentsManager.getIncomingPaymentForTxId(txId: liquidity.txId)
+					log.debug("causedBy = \(causedBy?.id.description() ?? "<nil>")")
+				} catch {
+					log.error("listIncomingPaymentsForTxId(): error: \(error)")
+				}
+			}
+		} else {
+			log.debug("causedBy = nil (payment !is AutomaticLiquidityPurchasePayment)")
+			causedBy = nil
+		}
 	}
 	
 	// --------------------------------------------------

--- a/phoenix-ios/phoenix-ios/views/transactions/PaymentCell.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/PaymentCell.swift
@@ -141,7 +141,12 @@ struct PaymentCell : View {
 	func paymentAmount() -> some View {
 		
 		let (amount, isFailure, isOutgoing) = paymentAmountInfo()
-		if currencyPrefs.hideAmounts {
+		if isLiquidityWithFeesDisplayedElsewhere() {
+			
+			Text(verbatim: "")
+				.accessibilityHidden(true)
+					
+		} else if currencyPrefs.hideAmounts {
 			
 			HStack(alignment: VerticalAlignment.firstTextBaseline, spacing: 0) {
 				
@@ -301,6 +306,22 @@ struct PaymentCell : View {
 		let isOutgoing = payment is Lightning_kmpOutgoingPayment
 		
 		return (amount, isFailure, isOutgoing)
+	}
+	
+	func isLiquidityWithFeesDisplayedElsewhere() -> Bool {
+		
+		if let autoLiquidity = info.payment as? Lightning_kmpAutomaticLiquidityPurchasePayment {
+			
+			// payment.incomingPaymentReceivedAt:
+			// - if null, we should show the amount
+			// - if non-null it means the related payment was received
+			//   and so we should hide the channel management amount
+			//
+			return autoLiquidity.incomingPaymentReceivedAt != nil
+			
+		} else {
+			return false
+		}
 	}
 	
 	// --------------------------------------------------

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConnectionsDaemon.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConnectionsDaemon.kt
@@ -195,7 +195,7 @@ class AppConnectionsDaemon(
                     }
                 if (forceDisconnect || !it.canConnect) {
                     peerConnectionJob?.let { job ->
-                        logger.debug { "cancel peer connection loop" }
+                        logger.info { "disconnect and cancel peer connection loop" }
                         job.cancelAndJoin()
                         peer.disconnect()
                         peerConnectionJob = null
@@ -248,7 +248,7 @@ class AppConnectionsDaemon(
                     }
                 if (forceDisconnect || !it.canConnect) {
                     electrumConnectionJob?.let { job ->
-                        logger.debug { "cancel electrum connection loop" }
+                        logger.info { "disconnect and cancel electrum connection loop" }
                         job.cancelAndJoin()
                         electrumClient.disconnect()
                         electrumConnectionJob = null
@@ -405,10 +405,10 @@ class AppConnectionsDaemon(
     fun forceReconnect(target: ControlTarget = ControlTarget.All) {
         launch {
             if (target.containsPeer) {
-                peerControlChanges.send { copy(disconnectCount = -1) }
+                peerControlChanges.send { copy(disconnectCount = -1, configVersion = this.configVersion + 1) }
             }
             if (target.containsElectrum) {
-                electrumControlChanges.send { copy(disconnectCount = -1) }
+                electrumControlChanges.send { copy(disconnectCount = -1, configVersion = this.configVersion + 1) }
             }
             if (target.containsHttp) {
                 httpApiControlChanges.send { copy(disconnectCount = -1) }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsManager.kt
@@ -4,6 +4,7 @@ import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.PaymentEvents
 import fr.acinq.lightning.blockchain.electrum.ElectrumClient
 import fr.acinq.lightning.db.Bolt11IncomingPayment
+import fr.acinq.lightning.db.IncomingPayment
 import fr.acinq.lightning.db.LightningOutgoingPayment
 import fr.acinq.lightning.db.WalletPayment
 import fr.acinq.lightning.logging.LoggerFactory
@@ -115,11 +116,16 @@ class PaymentsManager(
     }
 
     /**
-     * Returns the payment(s) that are related to a transaction id. Useful to link a commitment change in a channel to the
+     * Returns payment(s) related to a transaction id. Useful to link a commitment change in a channel to the
      * payment(s) that triggered that change.
      */
     suspend fun listPaymentsForTxId(txId: TxId): List<WalletPayment> {
         return paymentsDb().listPaymentsForTxId(txId)
+    }
+
+    /** Returns the first incoming payment related to a transaction id. Useful to find the incoming payment that triggered a liquidity purchase. */
+    suspend fun getIncomingPaymentForTxId(txId: TxId): WalletPayment? {
+        return listPaymentsForTxId(txId).filterIsInstance<IncomingPayment>().firstOrNull()
     }
 
     suspend fun getPayment(


### PR DESCRIPTION
With the database rework, we thought that we would be able to simply filter the `AutomaticLiquidityPurchasePayment` payments from the payments history. 

However it has some side-effects on the UI because of the way we build that payments history (the total number of payments in the db does not match the number of payments in the list displayed in the UI).

Thus we should keep displaying these `AutomaticLiquidityPurchasePayment`s. 

However, some adjustments are needed to avoid confusion: the fee of these purchase is already taken into account in the amount of the incoming payment that triggered it. See the example below, the amount received before fees was 400k. This is confusing and it feels like we paid twice.

<img src="https://github.com/user-attachments/assets/149c2853-0dbb-4a24-bfb3-4246a25f60aa" width=300 />

So we now hide the amount of the channel management row. 
This is done by checking `payment.incomingPaymentReceivedAt` : if `null`, we should show the amount ; if not, it means the related payment was received and so we should hide the channel management amount.

<img src="https://github.com/user-attachments/assets/a3f36b7c-79cd-4423-9e31-d6613c9f3057" width=300 />

The details screen also contains a button to navigate to the relevant incoming payment :

<img src="https://github.com/user-attachments/assets/ac748915-0957-4033-bbc8-674a9f3f498e" width=300 />

@robbiehanson You can use `PaymentsManager.getIncomingPaymentForTxId` to get that incoming payment from the auto purchase details screen

