### PR TITLE
(ios) Update text for unknown push notification

### DIFF
--- a/phoenix-ios/phoenix-notifySrvExt/NotificationService.swift
+++ b/phoenix-ios/phoenix-notifySrvExt/NotificationService.swift
@@ -477,7 +477,7 @@ class NotificationService: UNNotificationServiceExtension {
 		_ content: UNMutableNotificationContent,
 		_ item: NotificationServiceQueue.Item
 	) {
-		log.trace("updateNotification_localNotification()")
+		log.trace(#function)
 		
 		content.title = item.content.title
 		content.body = item.content.body
@@ -491,7 +491,7 @@ class NotificationService: UNNotificationServiceExtension {
 		_ content: UNMutableNotificationContent,
 		_ payment: Lightning_kmpIncomingPayment
 	) {
-		log.trace("updateNotificationContent_incomingPayment()")
+		log.trace(#function)
 		
 		content.title = String(localized: "Received payment", comment: "Push notification title")
 		
@@ -526,7 +526,7 @@ class NotificationService: UNNotificationServiceExtension {
 	private func updateNotificationContent_missedPayment(
 		_ content: UNMutableNotificationContent
 	) {
-		log.trace("updateNotificationContent_missedPayment()")
+		log.trace(#function)
 		
 		content.title = String(localized: "Missed incoming payment", comment: "")
 	}
@@ -534,7 +534,7 @@ class NotificationService: UNNotificationServiceExtension {
 	private func updateNotificationContent_pendingSettlement(
 		_ content: UNMutableNotificationContent
 	) {
-		log.trace("updateNotificationContent_pendingSettlement")
+		log.trace(#function)
 		
 		content.title = String(localized: "Please start Phoenix", comment: "")
 		content.body = String(localized: "An incoming settlement is pending.", comment: "")
@@ -543,24 +543,12 @@ class NotificationService: UNNotificationServiceExtension {
 	private func updateNotificationContent_unknown(
 		_ content: UNMutableNotificationContent
 	) {
-		log.trace("updateNotificationContent_unknown()")
+		log.trace(#function)
 		
-		var exchangeRate: ExchangeRate.BitcoinPriceRate? = nil
-		if let groupPrefs = PhoenixManager.shared.groupPrefs() {
-			let fiatCurrency = groupPrefs.fiatCurrency
-			exchangeRate = PhoenixManager.shared.exchangeRate(fiatCurrency: fiatCurrency)
-		}
-		
-		if let exchangeRate {
-			let fiatAmt = Utils.formatFiat(amount: exchangeRate.price, fiatCurrency: exchangeRate.fiatCurrency)
-			
-			content.title = String(localized: "Current bitcoin price", comment: "")
-			content.body = fiatAmt.string
-			
-		} else {
-			content.title = String(localized: "Current bitcoin price", comment: "")
-			content.body = "?"
-		}
+		content.title = "Phoenix"
+		content.body = String(localized: "is running in the background", comment: "")
+		content.relevanceScore = 0.0
+		content.threadIdentifier = "unknown"
 	}
 	
 	// --------------------------------------------------

--- a/phoenix-ios/phoenix-notifySrvExt/NotificationService.swift
+++ b/phoenix-ios/phoenix-notifySrvExt/NotificationService.swift
@@ -385,11 +385,20 @@ class NotificationService: UNNotificationServiceExtension {
 		connectionTimer = nil
 		postReceivedPaymentTimer?.invalidate()
 		postReceivedPaymentTimer = nil
+		
+		// We purposefully have the following call order:
+		// - updateRemoteNotificationContent()
+		// - stopPhoenix()
+		//
+		// Because we may need to fetch exchangeRates,
+		// and to do that we call PhoenixManager.groupPrefs().
+
+		updateRemoteNotificationContent(remoteNotificationContent)
+		displayLocalNotificationsForAdditionalPayments()
+		
 		stopXpc()
 		stopPhoenix()
 		
-		updateRemoteNotificationContent(remoteNotificationContent)
-		displayLocalNotificationsForAdditionalPayments()
 		contentHandler(remoteNotificationContent)
 	}
 	


### PR DESCRIPTION
In the past, if we received a push notification which resulted in a non-action (no received payments or other actions performed), the we displayed a push notification with the current bitcoin price. This PR changes the text to say "phoenix is running in the background", which is a similar message to what is displayed on Android.

<img width="350" height="275" alt="IMG_4428" src="https://github.com/user-attachments/assets/312dd69a-2cd2-4921-b4b5-1edbba56cb97" />
