### PR TITLE
Add recommended feerate flow in peer manager

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/send/cpfp/CpfpView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/send/cpfp/CpfpView.kt
@@ -66,7 +66,8 @@ fun CpfpView(
     val vm = viewModel<CpfpViewModel>(factory = CpfpViewModel.Factory(peerManager))
     val mempoolFeerate by business.appConfigurationManager.mempoolFeerate.collectAsState()
 
-    var feerate by remember { mutableStateOf(mempoolFeerate?.halfHour?.feerate ?: 10.sat) }
+    val recommendedFeerate by peerManager.recommendedFeerateFlow.collectAsState()
+    var feerate by remember { mutableStateOf(recommendedFeerate.feerate) }
 
     Column(
         modifier = Modifier.padding(horizontal = 24.dp),

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/send/spliceout/SpliceOutView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/send/spliceout/SpliceOutView.kt
@@ -29,7 +29,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -72,12 +71,13 @@ fun SendSpliceOutView(
     val keyboardManager = LocalSoftwareKeyboardController.current
 
     val peerManager = business.peerManager
+    val recommendedFeerate by peerManager.recommendedFeerateFlow.collectAsState()
     val mempoolFeerate by business.appConfigurationManager.mempoolFeerate.collectAsState()
     val balance = business.balanceManager.balance.collectAsState(null).value
     val mayDoPayments by business.peerManager.mayDoPayments.collectAsState()
     val vm = viewModel<SpliceOutViewModel>(factory = SpliceOutViewModel.Factory(peerManager, business.chain))
 
-    var feerate by remember { mutableStateOf(mempoolFeerate?.halfHour?.feerate ?: 3.sat) }
+    var feerate by remember { mutableStateOf(recommendedFeerate.feerate) }
     var amount by remember { mutableStateOf(requestedAmount) }
     var amountErrorMessage by remember { mutableStateOf("") }
 

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/MutualCloseView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/MutualCloseView.kt
@@ -94,7 +94,8 @@ fun MutualCloseView(
     var address by remember { mutableStateOf("") }
     var addressErrorMessage by remember { mutableStateOf<String?>(null) }
     val mempoolFeerate by business.appConfigurationManager.mempoolFeerate.collectAsState()
-    var feerate by remember { mutableStateOf(mempoolFeerate?.halfHour?.feerate ?: 3.sat) }
+    val recommendedFeerate by business.peerManager.recommendedFeerateFlow.collectAsState()
+    var feerate by remember { mutableStateOf(recommendedFeerate.feerate) }
 
     var showScannerView by remember { mutableStateOf(false) }
     var showConfirmationDialog by remember { mutableStateOf(false) }

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/fees/LiquidityPolicyView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/fees/LiquidityPolicyView.kt
@@ -212,7 +212,6 @@ private fun EditMaxFee(
                         )
                     }
                 }
-
             }
             Spacer(Modifier.width(12.dp))
             InlineSatoshiInput(

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/FinalWalletRefundView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/FinalWalletRefundView.kt
@@ -152,7 +152,8 @@ private fun ColumnScope.AvailableForRefund(
     val mempoolFeerate by business.appConfigurationManager.mempoolFeerate.collectAsState()
 
     var address by remember { mutableStateOf("") }
-    var feerate by remember { mutableStateOf(mempoolFeerate?.halfHour?.feerate ?: 3.sat) }
+    val recommendedFeerate by business.peerManager.recommendedFeerateFlow.collectAsState()
+    var feerate by remember { mutableStateOf(recommendedFeerate.feerate) }
 
     var showScannerView by remember { mutableStateOf(false) }
 

--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/SwapInRefundView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/settings/walletinfo/SwapInRefundView.kt
@@ -112,7 +112,8 @@ private fun AvailableForRefundView(
     var showScannerView by remember { mutableStateOf(false) }
 
     val mempoolFeerate by business.appConfigurationManager.mempoolFeerate.collectAsState()
-    var feerate by remember { mutableStateOf(mempoolFeerate?.halfHour?.feerate ?: 3.sat) }
+    val recommendedFeerate by peerManager.recommendedFeerateFlow.collectAsState()
+    var feerate by remember { mutableStateOf(recommendedFeerate.feerate) }
 
     if (showScannerView) {
         SwapInRefundScanner(


### PR DESCRIPTION
This recommended feerate relies on mempool.space estimation for the half-hour target, with a fallback to the peer funding feerate if mempool.space is unavailable. This is more robust than just relying on mempool.space, and the peer funding feerate is much more pertinent than a static hard-coded fallback.