### PR TITLE
(ios) Export BIP-321 URI via NFC (host card emulation)

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -32,6 +32,12 @@
 		DC0732EC263CA6C3004CB88D /* PaymentOptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0732EB263CA6C3004CB88D /* PaymentOptionsView.swift */; };
 		DC08A51827FB39530041603B /* AnimatedChevron.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC08A51727FB39530041603B /* AnimatedChevron.swift */; };
 		DC08A51A27FB6C5F0041603B /* TopTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC08A51927FB6C5F0041603B /* TopTab.swift */; };
+		DC08FC232DA978050003E88C /* CapabilitiesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC08FC222DA978050003E88C /* CapabilitiesContainer.swift */; };
+		DC08FC292DA978810003E88C /* Array+Read.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC08FC272DA978810003E88C /* Array+Read.swift */; };
+		DC08FC2B2DA978940003E88C /* CommandAPDU.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC08FC2A2DA978940003E88C /* CommandAPDU.swift */; };
+		DC08FC2F2DA9796A0003E88C /* HceWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC08FC2E2DA9796A0003E88C /* HceWriter.swift */; };
+		DC08FC6E2DA9ABE80003E88C /* Ndef.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC08FC6D2DA9ABE80003E88C /* Ndef.swift */; };
+		DC08FC732DAEABC20003E88C /* ByteArrayConversions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC08FC722DAEABB00003E88C /* ByteArrayConversions.swift */; };
 		DC09085825B5E43900A46136 /* String+VersionComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC09085725B5E43900A46136 /* String+VersionComparison.swift */; };
 		DC09086325B626B300A46136 /* AppStatusPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC09086225B626B300A46136 /* AppStatusPopover.swift */; };
 		DC0994B0263A074C003031CA /* InfoGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0994AF263A074C003031CA /* InfoGrid.swift */; };
@@ -339,6 +345,7 @@
 		DCCFE6C22B7140FA002FFF11 /* LoggerFactory+Foreground.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCFE6C12B7140FA002FFF11 /* LoggerFactory+Foreground.swift */; };
 		DCCFE6C52B714226002FFF11 /* LoggerFactory+Background.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCFE6C32B714171002FFF11 /* LoggerFactory+Background.swift */; };
 		DCD1208728663F4A00EB39C5 /* TransactionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD1208628663F4A00EB39C5 /* TransactionsView.swift */; };
+		DCD1BFD62CE775E900C2B811 /* NfcReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD1BFD52CE775E500C2B811 /* NfcReader.swift */; };
 		DCD5FF4326A0D34B009CC666 /* EqualSizes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD5FF4226A0D34B009CC666 /* EqualSizes.swift */; };
 		DCD777D226DE9FE800979A12 /* DelayedSave.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD777D126DE9FE800979A12 /* DelayedSave.swift */; };
 		DCD7E0AC28EC32CB009C30E5 /* BusinessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD7E0AB28EC32CB009C30E5 /* BusinessManager.swift */; };
@@ -469,6 +476,12 @@
 		DC0732EB263CA6C3004CB88D /* PaymentOptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentOptionsView.swift; sourceTree = "<group>"; };
 		DC08A51727FB39530041603B /* AnimatedChevron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedChevron.swift; sourceTree = "<group>"; };
 		DC08A51927FB6C5F0041603B /* TopTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTab.swift; sourceTree = "<group>"; };
+		DC08FC222DA978050003E88C /* CapabilitiesContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapabilitiesContainer.swift; sourceTree = "<group>"; };
+		DC08FC272DA978810003E88C /* Array+Read.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Read.swift"; sourceTree = "<group>"; };
+		DC08FC2A2DA978940003E88C /* CommandAPDU.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandAPDU.swift; sourceTree = "<group>"; };
+		DC08FC2E2DA9796A0003E88C /* HceWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HceWriter.swift; sourceTree = "<group>"; };
+		DC08FC6D2DA9ABE80003E88C /* Ndef.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ndef.swift; sourceTree = "<group>"; };
+		DC08FC722DAEABB00003E88C /* ByteArrayConversions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByteArrayConversions.swift; sourceTree = "<group>"; };
 		DC09085725B5E43900A46136 /* String+VersionComparison.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+VersionComparison.swift"; sourceTree = "<group>"; };
 		DC09086225B626B300A46136 /* AppStatusPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatusPopover.swift; sourceTree = "<group>"; };
 		DC0994AF263A074C003031CA /* InfoGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoGrid.swift; sourceTree = "<group>"; };
@@ -741,6 +754,7 @@
 		DCCFE6C12B7140FA002FFF11 /* LoggerFactory+Foreground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoggerFactory+Foreground.swift"; sourceTree = "<group>"; };
 		DCCFE6C32B714171002FFF11 /* LoggerFactory+Background.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoggerFactory+Background.swift"; sourceTree = "<group>"; };
 		DCD1208628663F4A00EB39C5 /* TransactionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsView.swift; sourceTree = "<group>"; };
+		DCD1BFD52CE775E500C2B811 /* NfcReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NfcReader.swift; sourceTree = "<group>"; };
 		DCD5FF4226A0D34B009CC666 /* EqualSizes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualSizes.swift; sourceTree = "<group>"; };
 		DCD777D126DE9FE800979A12 /* DelayedSave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelayedSave.swift; sourceTree = "<group>"; };
 		DCD7E0AB28EC32CB009C30E5 /* BusinessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessManager.swift; sourceTree = "<group>"; };
@@ -969,6 +983,7 @@
 				53BEF1337AFCFF0AE82A46BD /* utils */,
 				DCACF6EE2566D0A60009B01E /* extensions */,
 				DCA6DEC42829BD060073C658 /* xpc */,
+				DCD1BFD42CE775CE00C2B811 /* nfc */,
 				DCE3C7A92A6AD39E00F4D385 /* mempool */,
 				DCCFE6AC2B6430BD002FFF11 /* logging */,
 			);
@@ -1013,6 +1028,25 @@
 				DCA3B41D2A53434700E6B231 /* danger zone */,
 			);
 			path = configuration;
+			sourceTree = "<group>";
+		};
+		DC08FC6F2DAEAA5E0003E88C /* tools */ = {
+			isa = PBXGroup;
+			children = (
+				DC08FC222DA978050003E88C /* CapabilitiesContainer.swift */,
+				DC08FC2A2DA978940003E88C /* CommandAPDU.swift */,
+				DC08FC6D2DA9ABE80003E88C /* Ndef.swift */,
+			);
+			path = tools;
+			sourceTree = "<group>";
+		};
+		DC08FC712DAEAA790003E88C /* extensions */ = {
+			isa = PBXGroup;
+			children = (
+				DC08FC272DA978810003E88C /* Array+Read.swift */,
+				DC08FC722DAEABB00003E88C /* ByteArrayConversions.swift */,
+			);
+			path = extensions;
 			sourceTree = "<group>";
 		};
 		DC09FC3A2D5AAA9000E6579A /* updates */ = {
@@ -1568,6 +1602,17 @@
 			path = transactions;
 			sourceTree = "<group>";
 		};
+		DCD1BFD42CE775CE00C2B811 /* nfc */ = {
+			isa = PBXGroup;
+			children = (
+				DC08FC712DAEAA790003E88C /* extensions */,
+				DC08FC6F2DAEAA5E0003E88C /* tools */,
+				DC08FC2E2DA9796A0003E88C /* HceWriter.swift */,
+				DCD1BFD52CE775E500C2B811 /* NfcReader.swift */,
+			);
+			path = nfc;
+			sourceTree = "<group>";
+		};
 		DCDD9ECC28637390001800A3 /* main */ = {
 			isa = PBXGroup;
 			children = (
@@ -1971,15 +2016,18 @@
 				DC0E31BB26EFDED4002071C6 /* VSlider.swift in Sources */,
 				DC370A892B7FBD7C0093C56F /* BtcAddrOptionsSheet.swift in Sources */,
 				DC27E4CB2791D17A00C777CC /* RecoveryPhraseView.swift in Sources */,
+				DC08FC732DAEABC20003E88C /* ByteArrayConversions.swift in Sources */,
 				DCB410892902D5BF00CE4FF9 /* PaymentsSection.swift in Sources */,
 				DCA6DED0282AB7E20073C658 /* KeychainConstants.swift in Sources */,
 				DCACF6FC2566D0BA0009B01E /* AppSecurity.swift in Sources */,
+				DC08FC232DA978050003E88C /* CapabilitiesContainer.swift in Sources */,
 				DCCD045D27EE0173007D57A5 /* EditInfoView.swift in Sources */,
 				DC2DC86A2906AC620079E570 /* FiatCurrencySelector.swift in Sources */,
 				DC4CBC9E2D68E6F300129BDB /* DisplayAmounts.swift in Sources */,
 				DC1D2B4B2593EB860036AD38 /* Currency.swift in Sources */,
 				DC118C0827B457520080BBAC /* FetchActivityNotice.swift in Sources */,
 				DCD7E0AC28EC32CB009C30E5 /* BusinessManager.swift in Sources */,
+				DC08FC2F2DA9796A0003E88C /* HceWriter.swift in Sources */,
 				DC4CBC982D68DA1800129BDB /* Details_Outgoing_LiquidityManual.swift in Sources */,
 				DC4CBC882D66416800129BDB /* Details_Incoming_NewChannel.swift in Sources */,
 				DC4864DA29D4E52C00ACD539 /* BgRefreshDisabledPopover.swift in Sources */,
@@ -2096,12 +2144,14 @@
 				DC4CBC922D677D4F00129BDB /* Details_Outgoing_ChannelClose.swift in Sources */,
 				DCE77A5827C671D600F0FA24 /* ElectrumAddressSheet.swift in Sources */,
 				DC384D81265C12B700131772 /* Cache.swift in Sources */,
+				DCD1BFD62CE775E900C2B811 /* NfcReader.swift in Sources */,
 				DC4CF3CC2BE93311003A957F /* String+PIN.swift in Sources */,
 				DCB30E592A0C3F8200E7D7A2 /* LiquidityPolicyView.swift in Sources */,
 				DCEAE5B72943CC7400320C46 /* RangeSheet.swift in Sources */,
 				DCAC5B7027726FC80077BB98 /* DeepLink.swift in Sources */,
 				DC9473FA261270B4008D7242 /* MVI+Mock.swift in Sources */,
 				DCDD9ECE28637474001800A3 /* Orientation.swift in Sources */,
+				DC08FC2B2DA978940003E88C /* CommandAPDU.swift in Sources */,
 				DCCFE6B02B64326F002FFF11 /* OSLogHandler.swift in Sources */,
 				DCDD9ECB28637242001800A3 /* MainView.swift in Sources */,
 				DC9CF8412D2ECF08003F3B0F /* IncomingBalancePopover.swift in Sources */,
@@ -2135,6 +2185,7 @@
 				DCB04685260D162C007FDA37 /* ViewName.swift in Sources */,
 				DC4CF3CE2BE96C36003A957F /* DisablePinView.swift in Sources */,
 				DC4CBC822D6619B700129BDB /* Details_Incoming_Bolt12.swift in Sources */,
+				DC08FC292DA978810003E88C /* Array+Read.swift in Sources */,
 				DCB30E522A0A948000E7D7A2 /* WalletInfoView.swift in Sources */,
 				DCFA876D260E91E600AE8953 /* IntroContainer.swift in Sources */,
 				DCA5391C29F7202F001BD3D5 /* ChannelInfoPopup.swift in Sources */,
@@ -2184,6 +2235,7 @@
 				DCCCEAB528F6DA2A0047871A /* RootView.swift in Sources */,
 				DCDAA7402971C29700B406A8 /* RecentPaymentsSelector.swift in Sources */,
 				DC2ABAD72BED081400C11C9C /* VibrationFeedback.swift in Sources */,
+				DC08FC6E2DA9ABE80003E88C /* Ndef.swift in Sources */,
 				DCD5FF4326A0D34B009CC666 /* EqualSizes.swift in Sources */,
 				DC6F04272C3895E300627B4F /* ContactPhoto.swift in Sources */,
 				DC4CBC9C2D68E65500129BDB /* Details_Outgoing_SpliceCpfp.swift in Sources */,

--- a/phoenix-ios/phoenix-ios/Info.plist
+++ b/phoenix-ios/phoenix-ios/Info.plist
@@ -85,12 +85,16 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED</key>
+	<true/>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NFCReaderUsageDescription</key>
+	<string>The app would like to scan an NFC card.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Phoenix would like to use the camera to scan payment requests.</string>
 	<key>NSFaceIDUsageDescription</key>
@@ -136,7 +140,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED</key>
-	<true/>
 </dict>
 </plist>

--- a/phoenix-ios/phoenix-ios/InfoPlist.xcstrings
+++ b/phoenix-ios/phoenix-ios/InfoPlist.xcstrings
@@ -37,6 +37,18 @@
         }
       }
     },
