### PR TITLE
Remove payments count flow and query

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomePayments.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomePayments.kt
@@ -46,7 +46,6 @@ fun ColumnScope.PaymentsList(
     onPaymentClick: (UUID) -> Unit,
     onPaymentsHistoryClick: () -> Unit,
     payments: List<WalletPaymentInfo>,
-    allPaymentsCount: Long,
 ) {
     Column(modifier = modifier.weight(1f, fill = true), horizontalAlignment = Alignment.CenterHorizontally) {
         if (payments.isEmpty()) {
@@ -59,7 +58,6 @@ fun ColumnScope.PaymentsList(
             )
         } else {
             LatestPaymentsList(
-                allPaymentsCount = allPaymentsCount,
                 payments = payments,
                 onPaymentClick = onPaymentClick,
                 onPaymentsHistoryClick = onPaymentsHistoryClick,
@@ -71,7 +69,6 @@ fun ColumnScope.PaymentsList(
 
 @Composable
 private fun ColumnScope.LatestPaymentsList(
-    allPaymentsCount: Long,
     payments: List<WalletPaymentInfo>,
     onPaymentClick: (UUID) -> Unit,
     onPaymentsHistoryClick: () -> Unit,
@@ -95,7 +92,7 @@ private fun ColumnScope.LatestPaymentsList(
         items(payments) {
             PaymentLine(it, null, onPaymentClick, isAmountRedacted)
         }
-        if (payments.isNotEmpty() && allPaymentsCount > PaymentsViewModel.paymentsCountInHome) {
+        if (payments.isNotEmpty()) {
             item {
                 Spacer(Modifier.height(16.dp))
                 morePaymentsButton()

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/home/HomeView.kt
@@ -95,7 +95,6 @@ fun HomeView(
         )
     }
 
-    val allPaymentsCount by business.paymentsManager.paymentsCount.collectAsState()
     val payments by paymentsViewModel.homePaymentsFlow.collectAsState()
     val swapInBalance = business.balanceManager.swapInWalletBalance.collectAsState()
     val finalWallet = business.peerManager.finalWallet.collectAsState()
@@ -244,7 +243,6 @@ fun HomeView(
                 onPaymentClick = onPaymentClick,
                 onPaymentsHistoryClick = onPaymentsHistoryClick,
                 payments = payments,
-                allPaymentsCount = allPaymentsCount
             )
             BottomBar(Modifier, onSettingsClick, onReceiveClick, onSendClick)
         }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/history/PaymentsHistoryView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/history/PaymentsHistoryView.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -34,6 +35,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -46,6 +48,7 @@ import fr.acinq.phoenix.android.components.CardHeader
 import fr.acinq.phoenix.android.components.DefaultScreenHeader
 import fr.acinq.phoenix.android.components.DefaultScreenLayout
 import fr.acinq.phoenix.android.components.ItemCard
+import fr.acinq.phoenix.android.components.TextWithIcon
 import fr.acinq.phoenix.android.utils.logger
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
@@ -99,8 +102,8 @@ fun PaymentsHistoryView(
     onPaymentClick: (UUID) -> Unit,
     onCsvExportClick: () -> Unit,
 ) {
+    val log = logger("PaymentsHistory")
     val listState = rememberLazyListState()
-    val allPaymentsCount by business.paymentsManager.paymentsCount.collectAsState()
     val paymentsPage by paymentsViewModel.paymentsPage.collectAsState()
     val payments by paymentsViewModel.paymentsFlow.collectAsState()
 
@@ -120,15 +123,13 @@ fun PaymentsHistoryView(
         }
     }
 
-    val log = logger("PaymentsHistory")
-
     DefaultScreenLayout(
         isScrollable = false,
         backgroundColor = MaterialTheme.colors.background
     ) {
         DefaultScreenHeader(
             content = {
-                Text(text = stringResource(id = R.string.payments_history_title, allPaymentsCount))
+                Text(text = stringResource(id = R.string.payments_history_title))
                 Spacer(Modifier.weight(1f))
                 Button(
                     text = stringResource(id = R.string.payments_history_export_button),
@@ -162,6 +163,16 @@ fun PaymentsHistoryView(
                 .collect { offset ->
                     paymentsViewModel.subscribeToPayments(offset, PaymentsViewModel.pageSize)
                 }
+        }
+
+        if (groupedPayments.isEmpty()) {
+            TextWithIcon(
+                text = stringResource(R.string.payments_history_empty),
+                textStyle = MaterialTheme.typography.caption,
+                icon = R.drawable.ic_sleep,
+                iconTint = MaterialTheme.typography.caption.color,
+                modifier = Modifier.padding(top = 60.dp).align(Alignment.CenterHorizontally)
+            )
         }
 
         LazyColumn(

--- a/phoenix-android/src/main/res/values-b+es+419/strings.xml
+++ b/phoenix-android/src/main/res/values-b+es+419/strings.xml
@@ -590,7 +590,7 @@
 
     <!-- payments history -->
 
-    <string name="payments_history_title">Pagos locales (%1$d)</string>
+    <string name="payments_history_title">Pagos locales</string>
     <string name="payments_history_export_button">Exportar</string>
     <string name="payments_history_today">Hoy</string>
     <string name="payments_history_yesterday">Ayer</string>

--- a/phoenix-android/src/main/res/values-cs/strings.xml
+++ b/phoenix-android/src/main/res/values-cs/strings.xml
@@ -606,7 +606,7 @@
 
     <!-- payments history -->
 
-    <string name="payments_history_title">Místní platby (%1$d)</string>
+    <string name="payments_history_title">Místní platby</string>
     <string name="payments_history_export_button">Exportovat</string>
     <string name="payments_history_today">Dnes</string>
     <string name="payments_history_yesterday">Včera</string>

--- a/phoenix-android/src/main/res/values-de/strings.xml
+++ b/phoenix-android/src/main/res/values-de/strings.xml
@@ -614,7 +614,7 @@
 
     <!-- payments history -->
 
-    <string name="payments_history_title">Zahlungen (%1$d)</string>
+    <string name="payments_history_title">Zahlungen</string>
     <string name="payments_history_export_button">Exportieren</string>
     <string name="payments_history_today">Heute</string>
     <string name="payments_history_yesterday">Gestern</string>

--- a/phoenix-android/src/main/res/values-fr/strings.xml
+++ b/phoenix-android/src/main/res/values-fr/strings.xml
@@ -651,7 +651,7 @@
 
     <!-- payments history -->
 
-    <string name="payments_history_title">Paiements locaux (%1$d)</string>
+    <string name="payments_history_title">Paiements locaux</string>
     <string name="payments_history_export_button">Exporter</string>
     <string name="payments_history_today">Aujourd\'hui</string>
     <string name="payments_history_yesterday">Hier</string>

--- a/phoenix-android/src/main/res/values-pt-rBR/strings.xml
+++ b/phoenix-android/src/main/res/values-pt-rBR/strings.xml
@@ -587,7 +587,7 @@
 
     <!-- payments history -->
 
-    <string name="payments_history_title">Pagamentos locais (%1$d)</string>
+    <string name="payments_history_title">Pagamentos locais</string>
     <string name="payments_history_export_button">Exportar</string>
     <string name="payments_history_today">Hoje</string>
     <string name="payments_history_yesterday">Ontem</string>

--- a/phoenix-android/src/main/res/values-sk/strings.xml
+++ b/phoenix-android/src/main/res/values-sk/strings.xml
@@ -653,7 +653,7 @@
 
     <!-- payments history -->
 
-    <string name="payments_history_title">Lokálne platby (%1$d)</string>
+    <string name="payments_history_title">Lokálne platby</string>
     <string name="payments_history_export_button">Exportovať</string>
     <string name="payments_history_today">Dnes</string>
     <string name="payments_history_yesterday">Včera</string>

--- a/phoenix-android/src/main/res/values-sw/strings.xml
+++ b/phoenix-android/src/main/res/values-sw/strings.xml
@@ -675,7 +675,7 @@
 
     <!-- Payments history -->
 
-    <string name="payments_history_title">Malipo ya ndani (%1$d)</string>
+    <string name="payments_history_title">Malipo ya ndani</string>
     <string name="payments_history_export_button">Hamisha</string>
     <string name="payments_history_today">Leo</string>
     <string name="payments_history_yesterday">Jana</string>

--- a/phoenix-android/src/main/res/values-vi/strings.xml
+++ b/phoenix-android/src/main/res/values-vi/strings.xml
@@ -609,7 +609,7 @@
 
     <!-- payments history -->
 
-    <string name="payments_history_title">Thanh toán địa phương (%1$d)</string>
+    <string name="payments_history_title">Thanh toán địa phương</string>
     <string name="payments_history_export_button">Truy xuất</string>
     <string name="payments_history_today">Ngày hôm nay</string>
     <string name="payments_history_yesterday">Ngày hôm qua</string>

--- a/phoenix-android/src/main/res/values/strings.xml
+++ b/phoenix-android/src/main/res/values/strings.xml
@@ -761,8 +761,9 @@
 
     <!-- payments history -->
 
-    <string name="payments_history_title">Local payments (%1$d)</string>
+    <string name="payments_history_title">Local payments</string>
     <string name="payments_history_export_button">Export</string>
+    <string name="payments_history_empty">No payments yet…</string>
     <string name="payments_history_today">Today</string>
     <string name="payments_history_yesterday">Yesterday</string>
     <string name="payments_history_thisweek">Earlier this week</string>

--- a/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers+Phoenix.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinPublishers+Phoenix.swift
@@ -352,24 +352,8 @@ extension PhoenixShared.NotificationsManager {
 extension PaymentsManager {
 	
 	fileprivate struct _Key {
-		static var paymentsCountPublisher = 0
 		static var lastCompletedPaymentPublisher = 0
 		static var lastIncomingPaymentPublisher = 0
-	}
-	
-	func paymentsCountPublisher() -> AnyPublisher<Int64, Never> {
-		
-		self.getSetAssociatedObject(storageKey: &_Key.paymentsCountPublisher) {
-			
-			// Transforming from Kotlin:
-			// `paymentsCount: StateFlow<Long>`
-			//
-			KotlinCurrentValueSubject<KotlinLong>(
-				self.paymentsCount
-			)
-			.compactMap { $0?.int64Value }
-			.eraseToAnyPublisher()
-		}
 	}
 	
 	func lastCompletedPaymentPublisher() -> AnyPublisher<Lightning_kmpWalletPayment, Never> {

--- a/phoenix-ios/phoenix-ios/views/main/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/main/HomeView.swift
@@ -776,7 +776,7 @@ struct HomeView : MVIView {
 		let balance = model.balance?.msat ?? 0
 		let incomingBalance = swapInWallet.totalBalance.sat
 		
-		if balance > 0 || incomingBalance > 0 || model.paymentsCount > 0 {
+		if balance > 0 || incomingBalance > 0 {
 			if Prefs.shared.isNewWallet {
 				Prefs.shared.isNewWallet = false
 			}

--- a/phoenix-ios/phoenix-ios/views/transactions/TransactionsView.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/TransactionsView.swift
@@ -23,9 +23,6 @@ struct TransactionsView: View {
 
 	private let paymentsPageFetcher = Biz.getPaymentsPageFetcher(name: "TransactionsView")
 	
-	let paymentsCountPublisher = Biz.business.paymentsManager.paymentsCountPublisher()
-	@State var paymentsCount: Int64 = 0
-	
 	let paymentsPagePublisher: AnyPublisher<PaymentsPage, Never>
 	@State var paymentsPage = PaymentsPage(offset: 0, count: 0, rows: [])
 	@State var cachedRows: [WalletPaymentInfo] = []
@@ -86,9 +83,6 @@ struct TransactionsView: View {
 		}
 		.onAppear {
 			onAppear()
-		}
-		.onReceive(paymentsCountPublisher) {
-			paymentsCountChanged($0)
 		}
 		.onReceive(paymentsPagePublisher) {
 			paymentsPageChanged($0)
@@ -282,12 +276,6 @@ struct TransactionsView: View {
 				}
 			}
 		}
-	}
-	
-	func paymentsCountChanged(_ count: Int64) {
-		log.trace("paymentsCountChanged() => \(count)")
-		
-		paymentsCount = count
 	}
 	
 	func paymentsPageChanged(_ page: PaymentsPage) {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/main/Home.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/main/Home.kt
@@ -7,12 +7,10 @@ object Home {
 
     data class Model(
         val balance: MilliSatoshi?,
-        val paymentsCount: Long
     ) : MVI.Model()
 
     val emptyModel = Model(
         balance = null,
-        paymentsCount = 0
     )
 
     sealed class Intent : MVI.Intent()

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/main/HomeController.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/controllers/main/HomeController.kt
@@ -1,17 +1,14 @@
 package fr.acinq.phoenix.controllers.main
 
-import co.touchlab.kermit.Logger
 import fr.acinq.lightning.logging.LoggerFactory
 import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.controllers.AppController
 import fr.acinq.phoenix.managers.BalanceManager
-import fr.acinq.phoenix.managers.PaymentsManager
 import kotlinx.coroutines.launch
 
 
 class AppHomeController(
     loggerFactory: LoggerFactory,
-    private val paymentsManager: PaymentsManager,
     private val balanceManager: BalanceManager
 ) : AppController<Home.Model, Home.Intent>(
     loggerFactory = loggerFactory,
@@ -19,7 +16,6 @@ class AppHomeController(
 ) {
     constructor(business: PhoenixBusiness): this(
         loggerFactory = business.loggerFactory,
-        paymentsManager = business.paymentsManager,
         balanceManager = business.balanceManager
     )
 
@@ -27,12 +23,6 @@ class AppHomeController(
         launch {
             balanceManager.balance.collect {
                 model { copy(balance = it) }
-            }
-        }
-
-        launch {
-            paymentsManager.paymentsCount.collect {
-                model { copy(paymentsCount = it) }
             }
         }
     }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/SqlitePaymentsDb.kt
@@ -196,16 +196,6 @@ class SqlitePaymentsDb(
         database.paymentsQueries.getOldestCompletedAt().executeAsOneOrNull()?.completed_at
     }
 
-    fun countPaymentsAsFlow(): Flow<Long> {
-        return database.paymentsQueries.count()
-            .asFlow()
-            .map {
-                withContext(Dispatchers.Default) {
-                    database.transactionWithResult { it.executeAsOne() }
-                }
-            }
-    }
-
     suspend fun countCompletedInRange(startDate: Long, endDate: Long): Long = withContext(Dispatchers.Default) {
         database.paymentsQueries.countCompletedInRange(completed_at_from = startDate, completed_at_to = endDate).executeAsOne()
     }

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsManager.kt
@@ -45,13 +45,6 @@ class PaymentsManager(
 
     private val log = loggerFactory.newLogger(this::class)
 
-    /**
-     * A flow containing the total number of payments in the database,
-     * and automatically refreshed when the database changes.
-     */
-    private val _paymentsCount = MutableStateFlow<Long>(0)
-    val paymentsCount: StateFlow<Long> = _paymentsCount
-
     /** Contains the most recently completed payment (only bolt11 incoming, or bolt11/bolt12 outgoing). */
     private val _lastCompletedPayment = MutableStateFlow<WalletPayment?>(null)
     val lastCompletedPayment: StateFlow<WalletPayment?> = _lastCompletedPayment
@@ -61,15 +54,10 @@ class PaymentsManager(
     }
 
     init {
-        launch { monitorPaymentsCountInDb() }
 
         launch { monitorLastCompletedPayment() }
 
         launch { monitorUnconfirmedTransactions() }
-    }
-
-    private suspend fun monitorPaymentsCountInDb() {
-        paymentsDb().countPaymentsAsFlow().collect { _paymentsCount.value = it }
     }
 
     private suspend fun monitorLastCompletedPayment() {

--- a/phoenix-shared/src/commonMain/sqldelight/paymentsdb/fr/acinq/phoenix/db/sqldelight/Payments.sq
+++ b/phoenix-shared/src/commonMain/sqldelight/paymentsdb/fr/acinq/phoenix/db/sqldelight/Payments.sq
@@ -53,10 +53,6 @@ getOldestCompletedAt:
 SELECT min(completed_at) AS completed_at
 FROM payments;
 
-count:
-SELECT count(id)
-FROM payments;
-
 countCompletedInRange:
 SELECT   count(id)
 FROM     payments


### PR DESCRIPTION
This PR removes the payments count flow obtained by monitoring the payments database using the `asFlow` operator from the SQLDelight coroutines-extension. It was still using the workaround from #415 which creates issues in some cases. Besides, this count is not useful anymore, it's only rarely used in the Android UI and thus can be removed.

### Removing the Home MVI controller

The MVI home controller now only contains the balance, which is already exposed by the `BalanceManager`. The Android does not use it anymore, but the iOS app still references it. @robbiehanson If that's fine with you, I think we can remove it, you can use this PR to do it.