### PR TITLE
(ios) MinerFeeSheet truncation

### DIFF
--- a/phoenix-ios/phoenix-ios/views/inspect/CpfpView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/CpfpView.swift
@@ -66,6 +66,13 @@ struct CpfpView: View {
 	)
 	@State var priorityBoxWidth: CGFloat? = nil
 	
+	enum PriorityBoxHeight: Preference {}
+	let priorityBoxHeightReader = GeometryPreferenceReader(
+		key: AppendValue<PriorityBoxWidth>.self,
+		value: { [$0.size.height] }
+	)
+	@State var priorityBoxHeight: CGFloat? = nil
+	
 	@Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 	
 	@EnvironmentObject var currencyPrefs: CurrencyPrefs
@@ -99,7 +106,6 @@ struct CpfpView: View {
 	func main() -> some View {
 		
 		VStack(alignment: HorizontalAlignment.center, spacing: 0) {
-		
 			header()
 			ScrollView {
 				content()
@@ -187,34 +193,47 @@ struct CpfpView: View {
 	@ViewBuilder
 	func priorityBoxes() -> some View {
 		
-		priorityBoxes_ios16()
+		ViewThatFits {
+			priorityBoxes_normal()
+			priorityBoxes_accessibility()
+		}
+		.assignMaxPreference(for: priorityBoxWidthReader.key, to: $priorityBoxWidth)
+		.assignMaxPreference(for: priorityBoxHeightReader.key, to: $priorityBoxHeight)
 	}
 	
 	@ViewBuilder
-	func priorityBoxes_ios16() -> some View {
+	func priorityBoxes_normal() -> some View {
 		
-		ViewThatFits {
-			Grid(horizontalSpacing: 8, verticalSpacing: 8) {
-				GridRow(alignment: VerticalAlignment.center) {
-					priorityBox_economy()
-					priorityBox_low()
-					priorityBox_medium()
-					priorityBox_high()
-				}
-			} // </Grid>
-			Grid(horizontalSpacing: 8, verticalSpacing: 8) {
-				GridRow(alignment: VerticalAlignment.center) {
-					priorityBox_economy()
-					priorityBox_low()
-					
-				}
-				GridRow(alignment: VerticalAlignment.center) {
-					priorityBox_medium()
-					priorityBox_high()
-				}
-			} // </Grid>
-		}
-		.assignMaxPreference(for: priorityBoxWidthReader.key, to: $priorityBoxWidth)
+		Grid(horizontalSpacing: 8, verticalSpacing: 8) {
+			GridRow(alignment: VerticalAlignment.center) {
+				priorityBox_economy()
+				priorityBox_low()
+				
+			}
+			GridRow(alignment: VerticalAlignment.center) {
+				priorityBox_medium()
+				priorityBox_high()
+			}
+		} // </Grid>
+	}
+	
+	@ViewBuilder
+	func priorityBoxes_accessibility() -> some View {
+		
+		Grid(horizontalSpacing: 8, verticalSpacing: 8) {
+			GridRow(alignment: VerticalAlignment.center) {
+				priorityBox_economy()
+			}
+			GridRow(alignment: VerticalAlignment.center) {
+				priorityBox_low()
+			}
+			GridRow(alignment: VerticalAlignment.center) {
+				priorityBox_medium()
+			}
+			GridRow(alignment: VerticalAlignment.center) {
+				priorityBox_high()
+			}
+		} // </Grid>
 	}
 	
 	@ViewBuilder
@@ -232,11 +251,13 @@ struct CpfpView: View {
 		}
 		.groupBoxStyle(PriorityBoxStyle(
 			width: priorityBoxWidth,
+			height: priorityBoxHeight,
 			disabled: isPriorityDisabled(),
 			selected: isPrioritySelected(.none),
 			tapped: { priorityTapped(.none) }
 		))
 		.read(priorityBoxWidthReader)
+		.read(priorityBoxHeightReader)
 	}
 	
 	@ViewBuilder
@@ -254,11 +275,13 @@ struct CpfpView: View {
 		}
 		.groupBoxStyle(PriorityBoxStyle(
 			width: priorityBoxWidth,
+			height: priorityBoxHeight,
 			disabled: isPriorityDisabled(),
 			selected: isPrioritySelected(.low),
 			tapped: { priorityTapped(.low) }
 		))
 		.read(priorityBoxWidthReader)
+		.read(priorityBoxHeightReader)
 	}
 	
 	@ViewBuilder
@@ -276,11 +299,13 @@ struct CpfpView: View {
 		}
 		.groupBoxStyle(PriorityBoxStyle(
 			width: priorityBoxWidth,
+			height: priorityBoxHeight,
 			disabled: isPriorityDisabled(),
 			selected: isPrioritySelected(.medium),
 			tapped: { priorityTapped(.medium) }
 		))
 		.read(priorityBoxWidthReader)
+		.read(priorityBoxHeightReader)
 	}
 	
 	@ViewBuilder
@@ -298,11 +323,13 @@ struct CpfpView: View {
 		}
 		.groupBoxStyle(PriorityBoxStyle(
 			width: priorityBoxWidth,
+			height: priorityBoxHeight,
 			disabled: isPriorityDisabled(),
 			selected: isPrioritySelected(.high),
 			tapped: { priorityTapped(.high) }
 		))
 		.read(priorityBoxWidthReader)
+		.read(priorityBoxHeightReader)
 	}
 	
 	@ViewBuilder

--- a/phoenix-ios/phoenix-ios/views/send/MinerFeeSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/send/MinerFeeSheet.swift
@@ -30,8 +30,9 @@ struct MinerFeeSheet: View {
 	@State var showLowMinerFeeWarning: Bool = false
 	
 	@Environment(\.colorScheme) var colorScheme: ColorScheme
-	@EnvironmentObject var smartModalState: SmartModalState
+	
 	@EnvironmentObject var currencyPrefs: CurrencyPrefs
+	@EnvironmentObject var smartModalState: SmartModalState
 	
 	enum Field: Hashable {
 		case satsPerByteTextField
@@ -44,6 +45,13 @@ struct MinerFeeSheet: View {
 		value: { [$0.size.width] }
 	)
 	@State var priorityBoxWidth: CGFloat? = nil
+	
+	enum PriorityBoxHeight: Preference {}
+	let priorityBoxHeightReader = GeometryPreferenceReader(
+		key: AppendValue<PriorityBoxWidth>.self,
+		value: { [$0.size.height] }
+	)
+	@State var priorityBoxHeight: CGFloat? = nil
 	
 	enum FooterContentHeight: Preference {}
 	let footerContentHeightReader = GeometryPreferenceReader(
@@ -65,20 +73,28 @@ struct MinerFeeSheet: View {
 					smartModalState.dismissable = false
 				}
 		} else {
-			VStack(alignment: HorizontalAlignment.center, spacing: 0) {
-				header()
+			main()
+				.onAppear {
+					smartModalState.dismissable = true
+				}
+		}
+	}
+	
+	@ViewBuilder
+	func main() -> some View {
+		
+		VStack(alignment: HorizontalAlignment.center, spacing: 0) {
+			header()
+			ScrollView(.vertical) {
 				content()
 				footer()
 			}
-			.onChange(of: satsPerByte) { _ in
-				satsPerByteChanged()
-			}
-			.onChange(of: mempoolRecommendedResponse) { _ in
-				mempoolRecommendedResponseChanged()
-			}
-			.onAppear {
-				smartModalState.dismissable = true
-			}
+		}
+		.onChange(of: satsPerByte) { _ in
+			satsPerByteChanged()
+		}
+		.onChange(of: mempoolRecommendedResponse) { _ in
+			mempoolRecommendedResponseChanged()
 		}
 	}
 	
@@ -127,34 +143,47 @@ struct MinerFeeSheet: View {
 	@ViewBuilder
 	func priorityBoxes() -> some View {
 		
-		priorityBoxes_ios16()
+		ViewThatFits {
+			priorityBoxes_normal()
+			priorityBoxes_accessibility()
+		}
+		.assignMaxPreference(for: priorityBoxWidthReader.key, to: $priorityBoxWidth)
+		.assignMaxPreference(for: priorityBoxHeightReader.key, to: $priorityBoxHeight)
 	}
 	
 	@ViewBuilder
-	func priorityBoxes_ios16() -> some View {
+	func priorityBoxes_normal() -> some View {
 		
-		ViewThatFits {
-			Grid(horizontalSpacing: 8, verticalSpacing: 8) {
-				GridRow(alignment: VerticalAlignment.center) {
-					priorityBox_economy()
-					priorityBox_low()
-					priorityBox_medium()
-					priorityBox_high()
-				}
-			} // </Grid>
-			Grid(horizontalSpacing: 8, verticalSpacing: 8) {
-				GridRow(alignment: VerticalAlignment.center) {
-					priorityBox_economy()
-					priorityBox_low()
-					
-				}
-				GridRow(alignment: VerticalAlignment.center) {
-					priorityBox_medium()
-					priorityBox_high()
-				}
-			} // </Grid>
-		}
-		.assignMaxPreference(for: priorityBoxWidthReader.key, to: $priorityBoxWidth)
+		Grid(horizontalSpacing: 8, verticalSpacing: 8) {
+			GridRow(alignment: VerticalAlignment.center) {
+				priorityBox_economy()
+				priorityBox_low()
+				
+			}
+			GridRow(alignment: VerticalAlignment.center) {
+				priorityBox_medium()
+				priorityBox_high()
+			}
+		} // </Grid>
+	}
+	
+	@ViewBuilder
+	func priorityBoxes_accessibility() -> some View {
+		
+		Grid(horizontalSpacing: 8, verticalSpacing: 8) {
+			GridRow(alignment: VerticalAlignment.center) {
+				priorityBox_economy()
+			}
+			GridRow(alignment: VerticalAlignment.center) {
+				priorityBox_low()
+			}
+			GridRow(alignment: VerticalAlignment.center) {
+				priorityBox_medium()
+			}
+			GridRow(alignment: VerticalAlignment.center) {
+				priorityBox_high()
+			}
+		} // </Grid>
 	}
 	
 	@ViewBuilder
@@ -172,11 +201,13 @@ struct MinerFeeSheet: View {
 		}
 		.groupBoxStyle(PriorityBoxStyle(
 			width: priorityBoxWidth,
+			height: priorityBoxHeight,
 			disabled: isPriorityDisabled(),
 			selected: isPrioritySelected(.none),
 			tapped: { priorityTapped(.none) }
 		))
 		.read(priorityBoxWidthReader)
+		.read(priorityBoxHeightReader)
 	}
 	
 	@ViewBuilder
@@ -194,11 +225,13 @@ struct MinerFeeSheet: View {
 		}
 		.groupBoxStyle(PriorityBoxStyle(
 			width: priorityBoxWidth,
+			height: priorityBoxHeight,
 			disabled: isPriorityDisabled(),
 			selected: isPrioritySelected(.low),
 			tapped: { priorityTapped(.low) }
 		))
 		.read(priorityBoxWidthReader)
+		.read(priorityBoxHeightReader)
 	}
 	
 	@ViewBuilder
@@ -216,11 +249,13 @@ struct MinerFeeSheet: View {
 		}
 		.groupBoxStyle(PriorityBoxStyle(
 			width: priorityBoxWidth,
+			height: priorityBoxHeight,
 			disabled: isPriorityDisabled(),
 			selected: isPrioritySelected(.medium),
 			tapped: { priorityTapped(.medium) }
 		))
 		.read(priorityBoxWidthReader)
+		.read(priorityBoxHeightReader)
 	}
 	
 	@ViewBuilder
@@ -238,11 +273,13 @@ struct MinerFeeSheet: View {
 		}
 		.groupBoxStyle(PriorityBoxStyle(
 			width: priorityBoxWidth,
+			height: priorityBoxHeight,
 			disabled: isPriorityDisabled(),
 			selected: isPrioritySelected(.high),
 			tapped: { priorityTapped(.high) }
 		))
 		.read(priorityBoxWidthReader)
+		.read(priorityBoxHeightReader)
 	}
 	
 	@ViewBuilder

--- a/phoenix-ios/phoenix-ios/views/send/PriorityBoxStyle.swift
+++ b/phoenix-ios/phoenix-ios/views/send/PriorityBoxStyle.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct PriorityBoxStyle: GroupBoxStyle {
 	
 	let width: CGFloat?
+	let height: CGFloat?
 	let disabled: Bool
 	let selected: Bool
 	let tapped: () -> Void
@@ -13,7 +14,7 @@ struct PriorityBoxStyle: GroupBoxStyle {
 				.font(.headline)
 			configuration.content
 		}
-		.frame(width: width?.advanced(by: -16.0))
+		.frame(width: width?.advanced(by: -16.0), height: height?.advanced(by: -16.0))
 		.padding(.all, 8)
 		.background(RoundedRectangle(cornerRadius: 8, style: .continuous)
 			.fill(Color(UIColor.quaternarySystemFill)))


### PR DESCRIPTION
The MinerFeeSheet could be truncated in certain situations (small devices when very large fonts). This PR adds a ScrollView to ensure the content is accessible in all situations.

Before & After:

<img height="450" src="https://github.com/user-attachments/assets/e52b8323-8a42-4958-8bcd-d2b34ffe0f26"/><img height="450" src="https://github.com/user-attachments/assets/7db22a4f-65f9-423e-abe2-b92dae18128c"/>
