### PR TITLE
Use default dispatcher for phoenix-shared coroutine scopes

### DIFF
--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/PhoenixBusiness.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/PhoenixBusiness.kt
@@ -33,8 +33,10 @@ import fr.acinq.phoenix.controllers.payments.AppReceiveController
 import fr.acinq.phoenix.data.StartupParams
 import fr.acinq.phoenix.managers.*
 import fr.acinq.phoenix.utils.*
-import fr.acinq.phoenix.utils.logger.PhoenixLoggerConfig
-import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlin.time.Duration.Companion.seconds
 
@@ -51,8 +53,8 @@ class PhoenixBusiness(
 
     val chain: Chain = NodeParamsManager.chain
 
-    val electrumClient by lazy { ElectrumClient(scope = MainScope(), loggerFactory = loggerFactory, pingInterval = 30.seconds, rpcTimeout = 10.seconds) }
-    val electrumWatcher by lazy { ElectrumWatcher(electrumClient, MainScope(), loggerFactory) }
+    val electrumClient = ElectrumClient(scope = defaultScope(), loggerFactory = loggerFactory, pingInterval = 30.seconds, rpcTimeout = 10.seconds)
+    val electrumWatcher = ElectrumWatcher(client = electrumClient, scope = defaultScope(), loggerFactory = loggerFactory)
 
     var appConnectionsDaemon: AppConnectionsDaemon? = null
 
@@ -139,3 +141,7 @@ class PhoenixBusiness(
             AppCloseChannelsConfigurationController(_this, isForceClose = true)
     }
 }
+
+
+fun defaultScope() = CoroutineScope(Dispatchers.Default + SupervisorJob())
+fun ioScope() = CoroutineScope(Dispatchers.IO + SupervisorJob())

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/contacts/SqliteContactsDb.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/db/contacts/SqliteContactsDb.kt
@@ -14,12 +14,12 @@ import fr.acinq.phoenix.data.WalletPaymentMetadata
 import fr.acinq.phoenix.db.SqliteAppDb
 import fr.acinq.phoenix.db.migrations.appDb.v7.AfterVersion7Result
 import fr.acinq.phoenix.db.sqldelight.PaymentsDatabase
