### PR TITLE
ci: update actions to pinned SHA numbers

### DIFF
--- a/.github/workflows/testnet-build.yml
+++ b/.github/workflows/testnet-build.yml
@@ -17,12 +17,12 @@ jobs:
     # 1 - checkout project and dependencies
 
     - name: Checkout Phoenix
-      uses: actions/checkout@v2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         path: phoenix
 
     - name: Checkout lightning-kmp
-      uses: actions/checkout@v2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         repository: ACINQ/lightning-kmp
         ref: master
@@ -31,14 +31,14 @@ jobs:
     # 2 - setup cache/jdk
 
     - name: Cached Konan
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.konan
         key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
         restore-keys: ${{ runner.os }}-konan-
 
     - name: Set up jdk 1.17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
       with:
         java-version: 17
 


### PR DESCRIPTION
**Description**:

Update the actions in the `testnet-build.yml` file to pinned commit SHAs.

The following actions were updated to the latest version:
`actions/checkout` previously `v2`, now `v4.2.2`
`actions/setup-java` previously `v1`, now `v3.14.1`

**Related Issue(s)**:

Fixes #716