### PR TITLE
(ios) Display multiple notifications for multiple BG payments

### DIFF
--- a/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
+++ b/phoenix-ios/phoenix-ios.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		DC74174B270F332700F7E3E3 /* KotlinTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC74174A270F332700F7E3E3 /* KotlinTypes.swift */; };
 		DC74174D270F455D00F7E3E3 /* AES256.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC74174C270F455D00F7E3E3 /* AES256.swift */; };
 		DC784A112B31EA180018DC4A /* LiquidityAdsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC784A102B31EA180018DC4A /* LiquidityAdsView.swift */; };
+		DC78A5F92DF22ABE003A7DD8 /* NotificationServiceQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC78A5F82DF22AB8003A7DD8 /* NotificationServiceQueue.swift */; };
 		DC7BAA002CADAAE70074B568 /* WalletIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7BA9FF2CADAAE70074B568 /* WalletIdentifier.swift */; };
 		DC7DA9F62AD84DF200F86B99 /* String+Substring.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7DA9F52AD84DF200F86B99 /* String+Substring.swift */; };
 		DC808E9B2D5541F50019AE30 /* UsingTorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC808E9A2D5541F10019AE30 /* UsingTorSheet.swift */; };
@@ -659,6 +660,7 @@
 		DC74174A270F332700F7E3E3 /* KotlinTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinTypes.swift; sourceTree = "<group>"; };
 		DC74174C270F455D00F7E3E3 /* AES256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AES256.swift; sourceTree = "<group>"; };
 		DC784A102B31EA180018DC4A /* LiquidityAdsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidityAdsView.swift; sourceTree = "<group>"; };
+		DC78A5F82DF22AB8003A7DD8 /* NotificationServiceQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceQueue.swift; sourceTree = "<group>"; };
 		DC7BA9FF2CADAAE70074B568 /* WalletIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletIdentifier.swift; sourceTree = "<group>"; };
 		DC7DA9F52AD84DF200F86B99 /* String+Substring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Substring.swift"; sourceTree = "<group>"; };
 		DC808E9A2D5541F10019AE30 /* UsingTorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsingTorSheet.swift; sourceTree = "<group>"; };
@@ -1522,10 +1524,11 @@
 		DCB511C8281AED58001BC525 /* phoenix-notifySrvExt */ = {
 			isa = PBXGroup;
 			children = (
-				DC641C6E282085F500862DCD /* phoenix-notifySrvExt.entitlements */,
-				DCB511C9281AED58001BC525 /* NotificationService.swift */,
-				DC641C6A2820803100862DCD /* PhoenixManager.swift */,
 				DCB511CB281AED58001BC525 /* Info.plist */,
+				DCB511C9281AED58001BC525 /* NotificationService.swift */,
+				DC78A5F82DF22AB8003A7DD8 /* NotificationServiceQueue.swift */,
+				DC641C6E282085F500862DCD /* phoenix-notifySrvExt.entitlements */,
+				DC641C6A2820803100862DCD /* PhoenixManager.swift */,
 			);
 			path = "phoenix-notifySrvExt";
 			sourceTree = "<group>";
@@ -2289,6 +2292,7 @@
 			files = (
 				DC641C752821706600862DCD /* Currency.swift in Sources */,
 				DC641C7228208B4D00862DCD /* GroupPrefs.swift in Sources */,
+				DC78A5F92DF22ABE003A7DD8 /* NotificationServiceQueue.swift in Sources */,
 				DCEB2798282D7B070096B87E /* KotlinExtensions+Other.swift in Sources */,
 				DC641C7328208B7F00862DCD /* UserDefaults+Codable.swift in Sources */,
 				DCA6DED1282ABA930073C658 /* KeychainConstants.swift in Sources */,

--- a/phoenix-ios/phoenix-notifySrvExt/NotificationServiceQueue.swift
+++ b/phoenix-ios/phoenix-notifySrvExt/NotificationServiceQueue.swift
@@ -1,0 +1,32 @@
+import Foundation
+import UserNotifications
+
+class NotificationServiceQueue {
+	
+	struct Item {
+		let identifier: String
+		let content: UNNotificationContent
+	}
+	
+	public static let shared = NotificationServiceQueue()
+	
+	private var queue: [Item] = []
+	
+	private init() {} // Must use shared instance
+	
+	// --------------------------------------------------
+	// MARK: Public Functions
+	// --------------------------------------------------
+	
+	public func enqueue(identifier: String, content: UNNotificationContent) {
+		queue.append(Item(identifier: identifier, content: content))
+	}
+	
+	public func dequeue() -> Item? {
+		if queue.isEmpty {
+			return nil
+		} else {
+			return queue.removeFirst()
+		}
+	}
+}

--- a/phoenix-ios/phoenix-notifySrvExt/PhoenixManager.swift
+++ b/phoenix-ios/phoenix-notifySrvExt/PhoenixManager.swift
@@ -13,25 +13,6 @@ typealias ConnectionsListener = (Connections) -> Void
 typealias PaymentListener = (Lightning_kmpIncomingPayment) -> Void
 
 /**
- * What happens if multiple push notifications arrive ?
- *
- * iOS will launch the notification-service-extension upon receiving the first push notification.
- * Subsequent push notifications are queued by the OS. After the app extension finishes processing
- * the first notification (by invoking the `contentHandler`), then iOS will:
- *
- * - display the first push notification
- * - dealloc the `UNNotificationServiceExtension`
- * - Initialize a new `UNNotificationServiceExtension` instance
- * - And invoke it's `didReceive(_:)` function with the next item in the queue
- *
- * Note that it does **NOT** create a new app extension process.
- * It re-uses the existing process, and launches a new `UNNotificationServiceExtension` within it.
- *
- * This means that the following instances are recycled (continue existing in memory):
- * - PhoenixManager.shared
- * - XPC.shared
- *
- * ---------------------
  * # Architecture notes:
  *
  * In a previous implementation, we created the `PhoenixBusiness` instance once,


### PR DESCRIPTION
Reminder: On iOS there is a separate process (called a [notification service extension](https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension)) that handles receiving payments if the Phoenix app is in the background or isn't running at all.

The previous architecture did NOT do a good job displaying notifications IF multiple payments were received at the same time.

For example: if you send 2 payments to the same wallet at the same time, the receiving device will display a generic push notification that says "multiple payments received" (which is not ideal). Furthermore, if our server sends multiple push notifications to the device, then a second notification will be displayed that says "missed incoming payment" (which is incorrect).

This PR fixes the problem. Now the device will always display a separate push notification for each received payment. Which is more inline with user expectations. Also, if the server sends multiple notifications, they are handled properly by the device.

Technical details:

A "notification service extension" is designed to modify the content of a single **remote** push notification. However, it's also allowed to add or remove from the list of **local** notifications.

So if 2 payments arrive while processing a notification then:
* it updates the remote notification with info from payment 1 
* it creates and displays a local notification with info from payment 2


