### PR TITLE
(ios) Description was missing for outgoing payments using Bolt 12

### DIFF
--- a/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Payments.swift
+++ b/phoenix-ios/phoenix-ios/kotlin/KotlinExtensions+Payments.swift
@@ -76,8 +76,11 @@ extension WalletPaymentInfo {
 			
 			if let lightningPayment = outgoingPayment as? Lightning_kmpLightningOutgoingPayment {
 			
-				if let normal = lightningPayment.details.asNormal() {
-					return sanitize(normal.paymentRequest.desc)
+				if let bolt11 = lightningPayment.details.asNormal() {
+					return sanitize(bolt11.paymentRequest.desc)
+					
+				} else if let bolt12 = lightningPayment.details.asBlinded() {
+					return sanitize(bolt12.paymentRequest.description_)
 					
 				} else if let swapOut = lightningPayment.details.asSwapOut() {
 					return sanitize(swapOut.address)

--- a/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
+++ b/phoenix-shared/src/iosMain/kotlin/fr/acinq/phoenix/utils/LightningExposure.kt
@@ -94,6 +94,9 @@ fun LightningOutgoingPayment.explainAsFinalFailure(): FinalFailure? {
 fun LightningOutgoingPayment.Details.asNormal(): LightningOutgoingPayment.Details.Normal? =
     (this as? LightningOutgoingPayment.Details.Normal)
 
+fun LightningOutgoingPayment.Details.asBlinded(): LightningOutgoingPayment.Details.Blinded? =
+    (this as? LightningOutgoingPayment.Details.Blinded)
+
 @Suppress("DEPRECATION")
 fun LightningOutgoingPayment.Details.asSwapOut(): LightningOutgoingPayment.Details.SwapOut? =
     (this as? LightningOutgoingPayment.Details.SwapOut)


### PR DESCRIPTION
This was originally overlooked because we only supported the default Bolt 12 offer. And so when testing on our own offers, there was never a description. But now offers can have a description, so the bug is more visible.