+    "NFCReaderUsageDescription" : {
+      "comment" : "Privacy - NFC Scan Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The app would like to scan an NFC card."
+          }
+        }
+      }
+    },
     "NSCameraUsageDescription" : {
       "comment" : "Privacy - Camera Usage Description",
       "extractionState" : "extracted_with_value",

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -1018,6 +1018,9 @@
         }
       }
     },
+    "(wait a few seconds and then retry)" : {
+
+    },
     "**disabled**: sent payments will be anonymous" : {
       "localizations" : {
         "ar" : {
@@ -5675,6 +5678,9 @@
           }
         }
       }
+    },
+    "Amount required for card payment" : {
+
     },
     "Amount sent (fees included)" : {
       "localizations" : {
@@ -10603,6 +10609,9 @@
           }
         }
       }
+    },
+    "Communicating with card reader." : {
+
     },
     "completed at" : {
       "comment" : "Label in DetailsView_IncomingPayment",
@@ -16092,6 +16101,9 @@
         }
       }
     },
+    "Ending communication with card reader." : {
+
+    },
     "Enter a valid amount" : {
       "comment" : "error message",
       "localizations" : {
@@ -19645,6 +19657,9 @@
         }
       }
     },
+    "Hold your device near the reader." : {
+
+    },
     "Home screen" : {
       "comment" : "Navigation bar title",
       "localizations" : {
@@ -19725,6 +19740,15 @@
           }
         }
       }
+    },
+    "Host card emulation not available.\nLimited to European Economic Area." : {
+
+    },
+    "Host card emulation not available.\nRequires iOS 17.4 or later." : {
+
+    },
+    "Host card emulation session error\n%@" : {
+
     },
     "Host returned error response." : {
       "localizations" : {
@@ -26970,6 +26994,12 @@
           }
         }
       }
+    },
+    "nfc" : {
+      "comment" : "button label - try to make it short"
+    },
+    "NFC capabilities not available on this device" : {
+
     },
     "No" : {
       "extractionState" : "manual",
@@ -40632,6 +40662,7 @@
       }
     },
     "This appears to be a website (not a lightning invoice):" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -40670,6 +40701,9 @@
           }
         }
       }
+    },
+    "This appears to be a website:" : {
+
     },
     "This doesn't appear to be a Lightning invoice" : {
       "comment" : "Error message - scanning lightning invoice",

--- a/phoenix-ios/phoenix-ios/Localizable.xcstrings
+++ b/phoenix-ios/phoenix-ios/Localizable.xcstrings
@@ -16508,6 +16508,9 @@
         }
       }
     },
