### PR TITLE
(android) Fix wrong fiat unit on payment technical details (then) line

### DIFF
--- a/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/details/PaymentTechnicalView.kt
+++ b/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/details/PaymentTechnicalView.kt
@@ -301,7 +301,7 @@ fun TechnicalRowAmount(
         }
 
         if (rateThen != null) {
-            val fiatAmountThen = amount.toFiat(rateThen.price).toPrettyString(prefFiat, withUnit = true)
+            val fiatAmountThen = amount.toFiat(rateThen.price).toPrettyString(rateThen.fiatCurrency, withUnit = true)
             Spacer(modifier = Modifier.height(2.dp))
             Text(text = stringResource(id = R.string.paymentdetails_amount_rate_then, fiatAmountThen), style = MaterialTheme.typography.subtitle2)
         }

--- a/phoenix-android/src/test/kotlin/fr/acinq/phoenix/utils/AmountFormatterTest.kt
+++ b/phoenix-android/src/test/kotlin/fr/acinq/phoenix/utils/AmountFormatterTest.kt
@@ -18,11 +18,33 @@ package fr.acinq.phoenix.utils
 
 import fr.acinq.lightning.utils.msat
 import fr.acinq.phoenix.android.utils.converters.AmountConverter.toMilliSatoshi
+import fr.acinq.phoenix.android.utils.converters.AmountFormatter.toPrettyString
 import fr.acinq.phoenix.data.BitcoinUnit
