### PR TITLE
(ios) Match UI for failed payments with Android

### DIFF
--- a/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
+++ b/phoenix-ios/phoenix-ios/views/inspect/SummaryView.swift
@@ -70,6 +70,9 @@ struct SummaryView: View {
 	)
 	@State var buttonHeight: CGFloat? = nil
 	
+	// If we don't store this as a variable, the publisher seems to fire continuously.
+	let contactsListPublisher = Biz.business.databaseManager.contactsListPublisher()
+	
 	@StateObject var blockchainMonitorState = BlockchainMonitorState()
 	
 	@Environment(\.dynamicTypeSize) var dynamicTypeSize: DynamicTypeSize
@@ -152,7 +155,7 @@ struct SummaryView: View {
 		.onChange(of: paymentInfo) { _ in
 			paymentInfoChanged()
 		}
-		.onReceive(Biz.business.databaseManager.contactsListPublisher()) { _ in
+		.onReceive(contactsListPublisher) { _ in
 			contactsChanged()
 		}
 		.task {

--- a/phoenix-ios/phoenix-ios/views/transactions/PaymentCell.swift
+++ b/phoenix-ios/phoenix-ios/views/transactions/PaymentCell.swift
@@ -128,7 +128,7 @@ struct PaymentCell : View {
 				case WalletPaymentState.successOffChain : Image(systemName: "checkmark.circle.fill")
 				case WalletPaymentState.pendingOnChain  : Image(systemName: "clock.fill")
 				case WalletPaymentState.pendingOffChain : Image(systemName: "clock.fill")
-				case WalletPaymentState.failure         : Image(systemName: "x.circle.fill")
+				case WalletPaymentState.failure         : Image(systemName: "xmark")
 				@unknown default                        : Image(systemName: "magnifyingglass.circle.fill")
 			}
 		}
@@ -141,7 +141,7 @@ struct PaymentCell : View {
 	func paymentAmount() -> some View {
 		
 		let (amount, isFailure, isOutgoing) = paymentAmountInfo()
-		if isLiquidityWithFeesDisplayedElsewhere() {
+		if isFailure || isLiquidityWithFeesDisplayedElsewhere() {
 			
 			Text(verbatim: "")
 				.accessibilityHidden(true)


### PR DESCRIPTION
Before & After:

<img height="450" src="https://github.com/user-attachments/assets/733069ae-c21f-4068-adbb-5ed0dd0d3610"/>

<img height="450" src="https://github.com/user-attachments/assets/27719777-937b-4951-a15a-f3d744db3c83"/>
