### PR TITLE
Bug fix: storage of payment metadata missing post-refactor

### DIFF
--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -45269,7 +45269,6 @@
       }
     },
     "Wallet creation options" : {
-      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/phoenix-ios/phoenix-ios/sync/SyncBackupManager+Payments.swift
+++ b/phoenix-ios/phoenix-ios/sync/SyncBackupManager+Payments.swift
@@ -765,7 +765,7 @@ extension SyncBackupManager {
 		_ metadata: WalletPaymentMetadata
 	) -> URL? {
 		
-		guard let row = WalletPaymentMetadataRow.companion.serialize(metadata: metadata) else {
+		guard let row = metadata.serialize() else {
 			return nil
 		}
 		

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/DbInitHelper.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/DbInitHelper.kt
@@ -30,6 +30,7 @@ import fr.acinq.lightning.utils.UUID
 import fr.acinq.phoenix.db.sqldelight.*
 import fr.acinq.phoenix.managers.ContactsManager
 import fr.acinq.phoenix.managers.CurrencyManager
+import fr.acinq.phoenix.utils.MetadataQueue
 import fr.acinq.phoenix.utils.extensions.toByteArray
 
 fun createSqliteChannelsDb(driver: SqlDriver): SqliteChannelsDb {
@@ -43,7 +44,7 @@ fun createSqliteChannelsDb(driver: SqlDriver): SqliteChannelsDb {
     )
 }
 
-fun createSqlitePaymentsDb(driver: SqlDriver, contactsManager: ContactsManager?, currencyManager: CurrencyManager?): SqlitePaymentsDb {
+fun createSqlitePaymentsDb(driver: SqlDriver, metadataQueue: MetadataQueue?, contactsManager: ContactsManager?): SqlitePaymentsDb {
     return SqlitePaymentsDb(
         driver = driver,
         database = PaymentsDatabase(
@@ -56,8 +57,8 @@ fun createSqlitePaymentsDb(driver: SqlDriver, contactsManager: ContactsManager?,
             cloudkit_payments_queueAdapter = Cloudkit_payments_queue.Adapter(UUIDAdapter),
             cloudkit_payments_metadataAdapter = Cloudkit_payments_metadata.Adapter(UUIDAdapter),
         ),
-        contactsManager = contactsManager,
-        currencyManager = currencyManager,
+        metadataQueue = metadataQueue,
+        contactsManager = contactsManager
     )
 }
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataTypes.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/MetadataTypes.kt
@@ -287,42 +287,34 @@ data class WalletPaymentMetadataRow(
             && user_description == null
             && user_notes == null
     }
+}
 
-    companion object {
-        fun serialize(
-            metadata: WalletPaymentMetadata
-        ): WalletPaymentMetadataRow? {
+fun WalletPaymentMetadata.serialize(): WalletPaymentMetadataRow? {
 
-            var lnurlBase: Pair<LnurlBase.TypeVersion, ByteArray>? = null
-            var lnurlMetadata: Pair<LnurlMetadata.TypeVersion, ByteArray>? = null
-            var lnurlSuccessAction: Pair<LnurlSuccessAction.TypeVersion, ByteArray>? = null
-            var lnurlDescription: String? = null
+    var lnurlBase: Pair<LnurlBase.TypeVersion, ByteArray>? = null
+    var lnurlMetadata: Pair<LnurlMetadata.TypeVersion, ByteArray>? = null
+    var lnurlSuccessAction: Pair<LnurlSuccessAction.TypeVersion, ByteArray>? = null
+    var lnurlDescription: String? = null
 
-            metadata.lnurl?.let {
-                lnurlBase = LnurlBase.serialize(it.pay)
-                lnurlMetadata = LnurlMetadata.serialize(it.pay.metadata)
-                lnurlSuccessAction = it.successAction?.let { successAction ->
-                    LnurlSuccessAction.serialize(successAction)
-                }
-                lnurlDescription = it.pay.metadata.plainText
-            }
-
-            val originalFiat = metadata.originalFiat?.let {
-                Pair(it.fiatCurrency.name, it.price)
-            }
-
-            val row = WalletPaymentMetadataRow(
-                lnurl_base = lnurlBase,
-                lnurl_metadata = lnurlMetadata,
-                lnurl_successAction = lnurlSuccessAction,
-                lnurl_description = lnurlDescription,
-                original_fiat = originalFiat,
-                user_description = metadata.userDescription,
-                user_notes = metadata.userNotes,
-                modified_at = metadata.modifiedAt
-            )
-
-            return if (row.isEmpty()) null else row
+    lnurl?.let {
+        lnurlBase = LnurlBase.serialize(it.pay)
+        lnurlMetadata = LnurlMetadata.serialize(it.pay.metadata)
+        lnurlSuccessAction = it.successAction?.let { successAction ->
+            LnurlSuccessAction.serialize(successAction)
         }
+        lnurlDescription = it.pay.metadata.plainText
     }
+
+    val row = WalletPaymentMetadataRow(
+        lnurl_base = lnurlBase,
+        lnurl_metadata = lnurlMetadata,
+        lnurl_successAction = lnurlSuccessAction,
+        lnurl_description = lnurlDescription,
+        original_fiat = originalFiat?.let { Pair(it.fiatCurrency.name, it.price) },
+        user_description = userDescription,
+        user_notes = userNotes,
+        modified_at = modifiedAt
+    )
+
+    return if (row.isEmpty()) null else row
 }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/SqliteOutgoingPaymentsDb.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/payments/SqliteOutgoingPaymentsDb.kt
@@ -22,12 +22,19 @@ import fr.acinq.lightning.db.OnChainOutgoingPayment
 import fr.acinq.lightning.db.OutgoingPayment
 import fr.acinq.lightning.db.OutgoingPaymentsDb
 import fr.acinq.lightning.utils.UUID
+import fr.acinq.phoenix.data.WalletPaymentMetadata
 import fr.acinq.phoenix.db.sqldelight.PaymentsDatabase
 import fr.acinq.phoenix.db.didSaveWalletPayment
+import fr.acinq.phoenix.utils.MetadataQueue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-class SqliteOutgoingPaymentsDb(private val database: PaymentsDatabase) : OutgoingPaymentsDb {
+class SqliteOutgoingPaymentsDb(
+    private val database: PaymentsDatabase,
+    private val metadataQueue: MetadataQueue?
+) : OutgoingPaymentsDb {
+
+    val metadataQueries = PaymentsMetadataQueries(database)
 
     override suspend fun addLightningOutgoingPaymentParts(parentId: UUID, parts: List<LightningOutgoingPayment.Part>) {
         withContext(Dispatchers.Default) {
@@ -49,9 +56,10 @@ class SqliteOutgoingPaymentsDb(private val database: PaymentsDatabase) : Outgoin
     }
 
     override suspend fun addOutgoingPayment(outgoingPayment: OutgoingPayment) {
+        val metadata = metadataQueue?.dequeue(outgoingPayment.id)
         withContext(Dispatchers.Default) {
             database.transaction {
-                _addOutgoingPayment(outgoingPayment)
+                _addOutgoingPayment(outgoingPayment, metadata)
             }
         }
     }
@@ -63,7 +71,7 @@ class SqliteOutgoingPaymentsDb(private val database: PaymentsDatabase) : Outgoin
      * @param notify Set to false if `didSaveWalletPayment` should not be invoked
      *               (e.g. when downloading payments from the cloud)
      */
-    fun _addOutgoingPayment(outgoingPayment: OutgoingPayment, notify: Boolean = true) {
+    fun _addOutgoingPayment(outgoingPayment: OutgoingPayment, metadata: WalletPaymentMetadata?, notify: Boolean = true) {
         when (outgoingPayment) {
             is LightningOutgoingPayment -> {
                 database.paymentsOutgoingQueries.insert(
@@ -93,6 +101,9 @@ class SqliteOutgoingPaymentsDb(private val database: PaymentsDatabase) : Outgoin
                     locked_at = outgoingPayment.lockedAt
                 )
             }
+        }
+        metadata?.serialize()?.let { row ->
+            metadataQueries.addMetadata(outgoingPayment.id, row)
         }
         if (notify) {
             didSaveWalletPayment(outgoingPayment.id, database)

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/DatabaseManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/DatabaseManager.kt
@@ -15,6 +15,7 @@ import fr.acinq.phoenix.db.createSqliteChannelsDb
 import fr.acinq.phoenix.db.createSqlitePaymentsDb
 import fr.acinq.phoenix.db.makeCloudKitDb
 import fr.acinq.phoenix.db.payments.CloudKitInterface
+import fr.acinq.phoenix.utils.MetadataQueue
 import fr.acinq.phoenix.utils.PlatformContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
@@ -50,6 +51,8 @@ class DatabaseManager(
     private val _databases = MutableStateFlow<PhoenixDatabases?>(null)
     val databases: StateFlow<PhoenixDatabases?> = _databases.asStateFlow()
 
+    val metadataQueue = MetadataQueue(currencyManager)
+
     init {
         launch {
             nodeParamsManager.nodeParams.collect { nodeParams ->
@@ -60,7 +63,7 @@ class DatabaseManager(
                 val channelsDbDriver = createChannelsDbDriver(ctx, chain, nodeIdHash)
                 val channelsDb = createSqliteChannelsDb(channelsDbDriver)
                 val paymentsDbDriver = createPaymentsDbDriver(ctx, chain, nodeIdHash)
-                val paymentsDb = createSqlitePaymentsDb(paymentsDbDriver, contactsManager, currencyManager)
+                val paymentsDb = createSqlitePaymentsDb(paymentsDbDriver, metadataQueue, contactsManager)
                 val cloudKitDb = makeCloudKitDb(appDb, paymentsDb)
                 log.debug { "databases object created" }
                 _databases.value = PhoenixDatabases(

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/SendManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/SendManager.kt
@@ -25,7 +25,6 @@ import fr.acinq.phoenix.data.lnurl.LnurlAuth
 import fr.acinq.phoenix.data.lnurl.LnurlError
 import fr.acinq.phoenix.data.lnurl.LnurlPay
 import fr.acinq.phoenix.data.lnurl.LnurlWithdraw
-import fr.acinq.phoenix.db.payments.WalletPaymentMetadataRow
 import fr.acinq.phoenix.utils.DnsResolvers
 import fr.acinq.phoenix.utils.EmailLikeAddress
 import fr.acinq.phoenix.utils.Parser
@@ -442,8 +441,8 @@ class SendManager(
         val peer = peerManager.getPeer()
 
         // save lnurl metadata if any
-        metadata?.let { WalletPaymentMetadataRow.serialize(it) }?.let { row ->
-            databaseManager.paymentsDb().enqueueMetadata(row = row, id = paymentId)
+        metadata?.let { row ->
+            databaseManager.metadataQueue.enqueue(row = row, id = paymentId)
         }
 
         peer.send(

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/MetadataQueue.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/utils/MetadataQueue.kt
@@ -1,0 +1,43 @@
+package fr.acinq.phoenix.utils
+
+import fr.acinq.lightning.utils.UUID
+import fr.acinq.phoenix.data.WalletPaymentMetadata
+import fr.acinq.phoenix.managers.CurrencyManager
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class MetadataQueue(
+    private val currencyManager: CurrencyManager?
+) {
+
+    private var metadataQueue = MutableStateFlow(mapOf<UUID, WalletPaymentMetadata>())
+
+    /**
+     * The lightning-kmp layer triggers the addition of a payment to the database.
+     * But sometimes there is associated metadata that we want to include,
+     * and we would like to write it to the database within the same transaction.
+     * So we have a system to enqueue/dequeue associated metadata.
+     */
+    fun enqueue(row: WalletPaymentMetadata, id: UUID) {
+        val oldMap = metadataQueue.value
+        val newMap = oldMap + (id to row)
+        metadataQueue.value = newMap
+    }
+
+    /**
+     * Returns any enqueued metadata, and also appends the current fiat exchange rate.
+     */
+    internal fun dequeue(id: UUID): WalletPaymentMetadata {
+        val oldMap = metadataQueue.value
+        val newMap = oldMap - id
+        metadataQueue.value = newMap
+
+        val row = oldMap[id] ?: WalletPaymentMetadata()
+
+        // Append the current exchange rate, unless it was explicitly set earlier.
+        return if (row.originalFiat != null) {
+            row
+        } else {
+            row.copy(originalFiat = currencyManager?.calculateOriginalFiat())
+        }
+    }
+}

--- a/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/SqlitePaymentsDbTest.kt
+++ b/phoenix-shared/src/commonTest/kotlin/fr/acinq/phoenix/db/SqlitePaymentsDbTest.kt
@@ -79,7 +79,7 @@ class SqlitePaymentsDbTest : UsingContextTest() {
     @Test
     fun `read v1 db`() = runTest {
         val driver = createPaymentsDbDriver(getPlatformContext(), chain = Chain.Testnet3, nodeIdHash = "fedc36138a62ceadc8a93861d2c46f5ca5e8b418")
-        val paymentsDb = createSqlitePaymentsDb(driver, contactsManager = null, currencyManager = null)
+        val paymentsDb = createSqlitePaymentsDb(driver, metadataQueue = null, contactsManager = null)
 
         val payments = paymentsDb.database.paymentsQueries.list(limit = Long.MAX_VALUE, offset = 0)
             .executeAsList()
@@ -105,7 +105,7 @@ class SqlitePaymentsDbTest : UsingContextTest() {
     @Test
     fun `read v1 db - additional`() = runTest {
         val driver = createPaymentsDbDriver(getPlatformContext(), chain = Chain.Testnet3, nodeIdHash = "a224978853d2f4c94ac8e2dbb2acf8344e0146d0")
-        val paymentsDb = createSqlitePaymentsDb(driver, contactsManager = null, currencyManager = null)
+        val paymentsDb = createSqlitePaymentsDb(driver, metadataQueue = null, contactsManager = null)
 
         val payments = paymentsDb.database.paymentsQueries.list(limit = Long.MAX_VALUE, offset = 0)
             .executeAsList()
@@ -131,7 +131,7 @@ class SqlitePaymentsDbTest : UsingContextTest() {
     @Test
     fun `read v6 db`() = runTest {
         val driver = createPaymentsDbDriver(getPlatformContext(), chain = Chain.Testnet3, nodeIdHash = "700486fc7a90d5922d6f993f2941ab9f9f1a9d85")
-        val paymentsDb = createSqlitePaymentsDb(driver, contactsManager = null, currencyManager = null)
+        val paymentsDb = createSqlitePaymentsDb(driver, metadataQueue = null, contactsManager = null)
 
         val payments = paymentsDb.database.paymentsQueries.list(limit = Long.MAX_VALUE, offset = 0)
             .executeAsList()
@@ -157,7 +157,7 @@ class SqlitePaymentsDbTest : UsingContextTest() {
     @Test
     fun `read v10 db - large dataset`() = runTest {
         val driver = createPaymentsDbDriver(getPlatformContext(), chain = Chain.Testnet3, nodeIdHash = "28903aff")
-        val paymentsDb = createSqlitePaymentsDb(driver, contactsManager = null, currencyManager = null)
+        val paymentsDb = createSqlitePaymentsDb(driver, metadataQueue = null, contactsManager = null)
 
         val payments = paymentsDb.database.paymentsQueries.list(limit = Long.MAX_VALUE, offset = 0)
             .executeAsList()
@@ -253,7 +253,7 @@ class SqlitePaymentsDbTest : UsingContextTest() {
     @Test
     fun `read v10 db - fees`() = runTest {
         val driver = createPaymentsDbDriver(getPlatformContext(), chain = Chain.Testnet3, nodeIdHash = "f921bddf")
-        val paymentsDb = createSqlitePaymentsDb(driver, contactsManager = null, currencyManager = null)
+        val paymentsDb = createSqlitePaymentsDb(driver, metadataQueue = null, contactsManager = null)
 
         // On-chain deposit of 200k sat that triggered a liquidity purchase.
         // The effectively received amount was 198 150 sat after fees.
@@ -310,7 +310,7 @@ class SqlitePaymentsDbTest : UsingContextTest() {
     @Test
     fun `read v10 db - liquidity`() = runTest {
         val driver = createPaymentsDbDriver(getPlatformContext(), chain = Chain.Testnet3, nodeIdHash = "6a5e6f")
-        val paymentsDb = createSqlitePaymentsDb(driver, contactsManager = null, currencyManager = null)
+        val paymentsDb = createSqlitePaymentsDb(driver, metadataQueue = null, contactsManager = null)
 
         // swap-in 200_000 sat + liquidity purchase from channel balance => received 198_433 sat after fees.
         paymentsDb.database.paymentsIncomingQueries

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/CloudKitPaymentsDb.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/db/CloudKitPaymentsDb.kt
@@ -211,8 +211,8 @@ class CloudKitPaymentsDb(
             val ckQueries = paymentsDb.database.cloudKitPaymentsQueries
             val metaQueries = paymentsDb.database.paymentsMetadataQueries
 
-            val incomingPaymentsDb = SqliteIncomingPaymentsDb(paymentsDb.database)
-            val outgoingPaymentsDb = SqliteOutgoingPaymentsDb(paymentsDb.database)
+            val incomingPaymentsDb = SqliteIncomingPaymentsDb(paymentsDb.database, paymentsDb.metadataQueue)
+            val outgoingPaymentsDb = SqliteOutgoingPaymentsDb(paymentsDb.database, paymentsDb.metadataQueue)
 
             db.transaction {
 
@@ -222,12 +222,12 @@ class CloudKitPaymentsDb(
                     if (payment is IncomingPayment) {
                         val existing = inQueries.get(paymentId).executeAsOneOrNull()
                         if (existing == null) {
-                            incomingPaymentsDb._addIncomingPayment(payment, notify = false)
+                            incomingPaymentsDb._addIncomingPayment(payment, metadata = null, notify = false)
                         }
                     } else if (payment is OutgoingPayment) {
                         val existing = outQueries.get(paymentId).executeAsOneOrNull()
                         if (existing == null) {
-                            outgoingPaymentsDb._addOutgoingPayment(payment, notify = false)
+                            outgoingPaymentsDb._addOutgoingPayment(payment, metadata = null, notify = false)
                         }
                     }
                 }


### PR DESCRIPTION
Prior to the [refactor](https://github.com/ACINQ/phoenix/pull/670), we had 2 methods in SqlitePaymentsDb:
- enqueueMetadata
- dequeueMetadata

It's the lightning-kmp layer that actually triggers the addition of a payment to the database (via `addIncomingPayment`, `addOutgoingPayment`). So these `enqueue/dequeue` methods allowed us to enqueue the corresponding metadata associated with a payment. For example, an outgoing payment may have lnurl-related data that we need to store. Additionally, the `dequeueMetadata` function would always return an object with the proper `originalFiat` conversion.

However, at some point during the refactor the calls to `dequeueMetadata` got dropped. This PR restores that functionality. Additionally, it simplifies the design by moving that functionality to a separate `MetadataQueue` class.