+import fr.acinq.phoenix.data.ExchangeRate
+import fr.acinq.phoenix.data.FiatCurrency
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
+import java.util.Locale
 
 class AmountConverterTest {
+
+    private var defaultLocale: Locale? = null
+
+    @Before
+    fun pinLocale() {
+        defaultLocale = Locale.getDefault()
+        // NumberFormat.getInstance() in AmountFormatter is locale-sensitive; pin to US so assertions
+        // remain stable across developer machines and CI runners.
+        Locale.setDefault(Locale.US)
+    }
+
+    @After
+    fun restoreLocale() {
+        defaultLocale?.let { Locale.setDefault(it) }
+    }
     @Test
     fun test_double_to_msat_rounding() {
         // 1 msat
@@ -54,5 +76,61 @@ class AmountConverterTest {
         assertEquals(1_999_999.msat, 19.99_999_9.toMilliSatoshi(BitcoinUnit.Bit))
         assertEquals(1_999_999.msat, 0.01999_999_9.toMilliSatoshi(BitcoinUnit.MBtc))
         assertEquals(1_999_999.msat, 0.000_01999_999_9.toMilliSatoshi(BitcoinUnit.Btc))
+    }
+
+    // Regression test for issue #535: when displaying the historical ("then") fiat value of a
+    // payment, the (then) line must be denominated in the currency that was actually recorded
+    // (rateThen.fiatCurrency), regardless of the user's current preferred fiat.
+    //
+    // Before the fix, the same `prefFiat` unit was applied to both the (now) line and the
+    // (then) line, so after switching the preferred currency the (then) numeric value would
+    // visibly be wrong (e.g. "1 PHP" displayed for a payment originally worth ~1 EUR).
+    @Test
+    fun then_fiat_uses_historical_rate_currency_not_preferred_fiat() {
+        // Historical rate at the time of the payment: 1 BTC = 100,000 EUR (round number to keep
+        // floating-point conversion deterministic — FIAT_FORMAT uses RoundingMode.CEILING and
+        // would otherwise be sensitive to sub-cent drift).
+        val rateThen = ExchangeRate.BitcoinPriceRate(
+            fiatCurrency = FiatCurrency.EUR,
+            price = 100_000.0,
+            source = "test",
+            timestampMillis = 0L,
+        )
+        // 0.0001 BTC * 100_000 EUR/BTC = 10 EUR exactly.
+        val amount = 10_000_000.msat
+
+        // Mirrors the fixed call site in PaymentTechnicalView.kt: pass rateThen.fiatCurrency.
+        val formattedThen = amount.toPrettyString(rateThen.fiatCurrency, rateThen, withUnit = true)
+
+        assertTrue(
+            "expected output to end with the historical rate's currency code (EUR), got: $formattedThen",
+            formattedThen.endsWith(" EUR"),
+        )
+        assertTrue(
+            "expected numeric portion ~10 EUR (allowing for FIAT_FORMAT CEILING rounding), got: $formattedThen",
+            formattedThen.startsWith("10.0") || formattedThen.startsWith("10.01"),
+        )
+    }
+
+    @Test
+    fun then_fiat_label_does_not_follow_preferred_fiat_change() {
+        val rateThen = ExchangeRate.BitcoinPriceRate(
+            fiatCurrency = FiatCurrency.EUR,
+            price = 100_000.0,
+            source = "test",
+            timestampMillis = 0L,
+        )
+        val amount = 10_000_000.msat
+
+        // Sanity check: had the call site used the preferred fiat (PHP) as the display unit, the
+        // resulting string would carry " PHP" — that's the bug guarded against by passing
+        // rateThen.fiatCurrency at the call site.
+        val withBuggyPreferredFiat = amount.toPrettyString(FiatCurrency.PHP, rateThen, withUnit = true)
+        assertTrue(withBuggyPreferredFiat.endsWith(" PHP"))
+
+        // The fixed call site instead passes rateThen.fiatCurrency, producing the historically
+        // correct currency label.
+        val withFixedCallSite = amount.toPrettyString(rateThen.fiatCurrency, rateThen, withUnit = true)
+        assertTrue(withFixedCallSite.endsWith(" EUR"))
     }
 }


### PR DESCRIPTION
Closes #535.

## Summary

In the "Technical details" page of a payment, the `(then)` fiat value used the user's currently-preferred fiat as the display unit, while the numeric amount was computed from the historical exchange rate (which is recorded in a possibly-different currency). After switching the preferred fiat the line therefore showed a wrong amount with a wrong-but-currently-preferred currency code — e.g. a 1 EUR incoming payment displayed as "1 PHP (then)" after switching the preferred fiat to PHP, instead of "1 EUR (then)".

## Change

- [phoenix-android/.../PaymentTechnicalView.kt](https://github.com/ACINQ/phoenix/blob/master/phoenix-android/src/main/kotlin/fr/acinq/phoenix/android/payments/details/PaymentTechnicalView.kt#L304): the `(then)` line now formats with `rateThen.fiatCurrency` instead of the user's `prefFiat`. The `(now)` line is unchanged (it correctly uses the live rate for the preferred fiat).
- This matches the convention already followed by `CsvWriter.convertToFiat` in phoenix-shared, which reads `exchangeRate.fiatCurrency.name` directly off the historical rate.

## Tests

Added two JVM unit tests to [AmountFormatterTest.kt](https://github.com/ACINQ/phoenix/blob/master/phoenix-android/src/test/kotlin/fr/acinq/phoenix/utils/AmountFormatterTest.kt) that lock in the formatter contract the fix relies on:

- `then_fiat_uses_historical_rate_currency_not_preferred_fiat`
- `then_fiat_label_does_not_follow_preferred_fiat_change`

Both pass under `./gradlew :phoenix-android:testDebugUnitTest --tests "fr.acinq.phoenix.utils.AmountConverterTest"`.

## Pre-existing build note (not blocking)

`phoenix-android/src/test/.../LnurlAuthTest.kt` does not compile on current master because `Crypto.compact2der` was removed in bitcoin-kmp 0.30.0. I temporarily moved the file aside to run the new tests, then restored it untouched — this PR does not touch that file. The unit-test task will need the existing breakage resolved separately before CI can run.

## Test plan

- [x] Build passes (`:phoenix-android:assembleDebug`)
- [x] New unit tests pass
- [x] Manual verification on testnet3

### End-to-end verification on testnet3

Reproduced the original bug scenario against a real Phoenix wallet on Android Pixel 4a API 34 emulator, with a real Lightning channel funded via ACINQ's testnet3 LSP.

**Setup**:
1. Fresh wallet, preferred fiat set to **EUR** _before_ receiving anything.
2. On-chain deposit from a testnet3 faucet to the swap-in address: [tx `5297b4f6…43a29a4a`](https://mempool.space/testnet/tx/5297b4f6200517e2cf221a702ec8dcce61f3c43be3b1124af72f4abc43a29a4a) — 189,072 sat, confirmed at block 4,965,924.
3. After 3 confirmations, the ACINQ testnet LSP coordinated a splice-in tx `42061b2351d7…c04149c4b1f`, opening channel `d48a5c0fd8ae…d1b36654ef9`. Net wallet balance: 187,505 sat (deposit − 1,000 sat service fee − 567 sat miner fee).

**Step 1 — Technical details before changing preferred fiat (EUR)**:

| Row | Sat | (now) | (then) |
|---|---|---|---|
| Amount received | 187,505 | ≈ 122.41 EUR | ≈ 122.41 EUR |
| Service fees | 1,000 | ≈ 0.66 EUR | ≈ 0.66 EUR |
| Miner fees | 567 | ≈ 0.38 EUR | ≈ 0.38 EUR |

`(now)` and `(then)` match because the live fiat matches the recorded `originalFiat`.

**Step 2 — Switch preferred fiat to PHP, re-open Technical details**:

| Row | Sat | (now) | (then) |
|---|---|---|---|
| Amount received | 187,505 | ≈ **8,772.42 PHP** | ≈ **122.41 EUR** |
| Service fees | 1,000 | ≈ **46.79 PHP** | ≈ **0.66 EUR** |
| Miner fees | 567 | ≈ **26.53 PHP** | ≈ **0.38 EUR** |

The `(then)` line stayed in EUR (the currency recorded at receive time), with the same numeric values as before — exactly the behavior described in #535. The `(now)` line correctly recomputed against the live PHP rate (8,772.42 PHP / 122.41 EUR ≈ 71.7 PHP/EUR, which matches current real-world rates, confirming the live and historical rate paths are both functioning).

Without this fix the `(then)` line would have re-labeled to "PHP" while continuing to use the EUR-historical rate as the multiplier, producing the "122.41 PHP" wrong-amount-wrong-unit output reported in the issue.

Screenshots:
Before changing preferred fiat — both (now) and (then) lines show EUR.
<img width="692" height="1500" alt="image" src="https://github.com/user-attachments/assets/049b6c96-ce15-49f2-aad1-c518149f6bd6" />

After switching preferred fiat to PHP — (now) line correctly shows PHP, (then) line correctly stays in EUR with the same numeric value as before. This is exactly the behavior issue [#535](https://github.com/ACINQ/phoenix/issues/535) asked for.
<img width="692" height="1500" alt="image" src="https://github.com/user-attachments/assets/05bd8d0c-cfc6-404b-b178-d4ffa36687b0" />

