### PR TITLE
(ios) UI issues regarding received payments via Bolt 12

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsManager.kt
@@ -3,8 +3,8 @@ package fr.acinq.phoenix.managers
 import fr.acinq.bitcoin.TxId
 import fr.acinq.lightning.PaymentEvents
 import fr.acinq.lightning.blockchain.electrum.ElectrumClient
-import fr.acinq.lightning.db.Bolt11IncomingPayment
 import fr.acinq.lightning.db.IncomingPayment
+import fr.acinq.lightning.db.LightningIncomingPayment
 import fr.acinq.lightning.db.LightningOutgoingPayment
 import fr.acinq.lightning.db.WalletPayment
 import fr.acinq.lightning.logging.LoggerFactory
@@ -45,7 +45,7 @@ class PaymentsManager(
 
     private val log = loggerFactory.newLogger(this::class)
 
-    /** Contains the most recently completed payment (only bolt11 incoming, or bolt11/bolt12 outgoing). */
+    /** Contains the most recently completed payment (only Lightning incoming/outgoing). */
     private val _lastCompletedPayment = MutableStateFlow<WalletPayment?>(null)
     val lastCompletedPayment: StateFlow<WalletPayment?> = _lastCompletedPayment
 
@@ -64,7 +64,7 @@ class PaymentsManager(
         val nodeParams = nodeParamsManager.nodeParams.filterNotNull().first()
         nodeParams.nodeEvents.filterIsInstance<PaymentEvents>().collect {
             when (it) {
-                is PaymentEvents.PaymentReceived -> if (it.payment is Bolt11IncomingPayment) _lastCompletedPayment.value = it.payment
+                is PaymentEvents.PaymentReceived -> if (it.payment is LightningIncomingPayment) _lastCompletedPayment.value = it.payment
                 is PaymentEvents.PaymentSent -> if (it.payment is LightningOutgoingPayment) _lastCompletedPayment.value = it.payment
             }
         }


### PR DESCRIPTION
In the shared kotlin layer, `PaymentsManager.lastCompletedPayment` was changed at some point to **exclude** incoming Bolt12 payments. This resulted in the following bugs in iOS:

1. Normally, when an incoming payment is received, the iOS app displays a sheet (that slides up from the bottom of the screen) alerting the user to the payment. This wasn't occurring for incoming Bolt12 payments.
2. When inside the "Receive" screen, and looking at the Bolt12 info, an incoming Bolt12 payment should dismiss the screen, and show the user the Home screen's sheet. This wasn't occurring.
3. When a Bolt12 payment is received while the app is in the background, it should display a notification about the received payment. Instead it was displaying a notification of "missed incoming payment" even though the payment was received.

Problem 3 could also result in the database not properly updating in the foreground app, and the UI wouldn't display the received payment.

This PR changes `lastCompletedPayment` to include **ALL** lightning payments.
This PR addresses ticket [84169632](https://phoenix.jitbit.com/Ticket/84169632)

In iOS we create a derivative flow for sub-categories. I.E. `lastCompletedIncomingPayment` is a derivative flow that only emits incoming payments. If we need a derivative flow that excludes incoming Bolt12 for Android, we could create a similar "sub-flow".

---
Note that changing `lastCompletedPayment` affects 2 files in phoenix-android:

AppView.kt:
```kotlin
val lastCompletedPayment by business.paymentsManager.lastCompletedPayment.collectAsState()
lastCompletedPayment?.let { payment ->
    LaunchedEffect(key1 = payment.id) {
        navigateToPaymentDetails(navController, id = payment.id, isFromEvent = true)
    }
}
```

ReceiveLightningView.kt
```kotlin
// refresh LN invoice when it has been paid
val paymentsManager = business.paymentsManager
LaunchedEffect(key1 = Unit) {
    paymentsManager.lastCompletedPayment.collect { completedPayment ->
        if (state is LightningInvoiceState.Show && completedPayment is Bolt11IncomingPayment && state.invoice.paymentHash == completedPayment.paymentHash) {
            vm.generateInvoice(amount = customAmount, description = customDesc, expirySeconds = defaultExpiry)
            feeWarningDialogShownTimestamp = 0 // reset the dialog tracker to show it asap for a new invoice
        }
    }
}
```

