### PR TITLE
(ios) Tap on notification

### DIFF
--- a/phoenix-ios/phoenix-ios/AppDelegate.swift
+++ b/phoenix-ios/phoenix-ios/AppDelegate.swift
@@ -86,12 +86,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MessagingDelegate {
 			self._applicationDidEnterBackground()
 		}.store(in: &appCancellables)
 		
+		// Setup XPC for inter-process communication with notifySrvExt
 		XPC.shared.receivedMessagePublisher.sink { (msg: XpcMessage) in
 			self.didReceivePaymentViaAppExtension()
 		
 		}.store(in: &appCancellables)
-				
+		
 		XPC.shared.resume()
+		
+		// Setup NotificationsManager
+		// Important:
+		//   The `UNUserNotificationCenterDelegate` must be set before this function returns.
+		//   That's currently done in NotificationsManager.init.
 		NotificationsManager.shared.requestPermissionForProvisionalNotifications()
 		
 		return true
@@ -100,8 +106,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MessagingDelegate {
 	// The following functions are not called,
 	// because Firebase broke it with their stupid swizzling stuff.
 	// 
-	func applicationDidBecomeActive(_ application: UIApplication) {/* :( */}
-	func applicationWillResignActive(_ application: UIApplication) {/* :( */}
+	func applicationDidBecomeActive(_ application: UIApplication) {/* required by UIApplicationDelegate */}
+	func applicationWillResignActive(_ application: UIApplication) {/* required by UIApplicationDelegate */}
 //	func applicationWillEnterForeground(_ application: UIApplication) {/* :( */}
 //	func applicationDidEnterBackground(_ application: UIApplication) {/* :( */}
 	

--- a/phoenix-ios/phoenix-ios/officers/NotificationsManager.swift
+++ b/phoenix-ios/phoenix-ios/officers/NotificationsManager.swift
@@ -265,14 +265,19 @@ class NotificationsManager: NSObject, UNUserNotificationCenterDelegate {
 	) {
 		log.trace("userNotificationCenter(_:didReceive::)")
 		
-		if let id = response.notification.request.content.targetContentIdentifier {
+		DispatchQueue.main.async {
+			self.userDidTapNotification(response.notification)
+			completionHandler()
+		}
+	}
+	
+	func userDidTapNotification(_ notification: UNNotification) {
+		log.trace("userDidTapNotification()")
+		
+		if let id = notification.request.content.targetContentIdentifier {
 			if let paymentId = Lightning_kmpUUID.companion.tryFromString(string: id) {
 				GlobalEnvironment.deepLinkManager.broadcast(.payment(paymentId: paymentId))
 			}
-		}
-		
-		DispatchQueue.main.async {
-			completionHandler()
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/officers/NotificationsManager.swift
+++ b/phoenix-ios/phoenix-ios/officers/NotificationsManager.swift
@@ -78,7 +78,7 @@ enum NotificationPermissions: CustomStringConvertible {
 /// - monitoring iOS for our permission status
 /// - common handling for the display of notifications to the uer
 ///
-class NotificationsManager {
+class NotificationsManager: NSObject, UNUserNotificationCenterDelegate {
 	
 	/// Singleton instance
 	public static let shared = NotificationsManager()
@@ -102,7 +102,9 @@ class NotificationsManager {
 	private var cancellables = Set<AnyCancellable>()
 	
 	/// Must use shared instance
-	private init() {
+	private override init() {
+		
+		super.init()
 		
 		settings.sink { (settings: UNNotificationSettings?) in
 			
@@ -121,6 +123,8 @@ class NotificationsManager {
 		NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification).sink { _ in
 			self.didBecomeActiveNotification()
 		}.store(in: &cancellables)
+		
+		UNUserNotificationCenter.current().delegate = self
 		
 		refreshSettings()
 		refreshBackgroundRefreshStatus()
@@ -247,6 +251,28 @@ class NotificationsManager {
 			}
 			
 			self.refreshSettings()
+		}
+	}
+	
+	// --------------------------------------------------
+	// MARK: Delegate
+	// --------------------------------------------------
+	
+	func userNotificationCenter(
+		 _ center: UNUserNotificationCenter,
+		 didReceive response: UNNotificationResponse,
+		 withCompletionHandler completionHandler: @escaping () -> Void
+	) {
+		log.trace("userNotificationCenter(_:didReceive::)")
+		
+		if let id = response.notification.request.content.targetContentIdentifier {
+			if let paymentId = Lightning_kmpUUID.companion.tryFromString(string: id) {
+				GlobalEnvironment.deepLinkManager.broadcast(.payment(paymentId: paymentId))
+			}
+		}
+		
+		DispatchQueue.main.async {
+			completionHandler()
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/configuration/ConfigurationView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/ConfigurationView.swift
@@ -559,7 +559,7 @@ struct ConfigurationList: View {
 	}
 	
 	func deepLinkChanged(_ value: DeepLink?) {
-		log.trace("deepLinkChanged() => \(value?.rawValue ?? "nil")")
+		log.trace("deepLinkChanged() => \(value?.description ?? "nil")")
 		
 		if #available(iOS 17, *) {
 			// Nothing to do here.

--- a/phoenix-ios/phoenix-ios/views/configuration/ConfigurationView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/ConfigurationView.swift
@@ -584,6 +584,7 @@ struct ConfigurationList: View {
 				var newNavLinkTag: NavLinkTag? = nil
 				var delay: TimeInterval = 1.5 // seconds; multiply by number of screens we need to navigate
 				switch value {
+					case .payment(_)         : break
 					case .paymentHistory     : break
 					case .backup             : newNavLinkTag = .RecoveryPhrase       ; delay *= 1
 					case .drainWallet        : newNavLinkTag = .DrainWallet          ; delay *= 1

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/WalletInfoView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/WalletInfoView.swift
@@ -580,7 +580,7 @@ struct WalletInfoView: View {
 	// --------------------------------------------------
 	
 	func deepLinkChanged(_ value: DeepLink?) {
-		log.trace("deepLinkChanged() => \(value?.rawValue ?? "nil")")
+		log.trace("deepLinkChanged() => \(value?.description ?? "nil")")
 		
 		if #available(iOS 17, *) {
 			// Nothing to do here.

--- a/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/WalletInfoView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/advanced/wallet/WalletInfoView.swift
@@ -604,6 +604,7 @@ struct WalletInfoView: View {
 				// Navigate towards deep link (if needed)
 				var newNavLinkTag: NavLinkTag? = nil
 				switch value {
+					case .payment(_)         : break
 					case .paymentHistory     : break
 					case .backup             : break
 					case .drainWallet        : break

--- a/phoenix-ios/phoenix-ios/views/configuration/general/payment options/PaymentOptionsView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/general/payment options/PaymentOptionsView.swift
@@ -376,6 +376,7 @@ struct PaymentOptionsList: View {
 				// Navigate towards deep link (if needed)
 				var newNavLinkTag: NavLinkTag? = nil
 				switch value {
+					case .payment(_)         : break
 					case .paymentHistory     : break
 					case .backup             : break
 					case .drainWallet        : break

--- a/phoenix-ios/phoenix-ios/views/configuration/general/payment options/PaymentOptionsView.swift
+++ b/phoenix-ios/phoenix-ios/views/configuration/general/payment options/PaymentOptionsView.swift
@@ -352,7 +352,7 @@ struct PaymentOptionsList: View {
 	// --------------------------------------------------
 	
 	func deepLinkChanged(_ value: DeepLink?) {
-		log.trace("deepLinkChanged() => \(value?.rawValue ?? "nil")")
+		log.trace("deepLinkChanged() => \(value?.description ?? "nil")")
 		
 		if #available(iOS 17, *) {
 			// Nothing to do here.

--- a/phoenix-ios/phoenix-ios/views/environment/DeepLink.swift
+++ b/phoenix-ios/phoenix-ios/views/environment/DeepLink.swift
@@ -8,6 +8,7 @@ fileprivate var log = LoggerFactory.shared.logger(filename, .warning)
 #endif
 
 enum DeepLink: Equatable, CustomStringConvertible {
+	case payment(paymentId: Lightning_kmpUUID)
 	case paymentHistory
 	case backup
 	case drainWallet

--- a/phoenix-ios/phoenix-ios/views/environment/DeepLink.swift
+++ b/phoenix-ios/phoenix-ios/views/environment/DeepLink.swift
@@ -7,7 +7,7 @@ fileprivate var log = LoggerFactory.shared.logger(filename, .trace)
 fileprivate var log = LoggerFactory.shared.logger(filename, .warning)
 #endif
 
-enum DeepLink: String, Equatable {
+enum DeepLink: Equatable, CustomStringConvertible {
 	case paymentHistory
 	case backup
 	case drainWallet
@@ -17,6 +17,21 @@ enum DeepLink: String, Equatable {
 	case forceCloseChannels
 	case swapInWallet
 	case finalWallet
+	
+	var description: String {
+		switch self {
+			case .payment(let id)    : return "payment(\(id))"
+			case .paymentHistory     : return "paymentHistory"
+			case .backup             : return "backup"
+			case .drainWallet        : return "drainWallet"
+			case .electrum           : return "electrum"
+			case .backgroundPayments : return "backgroundPayments"
+			case .liquiditySettings  : return "liquiditySettings"
+			case .forceCloseChannels : return "forceCloseChannels"
+			case .swapInWallet       : return "swapInWallet"
+			case .finalWallet        : return "finalWallet"
+		}
+	}
 }
 
 class DeepLinkManager: ObservableObject {
@@ -27,7 +42,7 @@ class DeepLinkManager: ObservableObject {
 	private var deepLinkIdx = 0
 	
 	func broadcast(_ value: DeepLink) {
-		log.trace("broadcast(\(value.rawValue))")
+		log.trace("broadcast(\(value))")
 		
 		self.deepLinkIdx += 1
 		self.deepLink = value
@@ -67,7 +82,7 @@ class DeepLinkManager: ObservableObject {
 	}
 	
 	func unbroadcast(_ value: DeepLink) {
-		log.trace("unbroadcast(\(value.rawValue))")
+		log.trace("unbroadcast(\(value))")
 		
 		if self.deepLink == value {
 		
@@ -93,9 +108,9 @@ enum PopToDestination: CustomStringConvertible {
 	public var description: String {
 		switch self {
 		case .RootView(let followedBy):
-			return "RootView(followedBy: \(followedBy?.rawValue ?? "nil"))"
+			return "RootView(followedBy: \(followedBy?.description ?? "nil"))"
 		case .ConfigurationView(let followedBy):
-			return "ConfigurationView(follwedBy: \(followedBy?.rawValue ?? "nil"))"
+			return "ConfigurationView(follwedBy: \(followedBy?.description ?? "nil"))"
 		case .TransactionsView:
 			return "TransactionsView"
 		}

--- a/phoenix-ios/phoenix-ios/views/main/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/main/HomeView.swift
@@ -765,6 +765,12 @@ struct HomeView : MVIView {
 		if !didAppear {
 			didAppear = true
 			paymentsPageFetcher_subscribe()
+			
+			if let deepLink = deepLinkManager.deepLink {
+				DispatchQueue.main.async {
+					deepLinkChanged(deepLink)
+				}
+			}
 		}
 	}
 	

--- a/phoenix-ios/phoenix-ios/views/main/HomeView.swift
+++ b/phoenix-ios/phoenix-ios/views/main/HomeView.swift
@@ -66,9 +66,16 @@ struct HomeView : MVIView {
 	)
 	@State var noticeBoxContentHeight: CGFloat? = nil
 	
-	enum HomeViewSheet {
+	enum HomeViewSheet: Identifiable, Equatable {
 		case paymentView(payment: WalletPaymentInfo)
 		case notificationsView
+		
+		var id: String {
+			switch self {
+				case .paymentView(let payment) : return "paymentView(\(payment.id))"
+				case .notificationsView        : return "notificationsView"
+			}
+		}
 	}
 	
 	@State var activeSheet: HomeViewSheet? = nil
@@ -119,6 +126,9 @@ struct HomeView : MVIView {
 			.onChange(of: mvi.model) { newModel in
 				onModelChange(model: newModel)
 			}
+			.onChange(of: deepLinkManager.deepLink) {
+				deepLinkChanged($0)
+			}
 			.onChange(of: currencyPrefs.hideAmounts) { _ in
 				hideAmountsChanged()
 			}
@@ -161,11 +171,8 @@ struct HomeView : MVIView {
 			paymentsList()
 		}
 		.frame(maxWidth: .infinity, maxHeight: .infinity)
-		.sheet(isPresented: Binding( // SwiftUI only allows for 1 ".sheet"
-			get: { activeSheet != nil },
-			set: { if !$0 { activeSheet = nil }}
-		)) {
-			switch activeSheet! {
+		.sheet(item: $activeSheet) { (sheet: HomeViewSheet) in
+			switch sheet {
 			case .paymentView(let selectedPayment):
 				
 				PaymentView(
@@ -774,6 +781,33 @@ struct HomeView : MVIView {
 		if balance > 0 || incomingBalance > 0 {
 			if Prefs.shared.isNewWallet {
 				Prefs.shared.isNewWallet = false
+			}
+		}
+	}
+	
+	func deepLinkChanged(_ value: DeepLink?) {
+		log.trace("deepLinkChanged() => \(value?.description ?? "nil")")
+		
+		if let value {
+			switch value {
+			case .payment(let paymentId):
+				Biz.business.paymentsManager.getPayment(id: paymentId) { result, _ in
+					if let result {
+						activeSheet = .paymentView(payment: result)
+					} else {
+						log.warning("deepLinkChanged(): getPayment failed")
+					}
+				}
+				
+			case .paymentHistory     : break
+			case .backup             : break
+			case .drainWallet        : break
+			case .electrum           : break
+			case .backgroundPayments : break
+			case .liquiditySettings  : break
+			case .forceCloseChannels : break
+			case .swapInWallet       : break
+			case .finalWallet        : break
 			}
 		}
 	}

--- a/phoenix-ios/phoenix-ios/views/main/MainView_Big.swift
+++ b/phoenix-ios/phoenix-ios/views/main/MainView_Big.swift
@@ -609,7 +609,7 @@ struct MainView_Big: View {
 	}
 	
 	private func deepLinkChanged(_ value: DeepLink?) {
-		log.trace("deepLinkChanged() => \(value?.rawValue ?? "nil")")
+		log.trace("deepLinkChanged() => \(value?.description ?? "nil")")
 		
 		if let value = value {
 			switch value {

--- a/phoenix-ios/phoenix-ios/views/main/MainView_Big.swift
+++ b/phoenix-ios/phoenix-ios/views/main/MainView_Big.swift
@@ -613,6 +613,7 @@ struct MainView_Big: View {
 		
 		if let value = value {
 			switch value {
+				case .payment(_)         : break
 				case .paymentHistory     : showTransactions()
 				case .backup             : showSettings()
 				case .drainWallet        : showSettings()
@@ -627,8 +628,8 @@ struct MainView_Big: View {
 			if #available(iOS 17, *) {
 				
 				switch value {
-				case .paymentHistory:
-					break
+				case .payment(_): break
+				case .paymentHistory: break
 					
 				case .backup:
 					navCoordinator_settings.path.removeAll()

--- a/phoenix-ios/phoenix-ios/views/main/MainView_Small.swift
+++ b/phoenix-ios/phoenix-ios/views/main/MainView_Small.swift
@@ -660,6 +660,10 @@ struct MainView_Small: View {
 				navCoordinator.path.removeAll()
 				
 				switch value {
+				case .payment(_):
+					// Handled by HomeView
+					break
+					
 				case .paymentHistory:
 					navCoordinator.path.append(NavLinkTag.TransactionsView)
 					
@@ -707,6 +711,7 @@ struct MainView_Small: View {
 				var newNavLinkTag: NavLinkTag? = nil
 				var delay: TimeInterval = 1.5 // seconds; multiply by number of screens we need to navigate
 				switch value {
+					case .payment(_)         : break // Handled by HomeView
 					case .paymentHistory     : newNavLinkTag = .TransactionsView  ; delay *= 1
 					case .backup             : newNavLinkTag = .ConfigurationView ; delay *= 2
 					case .drainWallet        : newNavLinkTag = .ConfigurationView ; delay *= 2

--- a/phoenix-ios/phoenix-ios/views/main/MainView_Small.swift
+++ b/phoenix-ios/phoenix-ios/views/main/MainView_Small.swift
@@ -652,7 +652,7 @@ struct MainView_Small: View {
 	}
 	
 	func deepLinkChanged(_ value: DeepLink?) {
-		log.trace("deepLinkChanged() => \(value?.rawValue ?? "nil")")
+		log.trace("deepLinkChanged() => \(value?.description ?? "nil")")
 		
 		if #available(iOS 17, *) {
 			
@@ -718,7 +718,7 @@ struct MainView_Small: View {
 					case .finalWallet        : newNavLinkTag = .ConfigurationView ; delay *= 2
 				}
 				
-				if let newNavLinkTag = newNavLinkTag {
+				if let newNavLinkTag {
 					
 					self.swiftUiBugWorkaround = newNavLinkTag
 					self.swiftUiBugWorkaroundIdx += 1

--- a/phoenix-ios/phoenix-notifySrvExt/NotificationService.swift
+++ b/phoenix-ios/phoenix-notifySrvExt/NotificationService.swift
@@ -553,6 +553,10 @@ class NotificationService: UNNotificationServiceExtension {
 					}
 				}
 				
+				if let payment = receivedPayments.first {
+					bestAttemptContent.targetContentIdentifier = payment.id.description()
+				}
+				
 			} else {
 				bestAttemptContent.title = String(
 					localized: "Received multiple payments",

--- a/phoenix-ios/phoenix-notifySrvExt/NotificationService.swift
+++ b/phoenix-ios/phoenix-notifySrvExt/NotificationService.swift
@@ -31,6 +31,22 @@ fileprivate var log = LoggerFactory.shared.logger(filename, .warning)
  */
 class NotificationService: UNNotificationServiceExtension {
 
+	enum PushNotificationReason: CustomStringConvertible {
+		case incomingPayment
+		case incomingOnionMessage
+		case pendingSettlement
+		case unknown
+		
+		var description: String {
+			switch self {
+				case .incomingPayment      : return "incomingPayment"
+				case .incomingOnionMessage : return "incomingOnionMessage"
+				case .pendingSettlement    : return "pendingSettlement"
+				case .unknown              : return "unknown"
+			}
+		}
+	}
+	
 	private var contentHandler: ((UNNotificationContent) -> Void)?
 	private var bestAttemptContent: UNMutableNotificationContent?
 	
@@ -38,12 +54,15 @@ class NotificationService: UNNotificationServiceExtension {
 	private var phoenixStarted: Bool = false
 	private var srvExtDone: Bool = false
 	
+	private var business: PhoenixBusiness? = nil
+	private var pushNotificationReason: PushNotificationReason = .unknown
+	
 	private var isConnectedToPeer = false
 	private var receivedPayments: [Lightning_kmpIncomingPayment] = []
 	
 	private var totalTimer: Timer? = nil
 	private var connectionTimer: Timer? = nil
-	private var postPaymentTimer: Timer? = nil
+	private var postReceivedPaymentTimer: Timer? = nil
 	
 	private var cancellables = Set<AnyCancellable>()
 	
@@ -51,7 +70,7 @@ class NotificationService: UNNotificationServiceExtension {
 		_ request: UNNotificationRequest,
 		withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
 	) {
-		let selfPtr = Unmanaged.passUnretained(self).toOpaque().debugDescription
+		let selfPtr: String = Unmanaged.passUnretained(self).toOpaque().debugDescription
 		
 		log.trace("instance => \(selfPtr)")
 		log.trace("didReceive(request:withContentHandler:)")
@@ -67,6 +86,7 @@ class NotificationService: UNNotificationServiceExtension {
 		DispatchQueue.main.async {
 			
 			self.startTotalTimer()
+			self.processNotification(request.content.userInfo)
 			self.startXpc()
 			self.startPhoenix()
 		}
@@ -81,9 +101,120 @@ class NotificationService: UNNotificationServiceExtension {
 		
 		// IMPORTANT: This function is called on a NON-main thread.
 		DispatchQueue.main.async {
-			
 			self.displayPushNotification()
 		}
+	}
+	
+	// --------------------------------------------------
+	// MARK: Notification Processing
+	// --------------------------------------------------
+	
+	private func processNotification(_ userInfo: [AnyHashable : Any]) {
+		log.trace("processNotification()")
+		assertMainThread()
+		
+		// This could be a push notification coming from either:
+		// - Google's Firebase Cloud Messaging (FCM)
+		// - Amazon Web Services (AWS) (only used for debugging)
+		
+		if isFCM(userInfo) {
+			processNotification_fcm(userInfo)
+		} else {
+			processNotification_aws(userInfo)
+		}
+	}
+	
+	private func isFCM(_ userInfo: [AnyHashable : Any]) -> Bool {
+			
+		/* This could be a push notification coming from Google Firebase or from AWS.
+		 *
+		 * Example from Google FCM:
+		 * {
+		 *   "aps": {
+		 *     "alert": {
+		 *       "title": "foobar"
+		 *     }
+		 *     "mutable-content": 1
+		 *   },
+		 *   "reason": "IncomingPayment",
+		 *   "gcm.message_id": 1676919817341932,
+		 *   "google.c.a.e": 1,
+		 *   "google.c.fid": "f7Wfr_yqG00Gt6B9O7qI13",
+		 *   "google.c.sender.id": 358118532563
+		 * }
+		 *
+		 * Example from AWS:
+		 * {
+		 *   "aps": {
+		 *     "alert": {
+		 *       "title": "Missed incoming payment"
+		 *     }
+		 *     "mutable-content": 1
+		 *   },
+		 *   "acinq": {
+		 *     "amt": 120000,
+		 *     "h": "d48bf163c0e24d68567e80b10cc7dd583e2f44390c9592df56a61f79559611e6",
+		 *     "n": "02ed721545840184d1544328059e8b20c01965b73b301a7d03fc89d3d84aba0642",
+		 *     "t": "invoice",
+		 *     "ts": 1676920273561
+		 *   }
+		 * }
+		 */
+		
+		return userInfo["gcm.message_id"]     != nil ||
+		       userInfo["google.c.a.e"]       != nil ||
+		       userInfo["google.c.fid"]       != nil ||
+		       userInfo["google.c.sender.id"] != nil ||
+		       userInfo["reason"]             != nil // just in-case google changes format
+	}
+	
+	private func processNotification_fcm(_ userInfo: [AnyHashable : Any]) {
+		log.trace("processNotification_fcm()")
+		assertMainThread()
+		
+		// Example:
+		// {
+		//   "gcm.message_id": 1605136272123442,
+		//   "google.c.sender.id": 458618232423,
+		//   "google.c.a.e": 1,
+		//   "google.c.fid": "dRLLO-mxUxbDvmV1urj5Tt",
+		//   "reason": "IncomingPayment",
+		//   "aps": {
+		//     "alert": {
+		//       "title": "Missed incoming payment",
+		//     },
+		//     "mutable-content": 1
+		//   }
+		// }
+		
+		if let reason = userInfo["reason"] as? String {
+			log.debug("reason: (\(reason))")
+			
+			switch reason {
+				case "IncomingPayment"       : pushNotificationReason = .incomingPayment
+				case "IncomingOnionMessage$" : pushNotificationReason = .incomingOnionMessage
+				case "PendingSettlement"     : pushNotificationReason = .pendingSettlement
+				default                      : pushNotificationReason = .unknown
+			}
+		} else {
+			log.debug("reason: !string")
+			pushNotificationReason = .unknown
+		}
+		
+		log.debug("pushNotificationReason = \(pushNotificationReason)")
+		
+		// Nothing else to do here.
+		// These types of requests are handled automatically by the Peer.
+	}
+	
+	private func processNotification_aws(_ userInfo: [AnyHashable : Any]) {
+		log.trace("processNotification_aws()")
+		assertMainThread()
+		
+		pushNotificationReason = .unknown
+		log.debug("pushNotificationReason = \(pushNotificationReason)")
+		
+		return displayPushNotification()
 	}
 	
 	// --------------------------------------------------
@@ -94,7 +225,12 @@ class NotificationService: UNNotificationServiceExtension {
 		log.trace("startTotalTimer()")
 		assertMainThread()
 		
+		guard !srvExtDone else {
+			log.debug("startTotalTimer(): ignoring: srvExtDone")
+			return
+		}
 		guard totalTimer == nil else {
+			log.debug("startTotalTimer(): ignoring: already started")
 			return
 		}
 		
@@ -117,7 +253,12 @@ class NotificationService: UNNotificationServiceExtension {
 		log.trace("startConnectionTimer()")
 		assertMainThread()
 		
+		guard !srvExtDone else {
+			log.debug("startConnectionTimer(): ignoring: srvExtDone")
+			return
+		}
 		guard connectionTimer == nil else {
+			log.debug("startConnectionTimer(): ignoring: already started")
 			return
 		}
 		
@@ -137,14 +278,14 @@ class NotificationService: UNNotificationServiceExtension {
 		}
 	}
 	
-	private func startPostPaymentTimer() {
-		log.trace("startPostPaymentTimer()")
+	private func startPostReceivedPaymentTimer() {
+		log.trace("startPostReceivedPaymentTimer()")
 		assertMainThread()
 		
 		// This method is called everytime we receive a payment,
 		// and it's possible we receive multiple payments.
 		// So for every payment, we want to restart the timer.
-		postPaymentTimer?.invalidate()
+		postReceivedPaymentTimer?.invalidate()
 		
 	#if DEBUG
 		let delay: TimeInterval = 5.0
@@ -152,13 +293,13 @@ class NotificationService: UNNotificationServiceExtension {
 		let delay: TimeInterval = 5.0
 	#endif
 		
-		postPaymentTimer = Timer.scheduledTimer(
+		postReceivedPaymentTimer = Timer.scheduledTimer(
 			withTimeInterval : delay,
 			repeats          : false
 		) {[weak self](_: Timer) -> Void in
 			
 			if let self = self {
-				log.debug("postPaymentTimer.fire()")
+				log.debug("postReceivedPaymentTimer.fire()")
 				self.displayPushNotification()
 			}
 		}
@@ -172,26 +313,34 @@ class NotificationService: UNNotificationServiceExtension {
 		log.trace("startXpc()")
 		assertMainThread()
 		
-		if !xpcStarted && !srvExtDone {
-			xpcStarted = true
-			
-			XPC.shared.receivedMessagePublisher.sink {[weak self](msg: XpcMessage) in
-				self?.didReceiveXpcMessage(msg)
-			}.store(in: &cancellables)
-			
-			XPC.shared.resume()
+		guard !srvExtDone else {
+			log.debug("startXpc(): ignoring: srvExtDone")
+			return
 		}
+		guard !xpcStarted else {
+			log.debug("startXpc(): ignoring: already started")
+			return
+		}
+		xpcStarted = true
+		
+		XPC.shared.receivedMessagePublisher.sink {[weak self](msg: XpcMessage) in
+			self?.didReceiveXpcMessage(msg)
+		}.store(in: &cancellables)
+		
+		XPC.shared.resume()
 	}
 	
 	private func stopXpc() {
 		log.trace("stopXpc()")
 		assertMainThread()
 		
-		if xpcStarted {
-			xpcStarted = false
-			
-			XPC.shared.suspend()
+		guard xpcStarted else {
+			log.debug("stopXpc(): ignoring: already stopped")
+			return
 		}
+		xpcStarted = false
+		
+		XPC.shared.suspend()
 	}
 	
 	private func didReceiveXpcMessage(_ msg: XpcMessage) {
@@ -212,7 +361,7 @@ class NotificationService: UNNotificationServiceExtension {
 				
 			} else {
 				
-				// Since we're not connected yet, we'll just go ahead and allow the main app to handle the payment.
+				// Since we're not connected yet, we'll just allow the main app to handle the payment.
 				//
 				// And we don't have to wait for the main app to finish handling the payment.
 				// Because whatever we emit from this app extension won't be displayed to the user.
@@ -231,45 +380,55 @@ class NotificationService: UNNotificationServiceExtension {
 		log.trace("startPhoenix()")
 		assertMainThread()
 		
-		if !phoenixStarted && !srvExtDone {
-			phoenixStarted = true
-			
-			let newBusiness = PhoenixManager.shared.setupBusiness()
-			
-			newBusiness.connectionsManager.connectionsPublisher().sink {
-				[weak self](connections: Connections) in
-					
-				self?.connectionsChanged(connections)
-			}
-			.store(in: &cancellables)
-
-			let pushReceivedAt = Date()
-			newBusiness.paymentsManager.lastIncomingPaymentPublisher().sink {
-				[weak self](payment: Lightning_kmpIncomingPayment) in
-				
-				guard
-					let paymentReceivedAt = payment.completedAtDate,
-					paymentReceivedAt > pushReceivedAt
-				else {
-					// Ignoring - this is the most recently received incomingPayment, but not a new one
-					return
-				}
-		
-				self?.didReceivePayment(payment)
-			}
-			.store(in: &cancellables)
+		guard !srvExtDone else {
+			log.debug("startPhoenix(): ignoring: srvExtDone")
+			return
 		}
+		guard !phoenixStarted else {
+			log.debug("startPhoenix(): ignoring: already started")
+			return
+		}
+		phoenixStarted = true
+		
+		let newBusiness = PhoenixManager.shared.setupBusiness()
+		business = newBusiness
+		
+		newBusiness.connectionsManager.connectionsPublisher().sink {
+			[weak self](connections: Connections) in
+				
+			self?.connectionsChanged(connections)
+		}
+		.store(in: &cancellables)
+			
+		let pushReceivedAt = Date()
+		newBusiness.paymentsManager.lastIncomingPaymentPublisher().sink {
+			[weak self](payment: Lightning_kmpIncomingPayment) in
+			
+			guard
+				let paymentReceivedAt = payment.completedAtDate,
+				paymentReceivedAt > pushReceivedAt
+			else {
+				// Ignoring - this is the most recently received incomingPayment, but not a new one
+				return
+			}
+			
+			self?.didReceivePayment(payment)
+		}
+		.store(in: &cancellables)
 	}
 	
 	private func stopPhoenix() {
 		log.trace("stopPhoenix()")
 		assertMainThread()
 		
-		if phoenixStarted {
-			phoenixStarted = false
-			
-			PhoenixManager.shared.teardownBusiness()
+		guard phoenixStarted else {
+			log.debug("stopPhoenix(): ignoring: already stopped")
+			return
 		}
+		phoenixStarted = false
+		
+		PhoenixManager.shared.teardownBusiness()
+		business = nil
 	}
 	
 	private func connectionsChanged(_ connections: Connections) {
@@ -288,49 +447,13 @@ class NotificationService: UNNotificationServiceExtension {
 		
 		receivedPayments.append(payment)
 		if !srvExtDone {
-			startPostPaymentTimer()
+			startPostReceivedPaymentTimer()
 		}
 	}
 	
 	// --------------------------------------------------
 	// MARK: Finish
 	// --------------------------------------------------
-	
-	enum PushNotificationReason {
-		case incomingPayment
-		case pendingSettlement
-		case unknown
-	}
-	
-	private func pushNotificationReason() -> PushNotificationReason {
-		
-		// Example: request.content.userInfo:
-		// {
-		//   "gcm.message_id": 1605136272123442,
-		//   "google.c.sender.id": 458618232423,
-		//   "google.c.a.e": 1,
-		//   "google.c.fid": "dRLLO-mxUxbDvmV1urj5Tt",
-		//   "reason": "IncomingPayment",
-		//   "aps": {
-		//     "alert": {
-		//       "title": "Phoenix is running in the background",
-		//     },
-		//     "mutable-content": 1
-		//   }
-		// }
-		
-		if let userInfo = bestAttemptContent?.userInfo,
-		   let reason = userInfo["reason"] as? String
-		{
-			switch reason {
-				case "IncomingPayment"   : return .incomingPayment
-				case "PendingSettlement" : return .pendingSettlement
-				default                  : break
-			}
-		}
-		
-		return .unknown
-	}
 	
 	private func displayPushNotification() {
 		log.trace("displayPushNotification()")
@@ -342,6 +465,7 @@ class NotificationService: UNNotificationServiceExtension {
 		srvExtDone = true
 		
 		guard let contentHandler, let bestAttemptContent else {
+			log.error("displayPushNotification(): invalid state")
 			return
 		}
 		
@@ -349,8 +473,8 @@ class NotificationService: UNNotificationServiceExtension {
 		totalTimer = nil
 		connectionTimer?.invalidate()
 		connectionTimer = nil
-		postPaymentTimer?.invalidate()
-		postPaymentTimer = nil
+		postReceivedPaymentTimer?.invalidate()
+		postReceivedPaymentTimer = nil
 		stopXpc()
 		stopPhoenix()
 		
@@ -359,20 +483,46 @@ class NotificationService: UNNotificationServiceExtension {
 	}
 	
 	private func updateBestAttemptContent() {
-		log.trace("updateBestAttemptContent()")
-		assertMainThread()
+		log.trace("updateBestAttemptContent_incomingPayment()")
+		
+		switch pushNotificationReason {
+		case .incomingPayment:
+			// We expected to receive 1 or more incoming payments
+			updateBestAttemptContent_incomingPayment()
+		
+		case .incomingOnionMessage:
+			// This is probably an incoming Bolt 12 payment.
+			// But it could be anything, so let's code defensively.
+			
+			if !receivedPayments.isEmpty {
+				updateBestAttemptContent_incomingPayment()
+			} else {
+				updateBestAttemptContent_unknown()
+			}
+			
+		case .pendingSettlement:
+			updateBestAttemptContent_incomingPayment()
+		
+		case .unknown:
+			updateBestAttemptContent_incomingPayment()
+		}
+	}
+	
+	private func updateBestAttemptContent_incomingPayment() {
+		log.trace("updateBestAttemptContent_incomingPayment()")
 		
 		guard let bestAttemptContent else {
+			log.warning("updateBestAttemptContent: bestAttemptContent is nil")
 			return
 		}
 		
 		if receivedPayments.isEmpty {
 			
-			if pushNotificationReason() == .pendingSettlement {
-				bestAttemptContent.title = NSLocalizedString("Please start Phoenix", comment: "")
-				bestAttemptContent.body = NSLocalizedString("An incoming settlement is pending.", comment: "")
+			if pushNotificationReason == .pendingSettlement {
+				bestAttemptContent.title = String(localized: "Please start Phoenix", comment: "")
+				bestAttemptContent.body = String(localized: "An incoming settlement is pending.", comment: "")
 			} else {
-				bestAttemptContent.title = NSLocalizedString("Missed incoming payment", comment: "")
+				bestAttemptContent.title = String(localized: "Missed incoming payment", comment: "")
 			}
 			
 		} else { // received 1 or more payments
@@ -421,6 +571,29 @@ class NotificationService: UNNotificationServiceExtension {
 			
 			GroupPrefs.shared.badgeCount += receivedPayments.count
 			bestAttemptContent.badge = NSNumber(value: GroupPrefs.shared.badgeCount)
+		}
+	}
+
+	private func updateBestAttemptContent_unknown() {
+		log.trace("updateBestAttemptContent_unknown()")
+		
+		guard let bestAttemptContent else {
+			log.warning("updateBestAttemptContent: bestAttemptContent is nil")
+			return
+		}
+		
+		let fiatCurrency = GroupPrefs.shared.fiatCurrency
+		let exchangeRate = PhoenixManager.shared.exchangeRate(fiatCurrency: fiatCurrency)
+		
+		if let exchangeRate {
+			let fiatAmt = Utils.formatFiat(amount: exchangeRate.price, fiatCurrency: exchangeRate.fiatCurrency)
+			
+			bestAttemptContent.title = String(localized: "Current bitcoin price", comment: "")
+			bestAttemptContent.body = fiatAmt.string
+			
+		} else {
+			bestAttemptContent.title = String(localized: "Current bitcoin price", comment: "")
+			bestAttemptContent.body = "?"
 		}
 	}
 	

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
@@ -365,3 +365,11 @@ fun OfferManager.Companion._deterministicOffer(
         pathId = pathId
     )
 }
+
+fun UUID.Companion.tryFromString(string: String): UUID? {
+    return try {
+        UUID.fromString(string)
+    } catch (e: Exception) {
+        null
+    }
+}


### PR DESCRIPTION
We display iOS notifications for received payments (if Phoenix was in the background). But if the user taps on those notifications, iOS launches our app, but we don't properly display the corresponding received payment.

This PR fixes that bug by implementing the proper callbacks.