+    "Error reading tag" : {
+
+    },
     "Error: %@" : {
       "localizations" : {
         "ar" : {
@@ -26998,7 +27001,13 @@
     "nfc" : {
       "comment" : "button label - try to make it short"
     },
+    "NFC cababilities not available on this device" : {
+
+    },
     "NFC capabilities not available on this device" : {
+
+    },
+    "NFC reader is already scanning" : {
 
     },
     "No" : {
@@ -27564,6 +27573,9 @@
         }
       }
     },
+    "No URI or text detected in NFC tag" : {
+
+    },
     "No, I don't want to use an onion address" : {
       "localizations" : {
         "ar" : {
@@ -27849,6 +27861,9 @@
           }
         }
       }
+    },
+    "Nothing scanned" : {
+
     },
     "Notifications" : {
       "localizations" : {

--- a/phoenix-ios/phoenix-ios/Phoenix.entitlements
+++ b/phoenix-ios/phoenix-ios/Phoenix.entitlements
@@ -12,6 +12,16 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
+	<key>com.apple.developer.nfc.hce</key>
+	<true/>
+	<key>com.apple.developer.nfc.hce.iso7816.select-identifier-prefixes</key>
+	<array>
+		<string>D2760000850101</string>
+	</array>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>TAG</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.co.acinq.phoenix</string>

--- a/phoenix-ios/phoenix-ios/nfc/HceWriter.swift
+++ b/phoenix-ios/phoenix-ios/nfc/HceWriter.swift
@@ -1,0 +1,324 @@
+import Foundation
+import CoreNFC
+
+fileprivate let filename = "HceWriter"
+#if DEBUG
+fileprivate let log = LoggerFactory.shared.logger(filename, .trace)
+#else
+fileprivate var log = LoggerFactory.shared.logger(filename, .warning)
+#endif
+
+/**
+ * The following document is referenced in the comments below:
+ *
+ * > NFC Forum: Type 4 Tag Operation Specification
+ * > Technical Specification
+ * > T4TOP 2.0
+ * > NFCForum-TS-Type-4-Tag_2.0
+ * > 2011-06-28
+ */
+
+enum HceWriterError: Error {
+	case nfcNotAvailable
+	case hceNotAvailable
+	case hceNotEligible
+	case sessionError(HceSessionError, Error)
+}
+
+enum HceSessionError {
+	case acquirePresentmentIntent
+	case initializeSession
+	case startEmulation
+	case eventStream
+}
+
+@available(iOS 17.4, *)
+class HceWriter {
+	
+	static let shared = HceWriter()
+	
+	private enum FileSpecifier: UInt8, CustomStringConvertible {
+		case CC_FILE   = 1
+		case NDEF_FILE = 2
+		
+		var identifier: [UInt8] {
+			switch self {
+				case .CC_FILE   : return [0xE1, 0x03]
+				case .NDEF_FILE : return [0xE1, 0x04]
+			}
+		}
+		
+		public var description: String {
+			switch self {
+				case .CC_FILE   : return "CC File (#1)"
+				case .NDEF_FILE : return "NDEF File (#2)"
+			}
+		}
+	}
+	
+	private struct HceWriterState {
+		let ndefFile: [UInt8]
+		var selectedFile: FileSpecifier?
+	}
+	
+	func start(ndefFile: [UInt8]) async -> HceWriterError? {
+		log.trace("start()")
+		
+		guard NFCReaderSession.readingAvailable else {
+			log.error("NFCReaderSession.readingAvailable is false")
+			return .nfcNotAvailable
+		}
+		
+		guard CardSession.isSupported else {
+			log.error("CardSession.isSupported is false")
+			return .hceNotAvailable
+		}
+			
+		guard await CardSession.isEligible else {
+			log.error("CardSession.isEligible is false")
+			return .hceNotEligible
+		}
+			
+		// Hold a presentment intent assertion reference to prevent the
+		// default contactless app from launching. In a real app, monitor
+		// presentmentIntent.isValid to ensure the assertion remains active.
+		var presentmentIntent: NFCPresentmentIntentAssertion? = nil
+		do {
+			presentmentIntent = try await NFCPresentmentIntentAssertion.acquire()
+		} catch {
+			log.error("Failed to acquire NFCPresentmentIntentAssertion: \(error)")
+			return .sessionError(.acquirePresentmentIntent, error)
+		}
+		
+		defer {
+			log.debug("Releasing presentmentIntent...")
+			withExtendedLifetime(presentmentIntent) {
+				presentmentIntent = nil // Release presentment intent assertion
+			}
+		}
+		
+		let session: CardSession
+		do {
+			session = try await CardSession()
+		} catch {
+			log.error("Failed initialize CardSession: \(error)")
+			return .sessionError(.initializeSession, error)
+		}
+		
+		defer {
+			log.debug("Invalidating CardSession...")
+			session.invalidate()
+		}
+		
+		do {
+			session.alertMessage = String(localized: "Hold your device near the reader.")
+			try await session.startEmulation()
+		} catch {
+			log.error("session.startEmulation: error: \(error)")
+			return .sessionError(.startEmulation, error)
+		}
+		
+		do {
+			var state = HceWriterState(ndefFile: ndefFile, selectedFile: nil)
+			for try await event in session.eventStream {
+				
+				var isDoneProcessingEventStream = false
+				switch event {
+				case .sessionStarted:
+					log.debug("session.event: sessionStarted")
+					break
+					
+				case .readerDetected:
+					log.debug("session.event: readerDetected")
+					session.alertMessage = String(localized: "Communicating with card reader.")
+					
+				case .readerDeselected:
+					log.debug("session.event: readerDeselected")
+					// Stop emulation on first notification of RF link loss.
+					await session.stopEmulation(status: .success)
+					log.debug("session.stopEmulation(): completed")
+					isDoneProcessingEventStream = true
+					break
+					
+				case .received(let cmd):
+					log.debug("session.event: received(cmd)")
+					
+					let response = handleReceivedCommand(cmd, &state)
+					while true {
+						do {
+							// Call handler to process received input and produce a response.
+							try await cmd.respond(response: response.toData())
+							break
+						} catch {
+							var tryAgain = false
+							if let cardError = error as? CardSession.Error {
+								log.error("msg.respond(): error: \(cardError.localizedDescription)")
+								if cardError == .transmissionError {
+									tryAgain = true
+								}
+							}
+							if !tryAgain {
+								break
+							}
+						}
+					} // </while true>
+					
+				case .sessionInvalidated(reason: _):
+					log.debug("session.event: sessionInvalidated")
+					session.alertMessage = String(localized: "Ending communication with card reader.")
+					isDoneProcessingEventStream = true
+					break
+					
+				@unknown default:
+					log.debug("session.event: unknown")
+					break
+					
+				} // </switch event>
+				
+				if isDoneProcessingEventStream {
+					break
+				}
+			} // </for try await event in session.eventStream>
+			
+		} catch {
+			log.error("session.eventStream: error: \(error)")
+			return .sessionError(.eventStream, error)
+		}
+		
+		return nil
+	}
+	
+	private func handleReceivedCommand(
+		_ cmd: CardSession.APDU,
+		_ state: inout HceWriterState
+	) -> [UInt8] {
+		log.trace("handleReceivedCommand()")
+		
+		guard let command = CommandAPDU(cmd: cmd) else {
+			log.debug("RECV: \(cmd.payload.toHex())")
+			log.error("Unable to parse command")
+			return aError()
+		}
+		
+		// Command 1:
+		// - NDEF Tag Application select
+		// - Section 5.4.2
+		//
+		if command.isNdefTagApplicationSelect() {
+			log.debug("RECV: NDEF Tag Select")
+			log.debug("SEND: OK")
+			
+			return aOkay()
+		}
+		
+		// Command 2:
+		// - SelectFile: Capability Container
+		// - Section 5.4.3
+		//
+		// Command 4:
+		// - SelectFile: NDEF File
+		// - Section 5.4.5
+		//
+		if let selectFile = command.asSelectFileCommand() {
+			log.debug("RECV: SelectFile: \(selectFile.fileId.toHex())")
+			
+			if selectFile.fileId == FileSpecifier.CC_FILE.identifier {
+				log.debug("Selecting CC_FILE...")
+				state.selectedFile = .CC_FILE
+				
+				log.debug("SEND: OK")
+				return aOkay()
+				
+			} else if selectFile.fileId == FileSpecifier.NDEF_FILE.identifier {
+				log.debug("Selecting NDEF_FILE...")
+				state.selectedFile = .NDEF_FILE
+				
+				log.debug("SEND: OK")
+				return aOkay()
+				
+			} else {
+				log.debug("Unknown file...")
+				state.selectedFile = nil
+				
+				log.debug("SEND: ERROR")
+				return aError()
+			}
+		}
+		
+		// Command 3:
+		// - ReadBinary data from CC file
+		// - Section 5.4.4
+		//
+		// Command 5:
+		// - ReadBinary data from NDEF file
+		// - Section 5.4.6
+		//
+		if let readBinary = command.asReadBinaryCommand() {
+			log.debug("RECV: ReadBinary: offset(\(readBinary.offset)) length(\(readBinary.length))")
+			
+			if state.selectedFile == .CC_FILE {
+				log.debug("Reading CC_FILE...")
+				
+				let ccFile = CapabilitiesContainer.hce_defaultValue().encode()
+				let prefix: [UInt8] = readFile(ccFile, readBinary)
+				let suffix: [UInt8] = aOkay()
+				
+				let response = prefix + suffix
+				log.debug("SEND: \(response.toHex())")
+				return response
+				
+			} else if state.selectedFile == .NDEF_FILE {
+				log.debug("Reading NDEF_FILE...")
+				
+				let prefix: [UInt8] = readFile(state.ndefFile, readBinary)
+				let suffix: [UInt8] = aOkay()
+				
+				let response = prefix + suffix
+				log.debug("SEND: \(response.toHex())")
+				return response
+				
+			} else {
+				log.debug("No file selected...")
+				log.debug("SEND: aError")
+				
+				return aError()
+			}
+		}
+		
+		log.debug("RECV: \(cmd.payload.toHex())")
+		log.error("Unknown command")
+		return aError()
+	}
+	
+	private func readFile(_ file: [UInt8], _ cmd: ReadBinaryCommand) -> [UInt8] {
+		
+		let startOffset = Int(cmd.offset)
+		if startOffset >= file.count {
+			log.debug("startOffset >= file.count")
+			return []
+		}
+		
+		let endOffset = startOffset + Int(cmd.length)
+		if endOffset < file.count {
+			log.debug("range: \(startOffset)..<\(endOffset)")
+			return Array(file[startOffset..<endOffset])
+		} else {
+			log.debug("range: \(startOffset)..<\(file.count)")
+			return Array(file[startOffset..<file.count])
+		}
+	}
+	
+	private func aOkay() -> [UInt8] {
+		return [
+			0x90, // SW1 - Status word 1
+			0x00  // SW2 - Status word 2
+		]
+	}
+	
+	private func aError() -> [UInt8] {
+		return [
+			0x6A, // SW1 Status byte 1 - Command processing status
+			0x82  // SW2 Status byte 2 - Command processing qualifier
+		]
+	}
+}

--- a/phoenix-ios/phoenix-ios/nfc/NfcReader.swift
+++ b/phoenix-ios/phoenix-ios/nfc/NfcReader.swift
@@ -1,0 +1,154 @@
+import Foundation
+import CoreNFC
+
+fileprivate let filename = "NfcReader"
+#if DEBUG
+fileprivate let log = LoggerFactory.shared.logger(filename, .trace)
+#else
+fileprivate var log = LoggerFactory.shared.logger(filename, .warning)
+#endif
+
+class NfcReader: NSObject, NFCNDEFReaderSessionDelegate {
+	
+	enum ReadError: Error {
+		case readingNotAvailable
+		case alreadyStarted
+		case errorReadingTag
+		case scanningTerminated(NFCReaderError)
+	}
+	
+	static let shared = NfcReader()
+	
+	private let queue: DispatchQueue
+	
+	private var session: NFCNDEFReaderSession? = nil
+	private var callback: ((Result<NFCNDEFMessage, ReadError>) -> Void)? = nil
+	
+	override init() {
+		queue = DispatchQueue(label: "NfcReader")
+	}
+	
+	func readCard(_ callback: @escaping (Result<NFCNDEFMessage, ReadError>) -> Void) {
+		log.trace("readCard()")
+		
+		let fail = { (error: ReadError) in
+			DispatchQueue.main.async {
+				callback(Result.failure(error))
+			}
+		}
+		
+		queue.async { [self] in
+			
+			guard NFCReaderSession.readingAvailable else {
+				log.error("NFCReaderSession.readingAvailable is false")
+				return fail(.readingNotAvailable)
+			}
+			
+			guard session == nil else {
+				log.error("session is already started")
+				return fail(.alreadyStarted)
+			}
+			
+			session = NFCNDEFReaderSession(delegate: self, queue: queue, invalidateAfterFirstRead: true)
+			session?.alertMessage = "Hold your card near the device to read it."
+			
+			self.callback = callback
+			session?.begin()
+			
+			log.info("session is ready")
+		}
+	}
+	
+	// --------------------------------------------------
+	// MARK: Private
+	// --------------------------------------------------
+	
+	private func finishWithSuccess(_ message: NFCNDEFMessage) {
+		
+		guard let session, let callback else {
+			return
+		}
+		log.trace("finishWithSuccess()")
+		
+		session.invalidate()
+		self.session = nil
+		self.callback = nil
+		DispatchQueue.main.async {
+			callback(.success(message))
+		}
+	}
+	
+	private func finishWithError(_ error: ReadError) {
+		
+		guard let session, let callback else {
+			return
+		}
+		log.trace("finishWithError()")
+		
+		session.invalidate()
+		self.session = nil
+		self.callback = nil
+		
+		DispatchQueue.main.async {
+			callback(.failure(error))
+		}
+	}
+	
+	// --------------------------------------------------
+	// MARK: NFCNDEFReaderSessionDelegate
+	// --------------------------------------------------
+	
+	func readerSessionDidBecomeActive(_ session: NFCNDEFReaderSession) {
+		log.trace("readerSessionDidBecomeActive(_)")
+	}
+	
+	func readerSession(_ session: NFCNDEFReaderSession, didInvalidateWithError error: any Error) {
+		log.trace("readerSession(_, didInvalidateWithError:)")
+		log.trace("error: \(error)")
+		
+		let nfcError = (error as? NFCReaderError) ??                                   // this is always the case
+			NFCReaderError(NFCReaderError.readerSessionInvalidationErrorSessionTimeout) // but just to be safe
+		
+		if let _ = error as? NFCReaderError {
+			log.debug("is NFCReaderError")
+		} else {
+			log.debug("!is NFCReaderError")
+		}
+		finishWithError(.scanningTerminated(nfcError))
+	}
+	
+	func readerSession(_ session: NFCNDEFReaderSession, didDetectNDEFs messages: [NFCNDEFMessage]) {
+		log.trace("readerSession(_, didDetectNDEFs:)")
+		log.trace("messages.count = \(messages.count)")
+		
+		if messages.count > 1 {
+			log.warning("NfcReader: Multiple messages detected: this is unsupported, only the first will be read")
+		}
+		
+		if let message = messages.first {
+			finishWithSuccess(message)
+		}
+	}
+	
+	func readerSession(_ session: NFCNDEFReaderSession, didDetect tags: [any NFCNDEFTag]) {
+		log.trace("readerSession(_, didDetectTags:)")
+		log.trace("messages.count = \(tags.count)")
+		
+		if tags.count > 1 {
+			log.warning("NfcReader: Multiple tags detected: this is unsupported, only the first will be read")
+		}
+		
+		if let tag = tags.first {
+			tag.readNDEF { [self] (result, error) in
+				
+				if let result {
+					finishWithSuccess(result)
+					
+				} else if let error {
+					log.error("readNDEF: error = \(error)")
+					finishWithError(.errorReadingTag)
+				}
+			}
+		}
+	}
+}

--- a/phoenix-ios/phoenix-ios/nfc/extensions/Array+Read.swift
+++ b/phoenix-ios/phoenix-ios/nfc/extensions/Array+Read.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+extension Array where Element == UInt8 {
+	
+	func readLittleEndian<T: FixedWidthInteger>(
+		offset: Int,
+		as: T.Type
+	) -> T {
+		
+		assert(offset + MemoryLayout<T>.size <= self.count)
+		
+		// Prepare a region aligned for `T`
+		var value: T = 0
+		// Copy the misaligned bytes at `offset` to aligned region `value`
+		_ = Swift.withUnsafeMutableBytes(of: &value) {valueBP in
+			self.withUnsafeBytes { bufPtr in
+				let range = offset..<offset+MemoryLayout<T>.size
+				bufPtr.copyBytes(to: valueBP, from: range)
+			}
+		}
+		
+		return T(littleEndian: value)
+	}
+	
+	func readBigEndian<T: FixedWidthInteger>(
+		offset: Int,
+		as: T.Type
+	) -> T {
+		
+		assert(offset + MemoryLayout<T>.size <= self.count)
+		
+		// Prepare a region aligned for `T`
+		var value: T = 0
+		// Copy the misaligned bytes at `offset` to aligned region `value`
+		_ = Swift.withUnsafeMutableBytes(of: &value) {valueBP in
+			self.withUnsafeBytes { bufPtr in
+				let range = offset..<offset+MemoryLayout<T>.size
+				bufPtr.copyBytes(to: valueBP, from: range)
+			}
+		}
+		
+		return T(bigEndian: value)
+	}
+}

--- a/phoenix-ios/phoenix-ios/nfc/extensions/ByteArrayConversions.swift
+++ b/phoenix-ios/phoenix-ios/nfc/extensions/ByteArrayConversions.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+extension Array where Element == UInt8 {
+	
+	func toData() -> Data {
+		return Data(bytes: self, count: self.count)
+	}
+}
+
+extension Data {
+	
+	func toByteArray() -> [UInt8] {
+		var buffer = [UInt8]()
+		self.withUnsafeBytes {
+			buffer.append(contentsOf: $0)
+		}
+		return buffer
+	}
+}
+
+extension FixedWidthInteger {
+	
+	func toByteArray() -> [UInt8] {
+		withUnsafeBytes(of: self, Array.init)
+	}
+}

--- a/phoenix-ios/phoenix-ios/nfc/tools/CapabilitiesContainer.swift
+++ b/phoenix-ios/phoenix-ios/nfc/tools/CapabilitiesContainer.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+struct CapabilitiesContainer {
+	
+	static let minByteCount: Int = 7
+	
+	/// Capabilities container length
+	/// Indicates the size of this capability container (including this field).
+	/// Valid values are: 000Fh-FFFEh (15-65534)
+	///
+	var len: UInt16
+	
+	/// Mapping version
+	/// Indicates the mapping specification version the tag is compliant with.
+	/// The most significant nibble (4 most significant bits) indicate the major version number.
+	/// The least significant nibble (4 least significant bits) indicate the minor version number.
+	///
+	var version: UInt8
+	
+	/// Maximum R-APDU data size
+	/// Defines the maximum data size that can be read from
+	/// the tag using a single ReadBinary command.
+	/// Valid values are: 000Fh-FFFFh (15-65535)
+	///
+	var mLe: UInt16
+	
+	/// Maximum C-APDU data size
+	/// Defines the maximum data size that can be sent to
+	/// the tag using a single UpdateBinary command.
+	/// Valid values are: 0001h-FFFFh (1-65535)
+	///
+	var mLc: UInt16
+	
+	/// NDEF files
+	/// TLV blocks that contain information to control and manage each available NDEF file.
+	///
+	var files: [CtrlTLV]
+	
+	init(len: UInt16, version: UInt8, mLe: UInt16, mLc: UInt16, files: [CtrlTLV]) {
+		self.len = len
+		self.version = version
+		self.mLe = mLe
+		self.mLc = mLc
+		self.files = files
+	}
+	
+	init?(data: [UInt8]) {
+		
+		guard data.count >= CapabilitiesContainer.minByteCount else { return nil }
+		
+		len = data.readBigEndian(offset: 0, as: UInt16.self)
+		version = data[2]
+		mLe = data.readBigEndian(offset: 3, as: UInt16.self)
+		mLc = data.readBigEndian(offset: 5, as: UInt16.self)
+		
+		var fileList: [CtrlTLV] = []
+		var start = 7
+		var end = start + CtrlTLV.byteCount
+		while (data.count >= end) {
+			guard let file = CtrlTLV(data: Array<UInt8>(data[start..<end])) else {
+				return nil
+			}
+			fileList.append(file)
+			start = end
+			end = start + CtrlTLV.byteCount
+		}
+		
+		files = fileList
+	}
+	
+	func encode() -> [UInt8] {
+		
+		var buffer: [UInt8] = Array<UInt8>()
+		buffer.reserveCapacity(CapabilitiesContainer.minByteCount + (CtrlTLV.byteCount * files.count))
+		
+		buffer.append(contentsOf: len.bigEndian.toByteArray())
+		buffer.append(version)
+		buffer.append(contentsOf: mLe.bigEndian.toByteArray())
+		buffer.append(contentsOf: mLc.bigEndian.toByteArray())
+		
+		files.forEach { file in
+			buffer.append(contentsOf: file.encode())
+		}
+		
+		return buffer
+	}
+	
+	static func ntag424Dna_defaultValue() -> CapabilitiesContainer {
+		
+		let file2 = CtrlTLV.ntag424Dna_defaultFile2()
+		let file3 = CtrlTLV.ntag424Dna_defaultFile3()
+		
+		return CapabilitiesContainer(
+			len: 23,
+			version: 0x20,
+			mLe: 256,
+			mLc: 255,
+			files: [file2, file3]
+		)
+	}
+	
+	static func hce_defaultValue() -> CapabilitiesContainer {
+		
+		let file2 = CtrlTLV.hce_defaultFile2()
+		
+		return CapabilitiesContainer(
+			len: 15,
+			version: 0x20,
+			mLe: 256,
+			mLc: 255,
+			files: [file2]
+		)
+	}
+}
+
+struct CtrlTLV {
+	
+	static let byteCount = 8
+	
+	/// Type of TLV block
+	/// Valid values are:
+	/// - 4: NDEF File Control TLV
+	/// - 5: Proprietary File Control TLV
+	///
+	var t: UInt8
+	
+	/// Size in bytes of the value field.
+	/// Must be 6 for this implementation.
+	///
+	let l: UInt8
+	
+	/// File Identifier
+	/// The valid ranges are:
+	/// - 0001h - E101h
+	/// - E104h - 3EFFh
+	/// - 3F01h - 3FFEh
+	/// - 4000h - FFFEh
+	/// Other ranges are reserved for future use.
+	///
+	let fileId: [UInt8]
+	
+	/// Maximum file size (i.e. max storage capacity).
+	///
+	let fileSize: UInt16
+	
+	/// NDEF file read access condition:
+	/// - 00h: indicates read access granted without any security
+	/// - 80h-FEh: proprietary (card-specific protocol)
+	///
+	var readAccess: UInt8
+	
+	/// NDEF file write access condition:
+	/// - 00h: indicates write access granted without any security
+	/// - FFh: indicates no write access granted at all (read-only)
+	/// - 80h-FEh: proprietary (card-specific protocol)
+	///
+	var writeAccess: UInt8
+	
+	init(t: UInt8, l: UInt8, fileId: [UInt8], fileSize: UInt16, readAccess: UInt8, writeAccess: UInt8) {
+		self.t = t
+		self.l = l
+		self.fileId = fileId
+		self.fileSize = fileSize
+		self.readAccess = readAccess
+		self.writeAccess = writeAccess
+	}
+	
+	init?(data: [UInt8]) {
+		
+		guard data.count >= CtrlTLV.byteCount else { return nil }
+		
+		t = data[0]
+		l = data[1]
+		fileId = Array<UInt8>(data[2...3])
+		fileSize = data.readBigEndian(offset: 4, as: UInt16.self)
+		readAccess = data[6]
+		writeAccess = data[7]
+	}
+	
+	func encode() -> [UInt8] {
+		
+		var buffer: [UInt8] = Array<UInt8>()
+		buffer.reserveCapacity(CtrlTLV.byteCount)
+		
+		buffer.append(t)
+		buffer.append(l)
+		buffer.append(contentsOf: fileId)
+		buffer.append(contentsOf: fileSize.bigEndian.toByteArray())
+		buffer.append(readAccess)
+		buffer.append(writeAccess)
+		
+		return buffer
+	}
+	
+	static func ntag424Dna_defaultFile2() -> CtrlTLV {
+		return CtrlTLV(
+			t: 4,
+			l: 6,
+			fileId: [0xe1, 0x04],
+			fileSize: 256,
+			readAccess: 0x00,
+			writeAccess: 0x00
+		)
+	}
+	
+	static func ntag424Dna_defaultFile3() -> CtrlTLV {
+		return CtrlTLV(
+			t: 5,
+			l: 6,
+			fileId: [0xe1, 0x05],
+			fileSize: 128,
+			readAccess: 0x82,
+			writeAccess: 0x83
+		)
+	}
+	
+	static func hce_defaultFile2() -> CtrlTLV {
+		return CtrlTLV(
+			t: 4,
+			l: 6,
+			fileId: [0xe1, 0x04],
+			fileSize: 512,
+			readAccess: 0x00,
+			writeAccess: 0xFF
+		)
+	}
+}

--- a/phoenix-ios/phoenix-ios/nfc/tools/CommandAPDU.swift
+++ b/phoenix-ios/phoenix-ios/nfc/tools/CommandAPDU.swift
@@ -1,0 +1,172 @@
+import Foundation
+import CoreNFC
+
+/// Parser for Command APDU (C-APDU)
+/// Section 4.2.1
+///
+struct CommandAPDU: CustomStringConvertible {
+	
+	let raw: [UInt8]
+	
+	/// Class
+	var cla : UInt8 { return raw[0] }
+	
+	/// Instruction code
+	var ins : UInt8 { return raw[1] }
+	
+	/// Parameter 1
+	var p1  : UInt8 { return raw[2] }
+	
+	/// Parameter 2
+	var p2  : UInt8 { return raw[3] }
+	
+	/// Length command (length of data in command)
+	var lc: UInt8? {
+		return (raw.count >= 6) ? raw[4] : nil
+	}
+	
+	/// Data of command
+	var data: [UInt8]? {
+		if let dataCount = lc {
+			let dataEnd = 5 + Int(dataCount)
+			return [UInt8](raw[5..<dataEnd])
+		} else {
+			return nil
+		}
+	}
+	
+	/// Length expected (num bytes expected in the data field of response)
+	var le: UInt8? {
+		if let dataCount = lc {
+			let offset = 5 + Int(dataCount)
+			return (raw.count >= offset) ? raw[offset] : nil
+		} else if raw.count >= 5 {
+			return raw[4]
+		} else {
+			return nil
+		}
+	}
+	
+	@available(iOS 17.4, *)
+	init?(cmd: CardSession.APDU) {
+		
+		let bytes = cmd.payload.toByteArray()
+		
+		// 4 bytes are required minimum (CLA, INS, P1 & P2)
+		guard bytes.count >= 4 else { return nil }
+		
+		if bytes.count >= 5 {
+			// bytes[4] could be either Lc or Le field
+			
+			if bytes.count >= 6 {
+				// Lc field is present, which means:
+				// - data field must be present with length Lc
+				let dataLength = bytes[4]
+				let minLength = 5 + Int(dataLength)
+				guard bytes.count >= minLength else { return nil }
+			} else {
+				// bytes[4] => Le field
+			}
+		}
+		
+		self.raw = bytes
+	}
+	
+	var description: String {
+		
+		var desc = "CommandAPDU: "
+		desc += "cla(\(String(format: "%02hhx", cla))) "
+		desc += "ins(\(String(format: "%02hhx", ins))) "
+		desc += "p1(\(String(format: "%02hhx", p1))) "
+		desc += "p2(\(String(format: "%02hhx", p2)))"
+		
+		if let lc {
+			desc += " lc(\(String(format: "%hhx", lc))"
+		}
+		if let data {
+			desc += "\n - data: \(data.toHex(options: .lowerCase))"
+		}
+		if let le {
+			desc += "\n - le(\(String(format: "%02hhx", le)))"
+		}
+		
+		return desc
+	}
+	
+	/// Section 5.4.2 - NDEF Tag Application Select Procedure
+	///
+	func isNdefTagApplicationSelect() -> Bool {
+		let expectedPrefix: [UInt8] = [
+			0x00, // CLA
+			0xA4, // INS
+			0x04, // P1  - Select by name
+			0x00, // P2  - First or only occurrence
+			0x07, // Lc
+			0xD2, 0x76, 0x00, 0x00, 0x85, 0x01, 0x01
+		]
+		// I believe the `Le` field is optional
+		
+		return raw.starts(with: expectedPrefix)
+	}
+	
+	/// Section 5.4.3 - Capability Container Select Procedure
+	///
+	func isCapabilityContainerSelect() -> Bool {
+		let expectedPrefix: [UInt8] = [
+			0x00, // CLA
+			0xA4, // INS
+			0x00, // P1  - Select by elementary file (EF)
+			0x0c, // P2  - select by elementary file (EF)
+			0x02, // Lc
+			0xe1, 0x03 // File identifier (EF) of the capability container
+		]
+		// I believe the `Le` field is optional
+		
+		return raw.starts(with: expectedPrefix)
+	}
+	
+	func asSelectFileCommand() -> SelectFileCommand? {
+		// I think there's a typo in the docs.
+		// - Table 13: p2 == 0x0C
+		// - Table 14: p2 == 0x0C
+		// - Table 19: p2 == 0x0C
+		// - Table 20: p2 == 0x00 < !!!
+		//
+		// I'm not entirely sure it matters though.
+		// But for now, I ensure that it's one of the two values.
+		
+		if cla == 0x00,
+		   ins == 0xA4,
+			p1 == 0x00, // Select by elementary file (EF)
+			(p2 == 0x00 || p2 == 0x0C), // See note above
+			lc == 0x02,
+			let fileId = data
+		{
+			return SelectFileCommand(fileId: fileId)
+		} else {
+			return nil
+		}
+	}
+	
+	func asReadBinaryCommand() -> ReadBinaryCommand? {
+		if cla == 0x00,
+		   ins == 0xb0,
+		   let length = le,
+			length > 0
+		{
+			let offset = raw.readBigEndian(offset: 2, as: UInt16.self) // big endian ???
+			return ReadBinaryCommand(offset: offset, length: length)
+		} else {
+			return nil
+		}
+	}
+}
+
+struct SelectFileCommand {
+	let fileId: [UInt8]
+}
+
+struct ReadBinaryCommand {
+	let offset: UInt16
+	let length: UInt8
+}

--- a/phoenix-ios/phoenix-ios/nfc/tools/Ndef.swift
+++ b/phoenix-ios/phoenix-ios/nfc/tools/Ndef.swift
@@ -14,7 +14,7 @@ struct NdefHeaderFlags: OptionSet {
 	/// IL (ID Length) is present
 	static let IL = NdefHeaderFlags(rawValue: 0b00001000)
 	
-	
+	/// Type Name Format options:
 	static let TNF_WELL_KNOWN   = NdefHeaderFlags(rawValue: 0b00000001) // 0x01
 	static let TNF_MIME         = NdefHeaderFlags(rawValue: 0b00000010) // 0x02
 	/// Note: don't use this for URLS, use WELLKNOWN instead.
@@ -53,18 +53,6 @@ public class Ndef {
 			0x00, // Placeholder for NLEN
 		]
 		
-		// NDEF Message header:
-		
-		let flags: NdefHeaderFlags = [.MB, .ME, .SR, .TNF_WELL_KNOWN]
-		let type = NdefHeaderType.URL
-		
-		var messageHeader: [UInt8] = [
-			flags.rawValue, // NDEF header flags
-			0x01,           // Type length
-			0x00,           // URL length placeholder
-			type.rawValue   // Well-known type: URL
-		]
-		
 		// Header for: Well-known-type(URL)
 		//
 		// Note: If you have a long URL that doesn't fit, you can change the typeHeader here.
@@ -78,14 +66,49 @@ public class Ndef {
 		let urlData = url.absoluteString.data(using: .utf8) ?? Data()
 		var urlBytes =  urlData.toByteArray()
 		
-		let maxFileSize = 256 // As per NTAG 424 spcification for File #2
-		let maxUrlSize = maxFileSize - (fileHeader.count + messageHeader.count + typeHeader.count)
-		if urlBytes.count > maxUrlSize {
-			urlBytes = Array(urlBytes[0..<maxUrlSize])
+		// NDEF Message header:
+		
+		let messageHeader: [UInt8]
+		
+		let fitsInShortRecord = (typeHeader.count + urlBytes.count) <= 255
+		if fitsInShortRecord {
+			
+			let payloadLength = UInt8(typeHeader.count + urlBytes.count)
+			
+			let flags: NdefHeaderFlags = [.MB, .ME, .SR, .TNF_WELL_KNOWN]
+			let type = NdefHeaderType.URL
+			
+			messageHeader = [
+				flags.rawValue, // NDEF header flags
+				0x01,           // Type length
+				payloadLength,  // Payload length (SR = 1 byte)
+				type.rawValue   // Well-known type: URL
+			]
+			
+		} else {
+			
+			let payloadLengthLE = UInt32(typeHeader.count + urlBytes.count)
+			let payloadLength: [UInt8] = payloadLengthLE.bigEndian.toByteArray()
+			
+			let flags: NdefHeaderFlags = [.MB, .ME, .TNF_WELL_KNOWN]
+			let type = NdefHeaderType.URL
+			
+			messageHeader = [
+				flags.rawValue,   // NDEF header flags
+				0x01,             // Type length
+				payloadLength[0], // Payload length (!SR = 4 bytes)
+				payloadLength[1], // Payload length
+				payloadLength[2], // Payload length
+				payloadLength[3], // Payload length
+				type.rawValue     // Well-known type: URL
+			]
 		}
 		
-		fileHeader[1] = UInt8(messageHeader.count + typeHeader.count + urlBytes.count)
-		messageHeader[2] = UInt8(typeHeader.count + urlBytes.count)
+		let fileLengthLE = UInt16(messageHeader.count + typeHeader.count + urlBytes.count)
+		let fileLength: [UInt8] = fileLengthLE.bigEndian.toByteArray()
+		
+		fileHeader[0] = fileLength[0]
+		fileHeader[1] = fileLength[1]
 		
 		let result: [UInt8] = fileHeader + messageHeader + typeHeader + urlBytes
 		return result
@@ -107,18 +130,6 @@ public class Ndef {
 		var fileHeader: [UInt8] = [
 			0x00, // Placeholder for NLEN
 			0x00  // Placeholder for NLEN
-		]
-		
-		// NDEF Message header:
-		
-		let flags: NdefHeaderFlags = [.MB, .ME, .SR, .TNF_WELL_KNOWN]
-		let type = NdefHeaderType.TEXT
-		
-		var messageHeader: [UInt8] = [
-			flags.rawValue, // NDEF header flags
-			0x01,           // Type length
-			0x00,           // Text length placeholder
-			type.rawValue   // Well-known type: TEXT
 		]
 		
 		// Header for: Well-known-type(TEXT)
@@ -151,117 +162,51 @@ public class Ndef {
 		let textData = text.data(using: .utf8) ?? Data()
 		var textBytes = textData.toByteArray()
 		
-		let maxFileSize = 256 // As per NTAG 424 spcification for File #2
-		let maxTextSize = maxFileSize - (fileHeader.count + messageHeader.count + typeHeader.count)
-		if textBytes.count > maxTextSize {
-			textBytes = Array(textBytes[0..<maxTextSize])
+		// NDEF Message header:
+		
+		let messageHeader: [UInt8]
+		
+		let fitsInShortRecord = (typeHeader.count + textBytes.count) <= 255
+		if fitsInShortRecord {
+			
+			let payloadLength = UInt8(typeHeader.count + textBytes.count)
+			
+			let flags: NdefHeaderFlags = [.MB, .ME, .SR, .TNF_WELL_KNOWN]
+			let type = NdefHeaderType.TEXT
+			
+			messageHeader = [
+				flags.rawValue, // NDEF header flags
+				0x01,           // Type length
+				payloadLength,  // Payload length (SR = 1 byte)
+				type.rawValue   // Well-known type: TEXT
+			]
+			
+		} else {
+			
+			let payloadLengthLE = UInt32(typeHeader.count + textBytes.count)
+			let payloadLength: [UInt8] = payloadLengthLE.bigEndian.toByteArray()
+			
+			let flags: NdefHeaderFlags = [.MB, .ME, .TNF_WELL_KNOWN]
+			let type = NdefHeaderType.URL
+			
+			messageHeader = [
+				flags.rawValue,   // NDEF header flags
+				0x01,             // Type length
+				payloadLength[0], // Payload length (!SR = 4 bytes)
+				payloadLength[1], // Payload length
+				payloadLength[2], // Payload length
+				payloadLength[3], // Payload length
+				type.rawValue     // Well-known type: URL
+			]
 		}
 		
-		fileHeader[1] = UInt8(messageHeader.count + typeHeader.count + textBytes.count)
-		messageHeader[2] = UInt8(typeHeader.count + textBytes.count)
+		let fileLengthLE = UInt16(messageHeader.count + typeHeader.count + textBytes.count)
+		let fileLength: [UInt8] = fileLengthLE.bigEndian.toByteArray()
+		
+		fileHeader[0] = fileLength[0]
+		fileHeader[1] = fileLength[1]
 		
 		let result: [UInt8] = fileHeader + messageHeader + typeHeader + textBytes
 		return result
 	}
-	
-	class func ndefDataForTemplate(_ template: Template) -> [UInt8] {
-		
-		switch template.value {
-		case .Left(let url):
-			return ndefDataForUrl(url)
-		case .Right(let text):
-			return ndefDataForText(text)
-		}
-	}
-	
-	struct Template {
-		let value: Either<URL, String>
-		let piccDataOffset: Int
-		let cmacOffset: Int
-		
-		var valueString: String {
-			switch value {
-			case .Left(let url):
-				return url.absoluteString
-			case .Right(let text):
-				return text
-			}
-		}
-		
-		init?(baseUrl: URL) {
-			
-			guard var comps = URLComponents(url: baseUrl, resolvingAgainstBaseURL: false) else {
-				return nil
-			}
-			
-			var queryItems = comps.queryItems ?? []
-			
-			// The `baseUrl` SHOULD NOT have either `picc_data` or `cmac` parameters.
-			// But just to be safe, we'll remove them if they're present.
-			//
-			queryItems.removeAll(where: { item in
-				let name = item.name.lowercased()
-				return name == "picc_data" || name == "cmac"
-			})
-			
-			// picc_data=(16_bytes_hexadecimal)
-			// cmac=(8_bytes_hexadecimal)
-			
-			queryItems.append(URLQueryItem(name: "picc_data", value: "00000000000000000000000000000000"))
-			queryItems.append(URLQueryItem(name: "cmac",      value: "0000000000000000"))
-			
-			comps.queryItems = queryItems
-			
-			guard let resolvedUrl = comps.url else {
-				return nil
-			}
-			
-			let urlString = resolvedUrl.absoluteString
-			
-			// Ultimately, the URL gets encoded as UTF-8,
-			// and the offsets are used as indexes within this UTF-8 representation.
-			//
-			// So we need to do our calculations within the string's utf8View.
-			
-			let urlUtf8 = urlString.utf8
-			
-			guard let range1 = urlUtf8.ranges(of: "picc_data=".utf8).last else {
-				return nil
-			}
-			let offset1 = urlUtf8.distance(from: urlUtf8.startIndex, to: range1.upperBound)
-			
-			guard let range2 = urlUtf8.ranges(of: "cmac=".utf8).last else {
-				return nil
-			}
-			let offset2 = urlUtf8.distance(from: urlUtf8.startIndex, to: range2.upperBound)
-			
-			self.value = Either.Left(resolvedUrl)
-			self.piccDataOffset = offset1 + Ndef.URL_HEADER_SIZE
-			self.cmacOffset = offset2 + Ndef.URL_HEADER_SIZE
-		}
-		
-		init(baseText: String) {
-			
-			// picc_data=(16_bytes_hexadecimal)
-			// cmac=(8_bytes_hexadecimal)
-			
-			let fullText = "\(baseText)?picc_data=00000000000000000000000000000000&cmac=0000000000000000"
-			//                         +123456789 123456789 123456789 123456789 123456789
-			//                                    ^+11                                  ^+49
-			
-			// Ultimately, the value gets encoded as UTF-8,
-			// and the offsets are used as indexes within this UTF-8 representation.
-			//
-			// So we need to do our calculations within the string's utf8View.
-			
-			let baseTextLength = baseText.utf8.count
-			let offset1 = baseTextLength + 11
-			let offset2 = baseTextLength + 49
-			
-			self.value = Either.Right(fullText)
-			self.piccDataOffset = offset1 + Ndef.TEXT_HEADER_SIZE
-			self.cmacOffset = offset2 + Ndef.TEXT_HEADER_SIZE
-		}
-		
-	} // </struct Template>
 }

--- a/phoenix-ios/phoenix-ios/nfc/tools/Ndef.swift
+++ b/phoenix-ios/phoenix-ios/nfc/tools/Ndef.swift
@@ -1,0 +1,267 @@
+import Foundation
+
+struct NdefHeaderFlags: OptionSet {
+	let rawValue: UInt8
+	
+	/// Message begin flag
+	static let MB = NdefHeaderFlags(rawValue: 0b10000000)
+	/// Message end flag
+	static let ME = NdefHeaderFlags(rawValue: 0b01000000)
+	/// Chunked flag
+	static let CF = NdefHeaderFlags(rawValue: 0b00100000)
+	/// Short record flag
+	static let SR = NdefHeaderFlags(rawValue: 0b00010000)
+	/// IL (ID Length) is present
+	static let IL = NdefHeaderFlags(rawValue: 0b00001000)
+	
+	
+	static let TNF_WELL_KNOWN   = NdefHeaderFlags(rawValue: 0b00000001) // 0x01
+	static let TNF_MIME         = NdefHeaderFlags(rawValue: 0b00000010) // 0x02
+	/// Note: don't use this for URLS, use WELLKNOWN instead.
+	static let TNF_ABSOLUTE_URI = NdefHeaderFlags(rawValue: 0b00000011) // 0x03
+	static let TNF_EXTERNAL     = NdefHeaderFlags(rawValue: 0b00000100) // 0x04
+	static let TNF_UNKNOWN      = NdefHeaderFlags(rawValue: 0b00000101) // 0x05
+	static let TNF_UNCHANGED    = NdefHeaderFlags(rawValue: 0b00000110) // 0x06
+	static let TNF_RESERVED     = NdefHeaderFlags(rawValue: 0b00000111) // 0x07
+}
+
+enum NdefHeaderType: UInt8 {
+	case TEXT = 0x54 // 'T'.ascii
+	case URL  = 0x55 // 'U'.ascii
+}
+
+public class Ndef {
+	
+	static let URL_HEADER_SIZE = 7
+	static let TEXT_HEADER_SIZE = 9
+	
+	class func ndefDataForUrl(_ url: URL) -> [UInt8] {
+		
+		// See pgs. 30-31 of AN12196
+		
+		// NDEF File Format:
+		//
+		// Field        | Length     | Description
+		// ---------------------------------------------------------------
+		// NLEN         | 2 bytes    | Length of the NDEF message in big-endian format.
+		// NDEF Message | NLEN bytes | NDEF message. See NFC Data Exchange Format (NDEF).
+		//
+		// https://docs.nordicsemi.com/bundle/ncs-latest/page/nrfxlib/nfc/doc/type_4_tag.html#t4t-format
+		//
+		var fileHeader: [UInt8] = [
+			0x00, // Placeholder for NLEN
+			0x00, // Placeholder for NLEN
+		]
+		
+		// NDEF Message header:
+		
+		let flags: NdefHeaderFlags = [.MB, .ME, .SR, .TNF_WELL_KNOWN]
+		let type = NdefHeaderType.URL
+		
+		var messageHeader: [UInt8] = [
+			flags.rawValue, // NDEF header flags
+			0x01,           // Type length
+			0x00,           // URL length placeholder
+			type.rawValue   // Well-known type: URL
+		]
+		
+		// Header for: Well-known-type(URL)
+		//
+		// Note: If you have a long URL that doesn't fit, you can change the typeHeader here.
+		// For example, if you specify 0x02 for the typeHeader, it means:
+		// - prepend `https://www.` to the URL content, saving a few bytes.
+		//
+		let typeHeader: [UInt8] = [
+			0x00 // Just the URI (no prepended protocol)
+		]
+		
+		let urlData = url.absoluteString.data(using: .utf8) ?? Data()
+		var urlBytes =  urlData.toByteArray()
+		
+		let maxFileSize = 256 // As per NTAG 424 spcification for File #2
+		let maxUrlSize = maxFileSize - (fileHeader.count + messageHeader.count + typeHeader.count)
+		if urlBytes.count > maxUrlSize {
+			urlBytes = Array(urlBytes[0..<maxUrlSize])
+		}
+		
+		fileHeader[1] = UInt8(messageHeader.count + typeHeader.count + urlBytes.count)
+		messageHeader[2] = UInt8(typeHeader.count + urlBytes.count)
+		
+		let result: [UInt8] = fileHeader + messageHeader + typeHeader + urlBytes
+		return result
+	}
+	
+	class func ndefDataForText(_ text: String) -> [UInt8] {
+		
+		// See pgs. 30-31 of AN12196
+		
+		// NDEF File Format:
+		//
+		// Field        | Length     | Description
+		// ---------------------------------------------------------------
+		// NLEN         | 2 bytes    | Length of the NDEF message in big-endian format.
+		// NDEF Message | NLEN bytes | NDEF message. See NFC Data Exchange Format (NDEF).
+		//
+		// https://docs.nordicsemi.com/bundle/ncs-latest/page/nrfxlib/nfc/doc/type_4_tag.html#t4t-format
+		//
+		var fileHeader: [UInt8] = [
+			0x00, // Placeholder for NLEN
+			0x00  // Placeholder for NLEN
+		]
+		
+		// NDEF Message header:
+		
+		let flags: NdefHeaderFlags = [.MB, .ME, .SR, .TNF_WELL_KNOWN]
+		let type = NdefHeaderType.TEXT
+		
+		var messageHeader: [UInt8] = [
+			flags.rawValue, // NDEF header flags
+			0x01,           // Type length
+			0x00,           // Text length placeholder
+			type.rawValue   // Well-known type: TEXT
+		]
+		
+		// Header for: Well-known-type(TEXT)
+		//
+		// RTD TEXT specification:
+		//
+		// Byte 0 bit pattern:
+		//
+		// |     7    |    6     |   5, 4, 3, 2, 1, 0   |
+		// ----------------------------------------------
+		// | UTF 8/16 | Reserved | Language code length |
+		//
+		// UTF-8  => 0
+		// UTF-16 => 1
+		//
+		// Reserved => must be 0
+		//
+		// Language code should use ISO/IANA language code.
+		// We will use "en" - although for our use case it will be ignored.
+		//
+		// Thus our bit pattern is:
+		// 0b00000010 = 0x02
+		//
+		let typeHeader: [UInt8] = [
+			0x02, // UTF-8; langCode.length = 2
+			0x65, // 'e'
+			0x6e  // 'n'
+		]
+		
+		let textData = text.data(using: .utf8) ?? Data()
+		var textBytes = textData.toByteArray()
+		
+		let maxFileSize = 256 // As per NTAG 424 spcification for File #2
+		let maxTextSize = maxFileSize - (fileHeader.count + messageHeader.count + typeHeader.count)
+		if textBytes.count > maxTextSize {
+			textBytes = Array(textBytes[0..<maxTextSize])
+		}
+		
+		fileHeader[1] = UInt8(messageHeader.count + typeHeader.count + textBytes.count)
+		messageHeader[2] = UInt8(typeHeader.count + textBytes.count)
+		
+		let result: [UInt8] = fileHeader + messageHeader + typeHeader + textBytes
+		return result
+	}
+	
+	class func ndefDataForTemplate(_ template: Template) -> [UInt8] {
+		
+		switch template.value {
+		case .Left(let url):
+			return ndefDataForUrl(url)
+		case .Right(let text):
+			return ndefDataForText(text)
+		}
+	}
+	
+	struct Template {
+		let value: Either<URL, String>
+		let piccDataOffset: Int
+		let cmacOffset: Int
+		
+		var valueString: String {
+			switch value {
+			case .Left(let url):
+				return url.absoluteString
+			case .Right(let text):
+				return text
+			}
+		}
+		
+		init?(baseUrl: URL) {
+			
+			guard var comps = URLComponents(url: baseUrl, resolvingAgainstBaseURL: false) else {
+				return nil
+			}
+			
+			var queryItems = comps.queryItems ?? []
+			
+			// The `baseUrl` SHOULD NOT have either `picc_data` or `cmac` parameters.
+			// But just to be safe, we'll remove them if they're present.
+			//
+			queryItems.removeAll(where: { item in
+				let name = item.name.lowercased()
+				return name == "picc_data" || name == "cmac"
+			})
+			
+			// picc_data=(16_bytes_hexadecimal)
+			// cmac=(8_bytes_hexadecimal)
+			
+			queryItems.append(URLQueryItem(name: "picc_data", value: "00000000000000000000000000000000"))
+			queryItems.append(URLQueryItem(name: "cmac",      value: "0000000000000000"))
+			
+			comps.queryItems = queryItems
+			
+			guard let resolvedUrl = comps.url else {
+				return nil
+			}
+			
+			let urlString = resolvedUrl.absoluteString
+			
+			// Ultimately, the URL gets encoded as UTF-8,
+			// and the offsets are used as indexes within this UTF-8 representation.
+			//
+			// So we need to do our calculations within the string's utf8View.
+			
+			let urlUtf8 = urlString.utf8
+			
+			guard let range1 = urlUtf8.ranges(of: "picc_data=".utf8).last else {
+				return nil
+			}
+			let offset1 = urlUtf8.distance(from: urlUtf8.startIndex, to: range1.upperBound)
+			
+			guard let range2 = urlUtf8.ranges(of: "cmac=".utf8).last else {
+				return nil
+			}
+			let offset2 = urlUtf8.distance(from: urlUtf8.startIndex, to: range2.upperBound)
+			
+			self.value = Either.Left(resolvedUrl)
+			self.piccDataOffset = offset1 + Ndef.URL_HEADER_SIZE
+			self.cmacOffset = offset2 + Ndef.URL_HEADER_SIZE
+		}
+		
+		init(baseText: String) {
+			
+			// picc_data=(16_bytes_hexadecimal)
+			// cmac=(8_bytes_hexadecimal)
+			
+			let fullText = "\(baseText)?picc_data=00000000000000000000000000000000&cmac=0000000000000000"
+			//                         +123456789 123456789 123456789 123456789 123456789
+			//                                    ^+11                                  ^+49
+			
+			// Ultimately, the value gets encoded as UTF-8,
+			// and the offsets are used as indexes within this UTF-8 representation.
+			//
+			// So we need to do our calculations within the string's utf8View.
+			
+			let baseTextLength = baseText.utf8.count
+			let offset1 = baseTextLength + 11
+			let offset2 = baseTextLength + 49
+			
+			self.value = Either.Right(fullText)
+			self.piccDataOffset = offset1 + Ndef.TEXT_HEADER_SIZE
+			self.cmacOffset = offset2 + Ndef.TEXT_HEADER_SIZE
+		}
+		
+	} // </struct Template>
+}

--- a/phoenix-ios/phoenix-ios/views/receive/LightningDualView.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/LightningDualView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PhoenixShared
+import CoreNFC
 
 fileprivate let filename = "LightningDualView"
 #if DEBUG && true
@@ -40,8 +41,9 @@ struct LightningDualView: View {
 	@State var notificationPermissions = NotificationsManager.shared.permissions.value
 	
 	@State var modificationAmount: CurrencyAmount? = nil
+	@State var modificationTitleType: ModifyInvoiceSheet.TitleType = .normal
 	
-	let lastIncomingPaymentPublisher = Biz.business.paymentsManager.lastIncomingPaymentPublisher()
+	@State var nfcActive: Bool = false
 	
 	// For the cicular buttons: [copy, share, edit]
 	enum MaxButtonWidth: Preference {}
@@ -50,6 +52,8 @@ struct LightningDualView: View {
 		value: { [$0.size.width] }
 	)
 	@State var maxButtonWidth: CGFloat? = nil
+	
+	let lastIncomingPaymentPublisher = Biz.business.paymentsManager.lastIncomingPaymentPublisher()
 	
 	// To workaround a bug in SwiftUI, we're using multiple namespaces for our animation.
 	// In particular, animating the border around the qrcode doesn't work well.
@@ -170,11 +174,15 @@ struct LightningDualView: View {
 			actionButtons()
 				.padding(.bottom)
 			
-			switchTypeButton()
-			
-			if activeType == .bolt12_offer {
-				howToUseButton()
-					.padding(.top)
+			if nfcActive {
+				nfcActivity()
+				
+			} else {
+				switchTypeButton()
+				if activeType == .bolt12_offer {
+					howToUseButton()
+						.padding(.top)
+				}
 			}
 			
 			if notificationPermissions == .disabled {
@@ -307,12 +315,12 @@ struct LightningDualView: View {
 		
 			if activeType == .bolt11_invoice {
 				invoiceAmountView()
-					.font(.footnote)
+					.font(.callout)
 					.foregroundColor(.secondary)
 			
 				invoiceDescriptionView()
 					.lineLimit(1)
-					.font(.footnote)
+					.font(.callout)
 					.foregroundColor(.secondary)
 				
 			} else {
@@ -321,7 +329,7 @@ struct LightningDualView: View {
 					bip353AddressView(address)
 						.lineLimit(2)
 						.multilineTextAlignment(.center)
-						.font(.footnote)
+						.font(.callout)
 						.foregroundColor(.secondary)
 					
 				} else {
@@ -422,6 +430,7 @@ struct LightningDualView: View {
 			if activeType == .bolt11_invoice {
 				editButton()
 			}
+			nfcButton()
 		}
 		.assignMaxPreference(for: maxButtonWidthReader.key, to: $maxButtonWidth)
 	}
@@ -474,7 +483,7 @@ struct LightningDualView: View {
 	func copyButton() -> some View {
 		
 		actionButton(
-			text: NSLocalizedString("copy", comment: "button label - try to make it short"),
+			text: String(localized: "copy", comment: "button label - try to make it short"),
 			image: Image(systemName: "square.on.square"),
 			width: 20, height: 20,
 			xOffset: 0, yOffset: 0
@@ -491,7 +500,7 @@ struct LightningDualView: View {
 	func shareButton() -> some View {
 		
 		actionButton(
-			text: NSLocalizedString("share", comment: "button label - try to make it short"),
+			text: String(localized: "share", comment: "button label - try to make it short"),
 			image: Image(systemName: "square.and.arrow.up"),
 			width: 21, height: 21,
 			xOffset: 0, yOffset: -1
@@ -508,7 +517,7 @@ struct LightningDualView: View {
 	func editButton() -> some View {
 		
 		actionButton(
-			text: NSLocalizedString("edit", comment: "button label - try to make it short"),
+			text: String(localized: "edit", comment: "button label - try to make it short"),
 			image: Image(systemName: "square.and.pencil"),
 			width: 19, height: 19,
 			xOffset: 1, yOffset: -1
@@ -516,6 +525,20 @@ struct LightningDualView: View {
 			didTapEditButton()
 		}
 		.disabled(!(mvi.model is Receive.Model_Generated))
+	}
+	
+	@ViewBuilder
+	func nfcButton() -> some View {
+		
+		actionButton(
+			text: String(localized: "nfc", comment: "button label - try to make it short"),
+			image: Image(systemName: "dot.radiowaves.forward"),
+			width: 21, height: 21,
+			xOffset: 0, yOffset: 0
+		) {
+			didTapNfcButton()
+		}
+		.disabled(nfcActive)
 	}
 	
 	@ViewBuilder
@@ -566,6 +589,23 @@ struct LightningDualView: View {
 			showBolt12Sheet()
 		} label: {
 			Label("How to use", systemImage: "info.circle")
+		}
+	}
+	
+	@ViewBuilder
+	func nfcActivity() -> some View {
+		
+		if nfcActive {
+			
+			VStack(alignment: HorizontalAlignment.center, spacing: 0) {
+				
+				HorizontalActivity(color: .appAccent, diameter: 10, speed: 1.6)
+					.frame(width: 240, height: 10)
+					.padding(.horizontal)
+					.padding(.bottom, 4)
+				
+			} // </VStack>
+			.padding(.top)
 		}
 	}
 	
@@ -665,7 +705,7 @@ struct LightningDualView: View {
 	// MARK: View Transitions
 	// --------------------------------------------------
 	
-	func onAppear() -> Void {
+	func onAppear() {
 		log.trace("onAppear()")
 		
 		// Careful: this function may be called multiple times
@@ -794,6 +834,10 @@ struct LightningDualView: View {
 		))
 	}
 	
+	func modifyInvoiceSheetDidCancel() {
+		log.trace("modifyInvoiceSheetDidCancel()")
+	}
+	
 	func currencyConverterDidChange(_ amount: CurrencyAmount?) {
 		log.trace("currencyConverterDidChange()")
 		
@@ -813,11 +857,13 @@ struct LightningDualView: View {
 		smartModalState.display(dismissable: true) {
 			
 			ModifyInvoiceSheet(
+				titleType: modificationTitleType,
 				savedAmount: $modificationAmount,
 				amount: amount,
 				desc: desc ?? "",
 				openCurrencyConverter: openCurrencyConverter,
-				didSave: modifyInvoiceSheetDidSave
+				didSave: modifyInvoiceSheetDidSave,
+				didCancel: modifyInvoiceSheetDidCancel
 			)
 		}
 	}
@@ -940,18 +986,83 @@ struct LightningDualView: View {
 		log.trace("didTapEditButton()")
 		
 		// The edit button is only displayed for Bolt 11 invoices.
+		guard let model = mvi.model as? Receive.Model_Generated else {
+			log.warning("didTapEditButton(): ignoring: model is not Receive.Model_Generated")
+			return
+		}
 		
-		if let model = mvi.model as? Receive.Model_Generated {
+		modificationTitleType = .normal
+		smartModalState.display(dismissable: true) {
 			
-			smartModalState.display(dismissable: true) {
+			ModifyInvoiceSheet(
+				titleType: modificationTitleType,
+				savedAmount: $modificationAmount,
+				amount: model.amount,
+				desc: model.desc ?? "",
+				openCurrencyConverter: openCurrencyConverter,
+				didSave: modifyInvoiceSheetDidSave,
+				didCancel: modifyInvoiceSheetDidCancel
+			)
+		}
+	}
+	
+	func didTapNfcButton() {
+		log.trace("didTapNfcButton()")
+		
+		// We're going to build a BIP-321 URI
+		
+		var queryItems: [URLQueryItem] = []
+		
+		if activeType == .bolt11_invoice {
+			guard let m = mvi.model as? Receive.Model_Generated else {
+				log.warning("mvi.model !is Model_Generated")
+				return
+			}
+			
+			if let msat = m.amount {
 				
-				ModifyInvoiceSheet(
-					savedAmount: $modificationAmount,
-					amount: model.amount,
-					desc: model.desc ?? "",
-					openCurrencyConverter: openCurrencyConverter,
-					didSave: modifyInvoiceSheetDidSave
-				)
+				// BIP-321:
+				//
+				// > If an amount is provided, it MUST be specified in decimal BTC.
+				// > All amounts MUST contain no commas and use a period (.) as the
+				// > separating character to separate whole numbers and decimal fractions.
+				// > I.e. amount=50.00 or amount=50 is treated as 50 BTC,
+				// > and amount=50,000.00 is invalid.
+				
+				let formatter = NumberFormatter()
+				formatter.usesGroupingSeparator = false
+				formatter.decimalSeparator = "."
+				formatter.minimumFractionDigits = 0
+				formatter.maximumFractionDigits = 11
+				
+				let btc = Utils.convertBitcoin(msat: msat, to: .btc)
+				if let btcStr = formatter.string(from: NSNumber(value: btc)) {
+					queryItems.append(URLQueryItem(name: "amount", value: btcStr))
+				}
+			}
+			
+			queryItems.append(URLQueryItem(name: "lightning", value: m.request))
+			
+		} else {
+			guard let offer = offerStr else {
+				log.warning("offerStr is nil")
+				return
+			}
+			
+			queryItems.append(URLQueryItem(name: "lno", value: offer))
+		}
+		
+		var comps = URLComponents()
+		comps.scheme = "bitcoin"
+		comps.queryItems = queryItems
+		
+		if let url = comps.url {
+			log.debug("url: \(url.absoluteString)")
+			
+			if #available(iOS 17.4, *) {
+				startHostCardEmulation(url)
+			} else {
+				handleHceWriterError(.hceNotAvailable)
 			}
 		}
 	}
@@ -1058,5 +1169,71 @@ struct LightningDualView: View {
 		let uiImg = UIImage(cgImage: cgImage)
 		activeSheet = ActiveSheet.sharingImage(image: uiImg)
 	}
+	
+	// --------------------------------------------------
+	// MARK: Host Card Emulation
+	// --------------------------------------------------
+	
+	@available(iOS 17.4, *)
+	func startHostCardEmulation(_ url: URL) {
+		log.trace("startHostCardEmulation()")
+		
+		let file = Ndef.ndefDataForUrl(url)
+		
+		nfcActive = true
+		Task { @MainActor in
+			if let error = await HceWriter.shared.start(ndefFile: file) {
+				handleHceWriterError(error)
+			}
+			nfcActive = false
+		}
+	}
+	
+	func handleHceWriterError(_ error: HceWriterError) {
+		
+		let msg: String
+		switch error {
+		case .nfcNotAvailable:
+			msg = String(localized: "NFC capabilities not available on this device")
+			
+		case .hceNotAvailable:
+			msg = String(localized:
+				"""
+				Host card emulation not available.
+				Requires iOS 17.4 or later.
+				"""
+			)
+			
+		case .hceNotEligible:
+			msg = String(localized:
+				"""
+				Host card emulation not available.
+				Limited to European Economic Area.
+				"""
+			)
+			
+		case .sessionError(let sessionError, _):
+			let details: String
+			switch sessionError {
+			case .acquirePresentmentIntent:
+				details = String(localized: "(wait a few seconds and then retry)")
+			case .initializeSession:
+				details = "(cannot initialize CardSession)"
+			case .startEmulation:
+				details = "(cannot start emulation session)"
+			case .eventStream:
+				details = "(event stream termination)"
+			}
+			
+			msg = String(localized: "Host card emulation session error\n\(details)")
+		}
+		
+		toast.pop(msg,
+			colorScheme: colorScheme.opposite,
+			style: .chrome,
+			duration: 5.0,
+			alignment: .bottom,
+			showCloseButton: true
+		)
+	}
 }
-

--- a/phoenix-ios/phoenix-ios/views/receive/ModifyInvoiceSheet.swift
+++ b/phoenix-ios/phoenix-ios/views/receive/ModifyInvoiceSheet.swift
@@ -10,11 +10,18 @@ fileprivate var log = LoggerFactory.shared.logger(filename, .warning)
 
 struct ModifyInvoiceSheet: View {
 
+	enum TitleType {
+		case normal
+		case cardPaymentNeedsAmount
+	}
+	let titleType: TitleType
+	
 	@Binding var savedAmount: CurrencyAmount?
 	let initialAmount: Lightning_kmpMilliSatoshi?
 	
 	let openCurrencyConverter: () -> Void
 	let didSave: (Lightning_kmpMilliSatoshi?, String) -> Void
+	let didCancel: () -> Void
 	
 	@State var desc: String
 	
@@ -26,6 +33,8 @@ struct ModifyInvoiceSheet: View {
 	@State var parsedAmount: Result<Double, TextFieldCurrencyStylerError> = Result.failure(.emptyInput)
 	
 	@State var altAmount: String = ""
+	
+	@State var didTapSave: Bool = false
 	
 	@EnvironmentObject var currencyPrefs: CurrencyPrefs
 	@EnvironmentObject var smartModalState: SmartModalState
@@ -39,17 +48,21 @@ struct ModifyInvoiceSheet: View {
 	@State var textHeight: CGFloat? = nil
 
 	init(
+		titleType: TitleType,
 		savedAmount: Binding<CurrencyAmount?>,
 		amount: Lightning_kmpMilliSatoshi?,
 		desc: String,
 		openCurrencyConverter: @escaping () -> Void,
-		didSave: @escaping (Lightning_kmpMilliSatoshi?, String) -> Void
+		didSave: @escaping (Lightning_kmpMilliSatoshi?, String) -> Void,
+		didCancel: @escaping () -> Void
 	) {
+		self.titleType = titleType
 		self._savedAmount = savedAmount
 		self.initialAmount = amount
 		self._desc = State<String>(initialValue: desc)
 		self.openCurrencyConverter = openCurrencyConverter
 		self.didSave = didSave
+		self.didCancel = didCancel
 	}
 	
 	// --------------------------------------------------
@@ -60,10 +73,18 @@ struct ModifyInvoiceSheet: View {
 	var body: some View {
 		
 		VStack(alignment: .leading) {
-			Text("Edit payment request")
-				.font(.title3)
-				.padding([.top, .bottom])
-				.accessibilityAddTraits(.isHeader)
+			
+			Group {
+				switch titleType {
+				case .normal:
+					Text("Edit payment request")
+				case .cardPaymentNeedsAmount:
+					Text("Amount required for card payment").foregroundStyle(Color.appNegative).bold()
+				}
+			}
+			.font(.title3)
+			.padding([.top, .bottom])
+			.accessibilityAddTraits(.isHeader)
 
 			HStack {
 				TextField(
@@ -268,6 +289,12 @@ struct ModifyInvoiceSheet: View {
 		
 		currencyList = Currency.displayable(currencyPrefs: currencyPrefs, plus: currency)
 		currencyPickerChoice = CurrencyPickerOption.currency(currency)
+		
+		smartModalState.onNextDidDisappear {
+			if !didTapSave {
+				didCancel()
+			}
+		}
 	}
 	
 	func amountDidChange() -> Void {
@@ -402,6 +429,7 @@ struct ModifyInvoiceSheet: View {
 			savedAmount = nil
 		}
 		
+		didTapSave = true
 		smartModalState.close(animationCompletion: {
 			didSave(msat, trimmedDesc)
 		})

--- a/phoenix-ios/phoenix-ios/views/send/SendView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/SendView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import CoreNFC
 import PhoenixShared
 
 fileprivate let filename = "SendView"
@@ -62,6 +63,8 @@ struct SendView: View {
 		value: { [$0.size.width] }
 	)
 	@State var maxButtonWidth: CGFloat? = nil
+	
+	@ScaledMetric var labelImageSize: CGFloat = 22
 	
 	// <iOS_16_workarounds>
 	@State var navLinkTag: NavLinkTag? = nil
@@ -189,41 +192,6 @@ struct SendView: View {
 	}
 	
 	@ViewBuilder
-	func list() -> some View {
-		
-		List {
-			section_suggestions()
-			section_contacts()
-		}
-		.listStyle(.insetGrouped)
-		.listBackgroundColor(.primaryBackground)
-		.frame(maxWidth: deviceInfo.textColumnMaxWidth)
-	}
-	
-	@ViewBuilder
-	func footer() -> some View {
-		
-		HStack(alignment: VerticalAlignment.top, spacing: 0) {
-			Spacer()
-			actionButton_paste()
-			Spacer()
-			actionButton_chooseImage()
-			Spacer()
-			actionButton_scanQrCode()
-			Spacer()
-		}
-		.assignMaxPreference(for: maxButtonWidthReader.key, to: $maxButtonWidth)
-		.padding(.horizontal)
-		.padding(.top, 20)
-		.padding(.bottom, deviceInfo.isFaceID ? 10 : 20)
-		.background(
-			Color.mutedBackground
-				.cornerRadius(15, corners: [.topLeft, .topRight])
-				.edgesIgnoringSafeArea([.horizontal, .bottom])
-		)
-	}
-	
-	@ViewBuilder
 	func smartInputField() -> some View {
 		
 		HStack(alignment: VerticalAlignment.center, spacing: 0) {
@@ -252,7 +220,111 @@ struct SendView: View {
 	}
 	
 	@ViewBuilder
-	func actionButtonFactory(
+	func list() -> some View {
+		
+		List {
+			section_suggestions()
+			section_contacts()
+		}
+		.listStyle(.insetGrouped)
+		.listBackgroundColor(.primaryBackground)
+		.frame(maxWidth: deviceInfo.textColumnMaxWidth)
+	}
+	
+	@ViewBuilder
+	func footer() -> some View {
+		
+		ViewThatFits {
+			footer_standard()
+			footer_compact()
+			footer_accessibility()
+		}
+		.assignMaxPreference(for: maxButtonWidthReader.key, to: $maxButtonWidth)
+		.background(
+			Color.mutedBackground
+				.cornerRadius(15, corners: [.topLeft, .topRight])
+				.edgesIgnoringSafeArea([.horizontal, .bottom])
+		)
+	}
+	
+	@ViewBuilder
+	func footer_standard() -> some View {
+		
+		HStack(alignment: VerticalAlignment.top, spacing: 0) {
+			Spacer()
+			roundButton_paste()
+				.frame(width: maxButtonWidth)
+				.read(maxButtonWidthReader)
+			Spacer()
+			roundButton_chooseImage()
+				.frame(width: maxButtonWidth)
+				.read(maxButtonWidthReader)
+			Spacer()
+			roundButton_nfc()
+				.frame(width: maxButtonWidth)
+				.read(maxButtonWidthReader)
+			Spacer()
+			roundButton_scanQrCode()
+				.frame(width: maxButtonWidth)
+				.read(maxButtonWidthReader)
+			Spacer()
+		}
+		.padding(.top, 20)
+		.padding(.bottom, deviceInfo.isFaceID ? 10 : 20)
+	}
+	
+	@ViewBuilder
+	func footer_compact() -> some View {
+		
+		HStack(alignment: VerticalAlignment.top, spacing: 0) {
+			roundButton_paste()
+			Spacer()
+			roundButton_chooseImage()
+			Spacer()
+			roundButton_nfc()
+			Spacer()
+			roundButton_scanQrCode()
+		}
+		.padding(.horizontal)
+		.padding(.top, 20)
+		.padding(.bottom, deviceInfo.isFaceID ? 10 : 20)
+	}
+	
+	@ViewBuilder
+	func footer_accessibility() -> some View {
+		
+		VStack(alignment: HorizontalAlignment.center, spacing: 20) {
+			HStack(alignment: VerticalAlignment.top, spacing: 0) {
+				Spacer()
+				labelButton_paste()
+					.frame(width: maxButtonWidth, alignment: .leading)
+					.read(maxButtonWidthReader)
+				Spacer()
+				Spacer()
+				labelButton_scanQrCode()
+					.frame(width: maxButtonWidth, alignment: .leading)
+					.read(maxButtonWidthReader)
+				Spacer()
+			}
+			HStack(alignment: VerticalAlignment.top, spacing: 0) {
+				Spacer()
+				labelButton_chooseImage()
+					.frame(width: maxButtonWidth, alignment: .leading)
+					.read(maxButtonWidthReader)
+				Spacer()
+				Spacer()
+				labelButton_nfc()
+					.frame(width: maxButtonWidth, alignment: .leading)
+					.read(maxButtonWidthReader)
+				Spacer()
+			}
+		}
+		.padding(.top, 10)
+		.padding(.bottom, deviceInfo.isFaceID ? 10 : 20)
+	}
+	
+	@ViewBuilder
+	func roundButtonFactory(
 		text: String,
 		image: Image,
 		width: CGFloat = 20,
@@ -288,32 +360,29 @@ struct SendView: View {
 				
 			} // </VStack>
 		} // </Button>
-		.frame(width: maxButtonWidth)
-		.read(maxButtonWidthReader)
 		.accessibilityElement()
 		.accessibilityLabel(text)
 		.accessibilityAddTraits(.isButton)
 	}
 	
 	@ViewBuilder
-	func actionButton_paste() -> some View {
+	func roundButton_paste() -> some View {
 		
-		actionButtonFactory(
-			text: NSLocalizedString("paste", comment: "button label - try to make it short"),
+		roundButtonFactory(
+			text: String(localized: "paste", comment: "button label - try to make it short"),
 			image: Image(systemName: "arrow.right.doc.on.clipboard"),
 			width: 20, height: 20,
 			xOffset: 0, yOffset: 0
 		) {
 			pasteFromClipboard()
 		}
-	//	.disabled(!clipboardHasString)
 	}
 	
 	@ViewBuilder
-	func actionButton_chooseImage() -> some View {
+	func roundButton_chooseImage() -> some View {
 		
-		actionButtonFactory(
-			text: NSLocalizedString("choose image", comment: "button label - try to make it short"),
+		roundButtonFactory(
+			text: String(localized: "choose image", comment: "button label - try to make it short"),
 			image: Image(systemName: "photo"),
 			width: 20, height: 20,
 			xOffset: 0, yOffset: 0
@@ -323,15 +392,104 @@ struct SendView: View {
 	}
 	
 	@ViewBuilder
-	func actionButton_scanQrCode() -> some View {
+	func roundButton_nfc() -> some View {
 		
-		actionButtonFactory(
-			text: NSLocalizedString("scan qr code", comment: "button label - try to make it short"),
+		roundButtonFactory(
+			text: String(localized: "nfc", comment: "button label - try to make it short"),
+			image: Image(systemName: "dot.radiowaves.forward"),
+			width: 21, height: 21,
+			xOffset: 0, yOffset: 0
+		) {
+			startNfc()
+		}
+	}
+	
+	@ViewBuilder
+	func roundButton_scanQrCode() -> some View {
+		
+		roundButtonFactory(
+			text: String(localized: "scan qr code", comment: "button label - try to make it short"),
 			image: Image(systemName: "qrcode.viewfinder"),
 			width: 20, height: 20,
 			xOffset: 0, yOffset: 0
 		) {
 			scanQrCode()
+		}
+	}
+	
+	@ViewBuilder
+	func labelButton_paste() -> some View {
+		
+		Button {
+			pasteFromClipboard()
+		} label: {
+			Label {
+				Text("paste", comment: "button label - try to make it short")
+					.foregroundColor(.primaryForeground)
+			} icon: {
+				Image(systemName: "arrow.right.doc.on.clipboard")
+					.resizable()
+					.scaledToFit()
+					.frame(width: labelImageSize, height: labelImageSize)
+					.foregroundColor(.appAccent)
+			}
+		}
+	}
+	
+	@ViewBuilder
+	func labelButton_chooseImage() -> some View {
+		
+		Button {
+			chooseImage()
+		} label: {
+			Label {
+				Text("choose image", comment: "button label - try to make it short")
+					.foregroundColor(.primaryForeground)
+			} icon: {
+				Image(systemName: "photo")
+					.resizable()
+					.scaledToFit()
+					.frame(width: labelImageSize, height: labelImageSize)
+					.foregroundColor(.appAccent)
+			}
+		}
+	}
+	
+	@ViewBuilder
+	func labelButton_nfc() -> some View {
+		
+		Button {
+			startNfc()
+		} label: {
+			Label {
+				Text("nfc", comment: "button label - try to make it short")
+					.foregroundColor(.primaryForeground)
+			} icon: {
+				Image(systemName: "dot.radiowaves.forward")
+					.resizable()
+					.scaledToFit()
+					.frame(width: labelImageSize, height: labelImageSize)
+					.foregroundColor(.appAccent)
+			}
+		}
+	}
+	
+	@ViewBuilder
+	func labelButton_scanQrCode() -> some View {
+		
+		Button {
+			scanQrCode()
+		} label: {
+			Label {
+				Text("scan qr code", comment: "button label - try to make it short")
+					.foregroundColor(.primaryForeground)
+			} icon: {
+				Image(systemName: "qrcode.viewfinder")
+					.resizable()
+					.scaledToFit()
+					.frame(width: labelImageSize, height: labelImageSize)
+					.foregroundColor(.appAccent)
+			}
 		}
 	}
 	
@@ -850,6 +1008,20 @@ struct SendView: View {
 		activeSheet = .imagePicker
 	}
 	
+	func startNfc() {
+		log.trace("startNfc()")
+		
+		NfcReader.shared.readCard { (result: Result<NFCNDEFMessage, NfcReader.ReadError>) in
+			
+			switch result {
+			case .success(let ndefMsg):
+				handleNdefMessage(ndefMsg)
+			case .failure(let error):
+				handleNfcError(error)
+			}
+		}
+	}
+	
 	func scanQrCode() {
 		log.trace("scanQrCode()")
 		activeSheet = .qrCodeScanner
@@ -936,6 +1108,64 @@ struct SendView: View {
 	// --------------------------------------------------
 	// MARK: Parsing
 	// --------------------------------------------------
+	
+	func handleNdefMessage(_ ndefMsg: NFCNDEFMessage) {
+		log.trace("handleNdefMessage()")
+		
+		var uri_values: [URL] = []
+		var text_values: [String] = []
+		
+		ndefMsg.records.forEach { payload in
+			if let uri = payload.wellKnownTypeURIPayload() {
+				log.debug("found uri = \(uri)")
+				uri_values.append(uri)
+				
+			} else if let text = payload.wellKnownTypeTextPayload().0 {
+				log.debug("found text = \(text)")
+				text_values.append(text)
+			}
+		}
+		
+		if let uri = uri_values.first {
+			parseUserInput(uri.absoluteString)
+		} else if let text = text_values.first {
+			parseUserInput(text)
+		} else {
+			
+			let msg = String(localized: "No URI or text detected in NFC tag")
+			toast.pop(msg,
+				colorScheme: colorScheme.opposite,
+				style: .chrome,
+				duration: 5.0,
+				alignment: .middle,
+				showCloseButton: true
+			)
+		}
+	}
+	
+	func handleNfcError(_ error: NfcReader.ReadError) {
+		log.trace("handleNfcError()")
+		
+		let msg: String
+		switch error {
+		case .readingNotAvailable:
+			msg = String(localized: "NFC cababilities not available on this device")
+		case .alreadyStarted:
+			msg = String(localized: "NFC reader is already scanning")
+		case .scanningTerminated(_):
+			msg = String(localized: "Nothing scanned")
+		case .errorReadingTag:
+			msg = String(localized: "Error reading tag")
+		}
+
+		toast.pop(msg,
+			colorScheme: colorScheme.opposite,
+			style: .chrome,
+			duration: 5.0,
+			alignment: .middle,
+			showCloseButton: true
+		)
+	}
 	
 	func parseUserInput(_ input: String) {
 		log.trace("parseUserInput()")

--- a/phoenix-ios/phoenix-ios/views/send/WebsiteLinkPopover.swift
+++ b/phoenix-ios/phoenix-ios/views/send/WebsiteLinkPopover.swift
@@ -27,7 +27,7 @@ struct WebsiteLinkPopover: View {
 		
 		VStack(alignment: HorizontalAlignment.leading, spacing: 0) {
 			
-			Text("This appears to be a website (not a lightning invoice):")
+			Text("This appears to be a website:")
 				.padding(.bottom, 10)
 			
 			Text(verbatim: link.absoluteString)


### PR DESCRIPTION
https://github.com/user-attachments/assets/7213f43d-ffcf-426b-9e2b-c41d2986ea45

---

Technical notes:

- Reading an NFC tag is very simple (and doesn't require any special permissions from Apple)
- Performing HCE (host card emulation) and sending a tag is straight-forward once you have the building blocks in place (NDEF protocol stuff)
- HCE requires iOS 17.4 or later
- HCE will **only** work if your device is signed into iCloud, and your associated country is part of the European Economic Area
- For **development** builds, you can test with a device running iOS 18.2 or later (even if you're outside the EEA)
- Apple will need to accept our request to use HCE in our product
- The existing code we have in place for the SendManager is all we need to parse the received URL (no changes to kotlin shared layer needed).