### PR TITLE
(ios) Fix Send footer clipping with large Dynamic Type

### DIFF
--- a/phoenix-ios/phoenix-ios/views/send/SendView.swift
+++ b/phoenix-ios/phoenix-ios/views/send/SendView.swift
@@ -77,6 +77,7 @@ struct SendView: View {
 	
 	@Environment(\.colorScheme) var colorScheme: ColorScheme
 	@Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+	@Environment(\.dynamicTypeSize) var dynamicTypeSize: DynamicTypeSize
 	
 	@EnvironmentObject var navCoordinator: NavigationCoordinator
 	@EnvironmentObject var popoverState: PopoverState
@@ -236,11 +237,17 @@ struct SendView: View {
 	
 	@ViewBuilder
 	func footer() -> some View {
-		
-		ViewThatFits {
-			footer_standard()
-			footer_compact()
-			footer_accessibility()
+
+		Group {
+			if dynamicTypeSize.isAccessibilitySize {
+				footer_scrollable()
+			} else {
+				ViewThatFits {
+					footer_standard()
+					footer_compact()
+					footer_accessibility()
+				}
+			}
 		}
 		.assignMaxPreference(for: maxButtonWidthReader.key, to: $maxButtonWidth)
 		.background(
@@ -248,6 +255,30 @@ struct SendView: View {
 				.cornerRadius(15, corners: [.topLeft, .topRight])
 				.edgesIgnoringSafeArea([.horizontal, .bottom])
 		)
+	}
+
+	@ViewBuilder
+	func footer_scrollable() -> some View {
+
+		ScrollView(.horizontal, showsIndicators: false) {
+			HStack(alignment: VerticalAlignment.top, spacing: 20) {
+				roundButton_paste()
+					.frame(width: maxButtonWidth)
+					.read(maxButtonWidthReader)
+				roundButton_chooseImage()
+					.frame(width: maxButtonWidth)
+					.read(maxButtonWidthReader)
+				roundButton_nfc()
+					.frame(width: maxButtonWidth)
+					.read(maxButtonWidthReader)
+				roundButton_scanQrCode()
+					.frame(width: maxButtonWidth)
+					.read(maxButtonWidthReader)
+			}
+			.padding(.horizontal, 20)
+		}
+		.padding(.top, 20)
+		.padding(.bottom, deviceInfo.isFaceID ? 10 : 20)
 	}
 	
 	@ViewBuilder


### PR DESCRIPTION
## Problem

When the user has an accessibility font size enabled, the four action buttons in the Send screen footer (`paste`, `choose image`, `nfc`, `scan qr code`) overflow their container. Because the caption labels scale with Dynamic Type, `maxButtonWidth` grows large enough that the total width of the four buttons exceeds the screen width. 

The `ViewThatFits` fallback does not catch this correctly: it measures the layout during a first pass when `maxButtonWidth` is still `nil`, commits to `footer_standard()`, and then overflows silently after the `GeometryPreferenceReader` updates the value. As a result, the leftmost and rightmost buttons are clipped off-screen.

## Screenshots

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/31f8ac2e-9efb-442f-b9c8-2e90baca6fb7" width="250" alt="Before" /> | <img src="https://github.com/user-attachments/assets/7d59ed59-2b6c-43ed-bce9-ade10055ef9d" width="250" alt="After - ScrollView" /> |

## Fix

Detected the accessibility font size via `@Environment(\.dynamicTypeSize)`. When `isAccessibilitySize` is `true`, the `ViewThatFits` layout is replaced with a horizontal `ScrollView`. 

The scroll variant uses the exact same round buttons and `maxButtonWidth` equal-width logic — it is purely a layout change. For all non-accessibility font sizes, the standard behavior remains completely unchanged.

## How to Test
1. Launch the app in the iOS Simulator.
2. Go to Settings > Accessibility > Display & Text Size > Larger Text, and enable a large accessibility size.
3. Navigate to the Send screen. Verify that the footer buttons can now be scrolled horizontally without being clipped.