### PR TITLE
(ios) Bug fix for missing bip-353 address

### DIFF
--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -243,6 +243,9 @@
         }
       }
     },
+    " [more info](https://phoenix.acinq.co/faq#what-is-inbound-liquidity)" : {
+
+    },
     "-" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1381,6 +1384,7 @@
       }
     },
     "%@ [more info](https://phoenix.acinq.co/faq#what-is-inbound-liquidity)" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -45269,7 +45273,6 @@
       }
     },
     "Wallet creation options" : {
-      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/phoenix-ios/phoenix-ios/views/configuration/fees/liquidity management/LiquidityAdsHelp.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/fees/liquidity management/LiquidityAdsHelp.swift
@@ -73,7 +73,8 @@ struct LiquidityAdsHelp: View {
 			
 			HStack(alignment: .center, spacing: 0) {
 				Spacer()
-				Text("\(Image(systemName: "link")) [more info](https://phoenix.acinq.co/faq#what-is-inbound-liquidity)")
+				Text(Image(systemName: "link")) +
+				Text(" [more info](https://phoenix.acinq.co/faq#what-is-inbound-liquidity)")
 				Spacer()
 			}
 			.padding(.top)

--- a/phoenix-ios/phoenix-ios/views/receive/LightningDualView.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/LightningDualView.swift
@@ -380,14 +380,20 @@ struct LightningDualView: View {
 		
 		let bAddress = "₿\(address)"
 		
-		Text(verbatim: "\(Image(systemName: "bitcoinsign.circle")) \(address)")
-			.contextMenu {
-				Button {
-					copyTextToPasteboard(bAddress)
-				} label: {
-					Text("Copy")
-				}
+		Group {
+			if #available(iOS 18, *) {
+				Text(verbatim: "\(Image(systemName: "bitcoinsign.circle")) \(address)")
+			} else {
+				Text(Image(systemName: "bitcoinsign.circle")) + Text(verbatim: " \(address)")
 			}
+		}
+		.contextMenu {
+			Button {
+				copyTextToPasteboard(bAddress)
+			} label: {
+				Text("Copy")
+			}
+		}
 	}
 	
 	@ViewBuilder


### PR DESCRIPTION
This was a bug that affected iOS 16 & 17 (but not 18). Before & after:

<img height="450" src="https://github.com/user-attachments/assets/4ad2328f-1e4c-4a4a-831d-329389af54b2"/>

<img height="450" src="https://github.com/user-attachments/assets/d7dda529-c290-42fb-a8c4-192a6570afa7"/>
