### PR TITLE
(ios) Original fiat values were missing due to recent changes

### DIFF
--- a/phoenix-ios/phoenix-ios/officers/BusinessManager.swift
+++ b/phoenix-ios/phoenix-ios/officers/BusinessManager.swift
@@ -197,6 +197,7 @@ class BusinessManager {
 					walletId: walletId.nodeIdHash,
 					currencies: current
 				)
+				self.business.appConfigurationManager.updatePreferredFiatCurrencies(current: current)
 			}
 			.store(in: &cancellables)
 		
@@ -378,6 +379,7 @@ class BusinessManager {
 			walletId: walletId.nodeIdHash,
 			currencies: preferredFiatCurrencies
 		)
+		business.appConfigurationManager.updatePreferredFiatCurrencies(current: preferredFiatCurrencies)
 
 		let startupParams = StartupParams(
 			isTorEnabled: groupPrefs.isTorEnabled,


### PR DESCRIPTION
In PR #748, the `appConfigurationManager.preferredFiatCurrencies` was dropped and then re-added, and I missed this detail. Which meant the originalFiatValues were missing for all incoming/outgoing payments.