+import fr.acinq.phoenix.ioScope
 import fr.acinq.phoenix.utils.extensions.incomingOfferMetadata
 import fr.acinq.phoenix.utils.extensions.outgoingInvoiceRequest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -35,7 +35,7 @@ class SqliteContactsDb(
     val driver: SqlDriver,
     val database: PaymentsDatabase,
     val loggerFactory: LoggerFactory
-): CoroutineScope by MainScope() {
+): CoroutineScope by ioScope() {
 
     private val log = loggerFactory.newLogger(this::class)
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConfigurationManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConfigurationManager.kt
@@ -13,8 +13,8 @@ import fr.acinq.phoenix.data.mainnetElectrumServersOnion
 import fr.acinq.phoenix.data.platformElectrumRegtestConf
 import fr.acinq.phoenix.data.testnetElectrumServers
 import fr.acinq.phoenix.data.testnetElectrumServersOnion
+import fr.acinq.phoenix.defaultScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 class AppConfigurationManager(
     private val chain: Chain,
     private val electrumWatcher: ElectrumWatcher,
-) : CoroutineScope by MainScope() {
+) : CoroutineScope by defaultScope() {
 
     constructor(business: PhoenixBusiness) : this(
         chain = business.chain,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConnectionsDaemon.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/AppConnectionsDaemon.kt
@@ -11,6 +11,7 @@ import fr.acinq.lightning.logging.debug
 import fr.acinq.lightning.logging.error
 import fr.acinq.lightning.logging.info
 import fr.acinq.phoenix.PhoenixGlobal
+import fr.acinq.phoenix.defaultScope
 import fr.acinq.phoenix.managers.global.NetworkState
 import fr.acinq.phoenix.utils.extensions.isOnion
 import kotlinx.coroutines.*
@@ -35,7 +36,7 @@ class AppConnectionsDaemon(
     private val phoenixGlobal: PhoenixGlobal,
     private val tcpSocketBuilder: suspend () -> TcpSocket.Builder,
     private val electrumClient: ElectrumClient,
-) : CoroutineScope by MainScope() {
+) : CoroutineScope by defaultScope() {
 
     constructor(business: PhoenixBusiness) : this(
         loggerFactory = business.loggerFactory,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/BalanceManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/BalanceManager.kt
@@ -2,24 +2,22 @@ package fr.acinq.phoenix.managers
 
 import fr.acinq.bitcoin.Satoshi
 import fr.acinq.lightning.*
-import fr.acinq.lightning.blockchain.electrum.SwapInManager
 import fr.acinq.lightning.blockchain.electrum.WalletState
 import fr.acinq.lightning.blockchain.electrum.balance
 import fr.acinq.lightning.channel.states.ChannelState
 import fr.acinq.lightning.io.Peer
-import fr.acinq.lightning.logging.LoggerFactory
 import fr.acinq.lightning.utils.sat
 import fr.acinq.lightning.utils.sum
 import fr.acinq.phoenix.PhoenixBusiness
+import fr.acinq.phoenix.defaultScope
 import fr.acinq.phoenix.utils.extensions.localBalance
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 class BalanceManager(
     private val peerManager: PeerManager,
-) : CoroutineScope by MainScope() {
+) : CoroutineScope by defaultScope() {
 
     constructor(business: PhoenixBusiness): this(
         peerManager = business.peerManager,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/DatabaseManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/DatabaseManager.kt
@@ -17,12 +17,12 @@ import fr.acinq.phoenix.db.createSqliteChannelsDb
 import fr.acinq.phoenix.db.createSqlitePaymentsDb
 import fr.acinq.phoenix.db.makeCloudKitDb
 import fr.acinq.phoenix.db.payments.CloudKitInterface
+import fr.acinq.phoenix.defaultScope
 import fr.acinq.phoenix.managers.global.CurrencyManager
 import fr.acinq.phoenix.utils.PlatformContext
 import fr.acinq.phoenix.utils.extensions.phoenixName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -40,7 +40,7 @@ class DatabaseManager(
     private val nodeParamsManager: NodeParamsManager,
     appConfigurationManager: AppConfigurationManager,
     currencyManager: CurrencyManager,
-) : CoroutineScope by MainScope() {
+) : CoroutineScope by defaultScope() {
 
     constructor(business: PhoenixBusiness): this(
         loggerFactory = business.loggerFactory,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/LnurlManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/LnurlManager.kt
@@ -22,6 +22,7 @@ import fr.acinq.lightning.payment.PaymentRequest
 import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.data.lnurl.*
 import fr.acinq.lightning.logging.error
+import fr.acinq.phoenix.defaultScope
 import io.ktor.client.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
@@ -30,7 +31,6 @@ import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
@@ -41,7 +41,7 @@ import kotlinx.serialization.json.JsonObject
 class LnurlManager(
     loggerFactory: LoggerFactory,
     private val walletManager: WalletManager
-) : CoroutineScope by MainScope() {
+) : CoroutineScope by defaultScope() {
 
     // use special client for lnurl since we dont want ktor to break when receiving non-2xx response
     private val httpClient: HttpClient by lazy {

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/NodeParamsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/NodeParamsManager.kt
@@ -28,8 +28,8 @@ import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.shared.BuildVersions
 import fr.acinq.lightning.logging.info
 import fr.acinq.lightning.wire.OfferTypes
+import fr.acinq.phoenix.defaultScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
@@ -39,7 +39,7 @@ class NodeParamsManager(
     chain: Chain,
     walletManager: WalletManager,
     appConfigurationManager: AppConfigurationManager,
-) : CoroutineScope by MainScope() {
+) : CoroutineScope by defaultScope() {
 
     constructor(business: PhoenixBusiness): this(
         loggerFactory = business.loggerFactory,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/NotificationsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/NotificationsManager.kt
@@ -25,8 +25,8 @@ import fr.acinq.phoenix.data.Notification
 import fr.acinq.phoenix.data.WatchTowerOutcome
 import fr.acinq.phoenix.db.SqliteAppDb
 import fr.acinq.lightning.logging.debug
+import fr.acinq.phoenix.defaultScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -37,7 +37,7 @@ class NotificationsManager(
     private val loggerFactory: LoggerFactory,
     private val appDb: SqliteAppDb,
     private val walletManager: WalletManager
-) : CoroutineScope by MainScope() {
+) : CoroutineScope by defaultScope() {
 
     constructor(business: PhoenixBusiness) : this(
         loggerFactory = business.loggerFactory,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsManager.kt
@@ -13,9 +13,8 @@ import fr.acinq.lightning.logging.info
 import fr.acinq.lightning.utils.*
 import fr.acinq.phoenix.PhoenixBusiness
 import fr.acinq.phoenix.data.*
-import fr.acinq.phoenix.db.SqlitePaymentsDb
+import fr.acinq.phoenix.defaultScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -31,7 +30,7 @@ class PaymentsManager(
     private val databaseManager: DatabaseManager,
     private val electrumClient: ElectrumClient,
     private val nodeParamsManager: NodeParamsManager,
-) : CoroutineScope by MainScope() {
+) : CoroutineScope by defaultScope() {
 
     constructor(business: PhoenixBusiness) : this(
         loggerFactory = business.loggerFactory,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsPageFetcher.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PaymentsPageFetcher.kt
@@ -3,6 +3,7 @@ package fr.acinq.phoenix.managers
 import fr.acinq.lightning.logging.LoggerFactory
 import fr.acinq.lightning.logging.debug
 import fr.acinq.phoenix.data.WalletPaymentInfo
+import fr.acinq.phoenix.defaultScope
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -29,7 +30,7 @@ data class PaymentsPage(
 class PaymentsPageFetcher(
     loggerFactory: LoggerFactory,
     private val databaseManager: DatabaseManager
-): CoroutineScope by MainScope() {
+): CoroutineScope by defaultScope() {
 
     private val log = loggerFactory.newLogger(this::class)
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PeerManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/PeerManager.kt
@@ -35,6 +35,7 @@ import fr.acinq.phoenix.utils.extensions.nextTimeout
 import fr.acinq.lightning.logging.debug
 import fr.acinq.lightning.logging.error
 import fr.acinq.lightning.logging.info
+import fr.acinq.phoenix.defaultScope
 import fr.acinq.phoenix.managers.global.FeerateManager
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
@@ -49,7 +50,7 @@ class PeerManager(
     private val notificationsManager: NotificationsManager,
     private val electrumClient: ElectrumClient,
     private val electrumWatcher: ElectrumWatcher,
-) : CoroutineScope by CoroutineScope(CoroutineName("peer") + SupervisorJob() + Dispatchers.Main + CoroutineExceptionHandler { _, e ->
+) : CoroutineScope by CoroutineScope(CoroutineName("peer") + SupervisorJob() + Dispatchers.Default + CoroutineExceptionHandler { _, e ->
     println("error in Peer coroutine scope: ${e.message}")
     val logger = loggerFactory.newLogger("PeerManager")
     logger.error(e) { "error in Peer scope: " }
@@ -203,7 +204,7 @@ class PeerManager(
                 watcher = electrumWatcher,
                 db = databaseManager.databases.filterNotNull().first(),
                 socketBuilder = null,
-                scope = MainScope()
+                scope = defaultScope()
             )
             _peer.value = peer
 

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/SendManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/SendManager.kt
@@ -29,6 +29,7 @@ import fr.acinq.phoenix.data.lnurl.LnurlAuth
 import fr.acinq.phoenix.data.lnurl.LnurlError
 import fr.acinq.phoenix.data.lnurl.LnurlPay
 import fr.acinq.phoenix.data.lnurl.LnurlWithdraw
+import fr.acinq.phoenix.defaultScope
 import fr.acinq.phoenix.utils.DnsResolvers
 import fr.acinq.phoenix.utils.EmailLikeAddress
 import fr.acinq.phoenix.utils.Parser
@@ -36,7 +37,6 @@ import io.ktor.http.Url
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterNotNull
@@ -60,7 +60,7 @@ class SendManager(
     private val lnurlManager: LnurlManager,
     private val databaseManager: DatabaseManager,
     private val chain: Chain,
-) : CoroutineScope by MainScope() {
+) : CoroutineScope by defaultScope() {
 
     constructor(business: PhoenixBusiness): this(
         loggerFactory = business.loggerFactory,

--- a/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/WalletManager.kt
+++ b/phoenix-shared/src/commonMain/kotlin/fr.acinq.phoenix/managers/WalletManager.kt
@@ -20,13 +20,13 @@ import fr.acinq.bitcoin.*
 import fr.acinq.lightning.crypto.Bip84OnChainKeys
 import fr.acinq.lightning.crypto.LocalKeyManager
 import fr.acinq.lightning.crypto.div
+import fr.acinq.phoenix.defaultScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.*
 
 class WalletManager(
     private val chain: Chain
-) : CoroutineScope by MainScope() {
+) : CoroutineScope by defaultScope() {
 
     private val _localKeyManager = MutableStateFlow<LocalKeyManager?>(null)
     val keyManager: StateFlow<LocalKeyManager?> = _localKeyManager


### PR DESCRIPTION
We've been used the `MainScope` until now for all our coroutines, a scope that relies on the UI dispatcher. This is not suited for many of the phoenix-shared coroutines which are doing background stuff and should not run on the UI thread. I believe it was done this way for historical reasons, back when kotlin multiplatform had issues with background operations on iOS, but that was fixed when we adopted the new memory model (see #299).

This PR defines a `defaultScope` method that uses the predefined `Default` dispatcher:

> uses a common pool of shared background threads (...) an appropriate choice for compute-intensive coroutines that consume CPU resources.
> https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-dispatcher/

There's also a `Dispatcher.IO` dispatcher that could be used for coroutines doing I/O operations.

Note: we've been already using `Dispatchers.Default` for database queries, but we did that by explicitly switching context with `withContext`. @robbiehanson I think that this PR could allow us to remove those switches and simplify code (and also ensure we're not doing db stuff on the Main thread).